### PR TITLE
Sync OpenAPI spec and align API routes to /plans/{planId}

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -246,15 +246,18 @@ export async function buildServer(
   });
 
   app.get<{ Params: { planId: string } }>(
-    '/plan/:planId',
+    '/plans/:planId',
     async (request, reply) => {
       const plan = ensurePlan(store, request.params.planId);
-      void reply.send(plan);
+      const planItems = store.items.filter(
+        (item) => item.planId === plan.planId
+      );
+      void reply.send({ ...plan, items: planItems });
     }
   );
 
   app.patch<{ Params: { planId: string } }>(
-    '/plan/:planId',
+    '/plans/:planId',
     async (request, reply) => {
       const plan = ensurePlan(store, request.params.planId);
       const updates = planPatchSchema.parse(request.body ?? {});
@@ -290,7 +293,7 @@ export async function buildServer(
   );
 
   app.delete<{ Params: { planId: string } }>(
-    '/plan/:planId',
+    '/plans/:planId',
     async (request, reply) => {
       const index = store.plans.findIndex(
         (entry) => entry.planId === request.params.planId
@@ -311,7 +314,7 @@ export async function buildServer(
   );
 
   app.get<{ Params: { planId: string } }>(
-    '/plan/:planId/participants',
+    '/plans/:planId/participants',
     async (request, reply) => {
       const plan = ensurePlan(store, request.params.planId);
       const participantIds = new Set(plan.participantIds ?? []);
@@ -324,7 +327,7 @@ export async function buildServer(
   );
 
   app.post<{ Params: { planId: string } }>(
-    '/plan/:planId/participants',
+    '/plans/:planId/participants',
     async (request, reply) => {
       const plan = ensurePlan(store, request.params.planId);
       const parsed = participantCreateSchema.parse(request.body);
@@ -432,7 +435,7 @@ export async function buildServer(
   );
 
   app.get<{ Params: { planId: string } }>(
-    '/plan/:planId/items',
+    '/plans/:planId/items',
     async (request, reply) => {
       ensurePlan(store, request.params.planId);
       const planItems = store.items.filter(
@@ -443,7 +446,7 @@ export async function buildServer(
   );
 
   app.post<{ Params: { planId: string } }>(
-    '/plan/:planId/items',
+    '/plans/:planId/items',
     async (request, reply) => {
       ensurePlan(store, request.params.planId);
       const parsed = itemCreateSchema.parse(request.body);

--- a/src/core/api.generated.ts
+++ b/src/core/api.generated.ts
@@ -93,6 +93,137 @@ export interface paths {
       };
     };
     put?: never;
+    /**
+     * Create a new plan
+     * @description Create a new plan with the provided details
+     */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': components['schemas']['def-7'];
+        };
+      };
+      responses: {
+        /** @description Default Response */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-5'];
+          };
+        };
+        /** @description Default Response */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plans/{planId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get plan by ID
+     * @description Retrieve a single plan by its ID with associated items
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          planId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-12'];
+          };
+        };
+        /** @description Default Response */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    put?: never;
     post?: never;
     delete?: never;
     options?: never;
@@ -198,6 +329,52 @@ export interface components {
     'def-9': {
       /** Format: uuid */
       planId: string;
+    };
+    /** Item */
+    'def-10': {
+      /** Format: uuid */
+      itemId: string;
+      /** Format: uuid */
+      planId: string;
+      name: string;
+      /** @enum {string} */
+      category: 'equipment' | 'food';
+      quantity: number;
+      /** @enum {string} */
+      unit: 'pcs' | 'kg' | 'g' | 'lb' | 'oz' | 'l' | 'ml' | 'pack' | 'set';
+      /** @enum {string} */
+      status: 'pending' | 'purchased' | 'packed' | 'canceled';
+      notes?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+    };
+    /** ItemList */
+    'def-11': components['schemas']['def-10'][];
+    /** PlanWithItems */
+    'def-12': {
+      /** Format: uuid */
+      planId: string;
+      title: string;
+      description?: string | null;
+      /** @enum {string} */
+      status: 'draft' | 'active' | 'archived';
+      /** @enum {string} */
+      visibility: 'public' | 'unlisted' | 'private';
+      /** Format: uuid */
+      ownerParticipantId?: string | null;
+      location?: components['schemas']['def-4'] | null;
+      /** Format: date-time */
+      startDate?: string | null;
+      /** Format: date-time */
+      endDate?: string | null;
+      tags?: string[] | null;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+      items: components['schemas']['def-11'];
     };
   };
   responses: never;

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -17,7 +17,9 @@ import {
 } from './schemas/participant';
 import {
   planSchema,
+  planWithItemsSchema,
   type Plan,
+  type PlanWithItems,
   type PlanCreate,
   type PlanPatch,
 } from './schemas/plan';
@@ -97,9 +99,9 @@ export async function fetchPlans(): Promise<Plan[]> {
   return z.array(planSchema).parse(data);
 }
 
-export async function fetchPlan(planId: string): Promise<Plan> {
-  const data = await request<unknown>(`/plan/${planId}`);
-  return planSchema.parse(data);
+export async function fetchPlan(planId: string): Promise<PlanWithItems> {
+  const data = await request<unknown>(`/plans/${planId}`);
+  return planWithItemsSchema.parse(data);
 }
 
 export async function createPlan(plan: PlanCreate): Promise<Plan> {
@@ -114,7 +116,7 @@ export async function updatePlan(
   planId: string,
   updates: PlanPatch
 ): Promise<Plan> {
-  const data = await request<unknown>(`/plan/${planId}`, {
+  const data = await request<unknown>(`/plans/${planId}`, {
     method: 'PATCH',
     body: JSON.stringify(updates),
   });
@@ -122,7 +124,7 @@ export async function updatePlan(
 }
 
 export async function deletePlan(planId: string): Promise<void> {
-  await request(`/plan/${planId}`, {
+  await request(`/plans/${planId}`, {
     method: 'DELETE',
   });
 }
@@ -132,7 +134,7 @@ export async function deletePlan(planId: string): Promise<void> {
 export async function fetchParticipants(
   planId: string
 ): Promise<Participant[]> {
-  const data = await request<unknown>(`/plan/${planId}/participants`);
+  const data = await request<unknown>(`/plans/${planId}/participants`);
   return z.array(participantSchema).parse(data);
 }
 
@@ -140,10 +142,9 @@ export async function createParticipant(
   planId: string,
   participant: ParticipantCreate
 ): Promise<Participant> {
-  // Validate input before sending
   const validParticipant = participantCreateSchema.parse(participant);
 
-  const data = await request<unknown>(`/plan/${planId}/participants`, {
+  const data = await request<unknown>(`/plans/${planId}/participants`, {
     method: 'POST',
     body: JSON.stringify(validParticipant),
   });
@@ -180,7 +181,7 @@ export async function deleteParticipant(participantId: string): Promise<void> {
 // --- Items ---
 
 export async function fetchItems(planId: string): Promise<Item[]> {
-  const data = await request<unknown>(`/plan/${planId}/items`);
+  const data = await request<unknown>(`/plans/${planId}/items`);
   return z.array(itemSchema).parse(data);
 }
 
@@ -188,10 +189,9 @@ export async function createItem(
   planId: string,
   item: ItemCreate
 ): Promise<Item> {
-  // Validate input before sending
   const validItem = itemCreateSchema.parse(item);
 
-  const data = await request<unknown>(`/plan/${planId}/items`, {
+  const data = await request<unknown>(`/plans/${planId}/items`, {
     method: 'POST',
     body: JSON.stringify(validItem),
   });

--- a/src/core/openapi.json
+++ b/src/core/openapi.json
@@ -302,6 +302,145 @@
         },
         "required": ["planId"],
         "title": "PlanIdParam"
+      },
+      "def-10": {
+        "type": "object",
+        "properties": {
+          "itemId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "name": {
+            "type": "string"
+          },
+          "category": {
+            "type": "string",
+            "enum": ["equipment", "food"]
+          },
+          "quantity": {
+            "type": "integer"
+          },
+          "unit": {
+            "type": "string",
+            "enum": ["pcs", "kg", "g", "lb", "oz", "l", "ml", "pack", "set"]
+          },
+          "status": {
+            "type": "string",
+            "enum": ["pending", "purchased", "packed", "canceled"]
+          },
+          "notes": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "itemId",
+          "planId",
+          "name",
+          "category",
+          "quantity",
+          "unit",
+          "status",
+          "createdAt",
+          "updatedAt"
+        ],
+        "title": "Item"
+      },
+      "def-11": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/def-10"
+        },
+        "title": "ItemList"
+      },
+      "def-12": {
+        "type": "object",
+        "properties": {
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "title": {
+            "type": "string"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": ["draft", "active", "archived"]
+          },
+          "visibility": {
+            "type": "string",
+            "enum": ["public", "unlisted", "private"]
+          },
+          "ownerParticipantId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
+          "location": {
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/def-4"
+              },
+              {
+                "type": "null"
+              }
+            ]
+          },
+          "startDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "endDate": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "tags": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "items": {
+            "$ref": "#/components/schemas/def-11"
+          }
+        },
+        "required": [
+          "planId",
+          "title",
+          "status",
+          "visibility",
+          "createdAt",
+          "updatedAt",
+          "items"
+        ],
+        "title": "PlanWithItems"
       }
     }
   },
@@ -326,6 +465,62 @@
       }
     },
     "/plans": {
+      "post": {
+        "summary": "Create a new plan",
+        "tags": ["plans"],
+        "description": "Create a new plan with the provided details",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/def-7"
+              }
+            }
+          }
+        },
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-5"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      },
       "get": {
         "summary": "List all plans",
         "tags": ["plans"],
@@ -337,6 +532,76 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/def-6"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plans/{planId}": {
+      "get": {
+        "summary": "Get plan by ID",
+        "tags": ["plans"],
+        "description": "Retrieve a single plan by its ID with associated items",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-12"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }

--- a/src/core/schemas/plan.ts
+++ b/src/core/schemas/plan.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import { locationSchema } from './location';
+import { itemSchema } from './item';
 
 export const planStatusSchema = z.enum(['draft', 'active', 'archived']);
 export const planVisibilitySchema = z.enum(['public', 'unlisted', 'private']);
@@ -20,6 +21,10 @@ export const planSchema = z.object({
   updatedAt: z.string(),
 });
 
+export const planWithItemsSchema = planSchema.extend({
+  items: z.array(itemSchema),
+});
+
 export const planCreateSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   description: z.string().optional(),
@@ -38,5 +43,6 @@ export const planPatchSchema = planCreateSchema.partial();
 export type PlanStatus = z.infer<typeof planStatusSchema>;
 export type PlanVisibility = z.infer<typeof planVisibilitySchema>;
 export type Plan = z.infer<typeof planSchema>;
+export type PlanWithItems = z.infer<typeof planWithItemsSchema>;
 export type PlanCreate = z.infer<typeof planCreateSchema>;
 export type PlanPatch = z.infer<typeof planPatchSchema>;

--- a/src/core/types/plan.ts
+++ b/src/core/types/plan.ts
@@ -1,1 +1,6 @@
-export type { Plan, PlanStatus, PlanVisibility } from '../schemas/plan';
+export type {
+  Plan,
+  PlanWithItems,
+  PlanStatus,
+  PlanVisibility,
+} from '../schemas/plan';

--- a/src/hooks/usePlan.ts
+++ b/src/hooks/usePlan.ts
@@ -1,8 +1,9 @@
 import { useQuery } from '@tanstack/react-query';
 import { fetchPlan } from '../core/api';
+import type { PlanWithItems } from '../core/schemas/plan';
 
 export function usePlan(planId: string) {
-  return useQuery({
+  return useQuery<PlanWithItems>({
     queryKey: ['plan', planId],
     queryFn: () => fetchPlan(planId),
     retry: false,

--- a/src/test/integration/prod-api.test.ts
+++ b/src/test/integration/prod-api.test.ts
@@ -14,7 +14,7 @@ describe.skip('Production API - Smoke Tests', () => {
   });
 
   it('should return 404 for non-existent plan', async () => {
-    const response = await fetch(`${PROD_API_URL}/plan/non-existent-plan-id`);
+    const response = await fetch(`${PROD_API_URL}/plans/non-existent-plan-id`);
 
     expect(response.status).toBe(404);
   });

--- a/src/test/unit/api/server.test.ts
+++ b/src/test/unit/api/server.test.ts
@@ -91,6 +91,31 @@ describe('mock server', () => {
     }
   });
 
+  it('fetches a single plan with items', async () => {
+    const server = await buildServer({
+      initialData: createTestData(),
+      persist: false,
+    });
+    try {
+      const response = await server.inject({
+        method: 'GET',
+        url: '/plans/plan-1',
+      });
+      expect(response.statusCode).toBe(200);
+
+      const payload = response.json() as Record<string, unknown>;
+      expect(payload.planId).toBe('plan-1');
+      expect(payload.title).toBe('Test Plan');
+      expect(Array.isArray(payload.items)).toBe(true);
+      expect((payload.items as Array<Record<string, unknown>>).length).toBe(1);
+      expect((payload.items as Array<Record<string, unknown>>)[0].itemId).toBe(
+        'item-1'
+      );
+    } finally {
+      await server.close();
+    }
+  });
+
   it('adds a participant to a plan', async () => {
     const server = await buildServer({
       initialData: createTestData(),
@@ -99,7 +124,7 @@ describe('mock server', () => {
     try {
       const response = await server.inject({
         method: 'POST',
-        url: '/plan/plan-1/participants',
+        url: '/plans/plan-1/participants',
         payload: {
           displayName: 'Jamie',
           role: 'participant',
@@ -113,7 +138,7 @@ describe('mock server', () => {
 
       const planResponse = await server.inject({
         method: 'GET',
-        url: '/plan/plan-1',
+        url: '/plans/plan-1',
       });
       const plan = planResponse.json() as { participantIds?: string[] };
       expect(plan.participantIds).toEqual(
@@ -132,7 +157,7 @@ describe('mock server', () => {
     try {
       const response = await server.inject({
         method: 'POST',
-        url: '/plan/plan-1/items',
+        url: '/plans/plan-1/items',
         payload: {
           name: 'Lantern',
           category: 'equipment',
@@ -157,7 +182,7 @@ describe('mock server', () => {
     try {
       const response = await server.inject({
         method: 'GET',
-        url: '/plan/unknown',
+        url: '/plans/unknown',
       });
       expect(response.statusCode).toBe(404);
     } finally {

--- a/src/test/unit/core/api.test.ts
+++ b/src/test/unit/core/api.test.ts
@@ -57,6 +57,23 @@ describe('API Client', () => {
     updatedAt: '2025-01-01T00:00:00Z',
   };
 
+  const mockPlanWithItems = {
+    ...mockPlan,
+    items: [
+      {
+        itemId: 'item-1',
+        planId: 'plan-1',
+        name: 'Tent',
+        quantity: 1,
+        unit: 'pcs',
+        status: 'pending',
+        category: 'equipment',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      },
+    ],
+  };
+
   const mockParticipant = {
     participantId: 'p-1',
     displayName: 'Test User',
@@ -95,13 +112,14 @@ describe('API Client', () => {
       );
     });
 
-    it('fetches a single plan', async () => {
-      fetchMock.mockResolvedValueOnce(mockResponse(mockPlan));
+    it('fetches a single plan with items', async () => {
+      fetchMock.mockResolvedValueOnce(mockResponse(mockPlanWithItems));
 
       const plan = await fetchPlan('plan-1');
-      expect(plan).toEqual(mockPlan);
+      expect(plan).toEqual(mockPlanWithItems);
+      expect(plan.items).toHaveLength(1);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://api.test/plan/plan-1',
+        'http://api.test/plans/plan-1',
         expect.objectContaining({
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
@@ -143,7 +161,7 @@ describe('API Client', () => {
       const plan = await updatePlan('plan-1', updates);
       expect(plan.title).toBe('Updated');
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://api.test/plan/plan-1',
+        'http://api.test/plans/plan-1',
         expect.objectContaining({
           method: 'PATCH',
           body: JSON.stringify(updates),
@@ -159,7 +177,7 @@ describe('API Client', () => {
 
       await deletePlan('plan-1');
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://api.test/plan/plan-1',
+        'http://api.test/plans/plan-1',
         expect.objectContaining({
           method: 'DELETE',
           headers: expect.objectContaining({
@@ -177,7 +195,7 @@ describe('API Client', () => {
       const participants = await fetchParticipants('plan-1');
       expect(participants).toEqual([mockParticipant]);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://api.test/plan/plan-1/participants',
+        'http://api.test/plans/plan-1/participants',
         expect.objectContaining({
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
@@ -197,7 +215,7 @@ describe('API Client', () => {
       const participant = await createParticipant('plan-1', newParticipant);
       expect(participant).toEqual(mockParticipant);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://api.test/plan/plan-1/participants',
+        'http://api.test/plans/plan-1/participants',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(newParticipant),
@@ -266,7 +284,7 @@ describe('API Client', () => {
       const items = await fetchItems('plan-1');
       expect(items).toEqual([mockItem]);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://api.test/plan/plan-1/items',
+        'http://api.test/plans/plan-1/items',
         expect.objectContaining({
           headers: expect.objectContaining({
             'Content-Type': 'application/json',
@@ -286,7 +304,7 @@ describe('API Client', () => {
       const item = await createItem('plan-1', newItem);
       expect(item).toEqual(mockItem);
       expect(fetchMock).toHaveBeenCalledWith(
-        'http://api.test/plan/plan-1/items',
+        'http://api.test/plans/plan-1/items',
         expect.objectContaining({
           method: 'POST',
           body: JSON.stringify(newItem),
@@ -366,7 +384,7 @@ describe('API Client', () => {
         })
       );
 
-      await expect(fetchPlan('plan-1')).rejects.toThrow('API returned 500');
+      await expect(fetchPlans()).rejects.toThrow('API returned 500');
     });
 
     it('throws clear error when API returns HTML instead of JSON', async () => {


### PR DESCRIPTION
## Summary
- Fetch updated OpenAPI spec introducing `POST /plans` and `GET /plans/{planId}` (returns plan with items)
- Align mock server routes from `/plan/:planId` to `/plans/:planId` to match the backend API spec
- Add `PlanWithItems` schema/type so `GET /plans/{planId}` returns plan data with associated items
- Update FE API layer (`api.ts`), hooks, and all test suites to use the new plural route pattern

## Test plan
- [x] All 76 unit tests pass
- [x] TypeScript typecheck clean
- [x] ESLint clean
- [x] Production build succeeds
- [x] Mock server `GET /plans/:planId` returns plan object with `items` array
- [x] `fetchPlan` returns `PlanWithItems` with Zod validation

Closes #14

Made with [Cursor](https://cursor.com)