### PR TITLE
align all Zod schemas with OpenAPI spec and consolidate schema tests

### DIFF
--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -12,11 +12,12 @@ alwaysApply: true
 - Do NOT start coding without an issue to reference
 
 ## Starting Work
-1. Fetch the GitHub issue assigned to this task: `gh issue view <number>`
-2. Confirm with user which issue we're working on
-3. Assign yourself and add "in progress" label
-4. Create a feature branch from up-to-date main: `git checkout main && git pull origin main && git checkout -b <branch>`
-5. Implement the feature/fix per the issue description
+1. If working on a bug and no issue exists yet, create one first: `gh issue create --title "<title>" --label "bug" --body "<description>"`
+2. Fetch the GitHub issue assigned to this task: `gh issue view <number>`
+3. Confirm with user which issue we're working on
+4. Assign yourself and add "in progress" label
+5. Create a feature branch from up-to-date main: `git checkout main && git pull origin main && git checkout -b <branch>`
+6. Implement the feature/fix per the issue description
 
 ## Planning Mode
 - Output a concise plan before writing code
@@ -33,6 +34,21 @@ alwaysApply: true
 - No lazy coding: never use `// ... rest of code` placeholders
 - Read target file's imports, types, and style before generating code
 - Pin dependency versions exactly (no `^` or `~` ranges)
+
+## OpenAPI Schema Alignment (Mandatory on Every Schema Change)
+When the OpenAPI spec (`src/core/openapi.json`) or any Zod schema changes, verify alignment across ALL four layers:
+1. **OpenAPI spec** (`src/core/openapi.json`) — the contract
+2. **Frontend Zod schemas** (`src/core/schemas/`) — must mirror OpenAPI format constraints (`date-time` → `.datetime()`, `nullable` → `.nullish()`, `integer` → `.int()`, `maxLength` → `.max()`)
+3. **Mock server schemas** (`api/server.ts` request validation, `api/mock.ts` data loading) — must match the same constraints
+4. **Mock data** (`api/mock-data.json`) — all values must satisfy the schemas above
+5. **Tests** — all mock data in tests must use valid formats (e.g. RFC 3339 dates with `Z` suffix)
+
+Checklist per schema field:
+- `format: "date-time"` → `z.string().datetime()` everywhere (frontend, mock server, mock loader)
+- `nullable: true` + not required → `.nullish()` in frontend, `.nullable().optional()` in mock server
+- `type: "integer"` → `.int()` everywhere
+- `minLength` / `maxLength` → `.min()` / `.max()` everywhere
+- Required fields in OpenAPI → NOT `.optional()` in Zod
 
 ## Debugging
 - Stop on test/build failures - do not proceed

--- a/api/mock-data.json
+++ b/api/mock-data.json
@@ -17,8 +17,8 @@
         "region": "CA",
         "city": "Yosemite"
       },
-      "startDate": "2025-07-18",
-      "endDate": "2025-07-20",
+      "startDate": "2025-07-18T00:00:00Z",
+      "endDate": "2025-07-20T00:00:00Z",
       "tags": ["outdoors", "family", "camping"],
       "participantIds": ["participant-1", "participant-2", "participant-3"],
       "createdAt": "2025-05-01T12:00:00.000Z",
@@ -29,7 +29,7 @@
       "createdAt": "2025-12-15T10:38:27.314Z",
       "updatedAt": "2025-12-15T10:38:27.314Z",
       "description": "Trip with Ron",
-      "endDate": "2025-12-15T15:38:00",
+      "endDate": "2025-12-15T15:38:00Z",
       "location": {
         "name": "Park ha-Yarkon",
         "country": "Israel",
@@ -42,7 +42,7 @@
         "3cdcb33e-eebd-5716-8164-7da2b8158993",
         "de0bf12f-97de-534c-9930-27ebd6e0f944"
       ],
-      "startDate": "2025-12-15T12:38:00",
+      "startDate": "2025-12-15T12:38:00Z",
       "status": "active",
       "title": "Park trip",
       "visibility": "public"
@@ -52,7 +52,7 @@
       "createdAt": "2025-12-15T10:41:13.099Z",
       "updatedAt": "2025-12-15T10:41:13.099Z",
       "description": "sdsd",
-      "endDate": "2025-12-24T16:41:00",
+      "endDate": "2025-12-24T16:41:00Z",
       "location": {
         "name": "sdsd",
         "country": "",
@@ -66,7 +66,7 @@
         "de0bf12f-97de-534c-9930-27ebd6e0f944",
         "3238777c-8513-5c60-8964-99397eacfa28"
       ],
-      "startDate": "2025-12-15T13:40:00",
+      "startDate": "2025-12-15T13:40:00Z",
       "status": "active",
       "title": "Hdjhsd",
       "visibility": "public"

--- a/api/mock.ts
+++ b/api/mock.ts
@@ -28,12 +28,12 @@ const planSchema = z.object({
   visibility: z.enum(['public', 'unlisted', 'private']),
   ownerParticipantId: z.string().nullable().optional(),
   location: locationSchema.nullable().optional(),
-  startDate: z.string().nullable().optional(),
-  endDate: z.string().nullable().optional(),
+  startDate: z.string().datetime().nullable().optional(),
+  endDate: z.string().datetime().nullable().optional(),
   tags: z.array(z.string()).nullable().optional(),
   participantIds: z.array(z.string()).optional(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
 });
 
 const participantSchema = z.object({
@@ -43,23 +43,23 @@ const participantSchema = z.object({
   displayName: z.string(),
   role: z.enum(['owner', 'participant', 'viewer']),
   isOwner: z.boolean().optional(),
-  avatarUrl: z.string().url().optional(),
-  contactEmail: z.string().email().optional(),
-  contactPhone: z.string().optional(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  avatarUrl: z.string().url().nullish(),
+  contactEmail: z.string().email().nullish(),
+  contactPhone: z.string().nullish(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
 });
 
 const equipmentItemSchema = z.object({
   itemId: z.string(),
   planId: z.string(),
   name: z.string(),
-  quantity: z.number(),
+  quantity: z.number().int(),
   unit: z.enum(['pcs', 'kg', 'g', 'lb', 'oz', 'l', 'ml', 'pack', 'set']),
-  notes: z.string().optional(),
+  notes: z.string().nullish(),
   status: z.enum(['pending', 'purchased', 'packed', 'canceled']),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
   category: z.literal('equipment'),
 });
 

--- a/api/server.ts
+++ b/api/server.ts
@@ -53,14 +53,14 @@ const locationSchema = z.object({
 });
 
 const planCreateSchema = z.object({
-  title: z.string().min(1),
+  title: z.string().min(1).max(255),
   description: z.string().nullable().optional(),
   status: planStatusSchema.default('draft'),
   visibility: planVisibilitySchema.default('private'),
   ownerParticipantId: z.string().nullable().optional(),
   location: locationSchema.nullable().optional(),
-  startDate: z.string().nullable().optional(),
-  endDate: z.string().nullable().optional(),
+  startDate: z.string().datetime().nullable().optional(),
+  endDate: z.string().datetime().nullable().optional(),
   tags: z.array(z.string()).nullable().optional(),
   participantIds: z.array(z.string()).optional(),
 });
@@ -81,10 +81,10 @@ const participantPatchSchema = participantCreateSchema.partial();
 
 const itemCreateSchema = z.object({
   name: z.string().min(1),
-  quantity: z.number().positive().optional(),
+  quantity: z.number().int().positive().optional(),
   unit: unitSchema.optional(),
   status: itemStatusSchema.optional(),
-  notes: z.string().optional(),
+  notes: z.string().nullish(),
   category: itemCategorySchema,
 });
 

--- a/dev-lessons.md
+++ b/dev-lessons.md
@@ -6,6 +6,27 @@ A log of bugs fixed and problems solved in this project.
 
 <!-- Add new entries at the top -->
 
+## 2026-02-08: Zod Schemas Must Mirror OpenAPI Format Constraints
+
+**Problem**: Creating a new plan failed with `body/startDate must match format "date-time"`. The `makeDateTime` helper produced `2025-12-20T10:00:00` (no timezone designator), which is not valid RFC 3339.
+
+**Root Cause**: Three layers of defense all had gaps:
+1. Zod schemas used `z.string().optional()` instead of `z.string().datetime().optional()`, silently dropping the `format: "date-time"` constraint from the OpenAPI spec.
+2. `createPlan()` and `updatePlan()` did not validate input before sending (unlike `createParticipant()` / `createItem()` which already called `.parse()`).
+3. Tests asserted the wrong date format (`'2025-12-20T10:00:00'` instead of `'2025-12-20T10:00:00Z'`), encoding the bug as expected behavior.
+
+**Solution**:
+- Appended `Z` to `makeDateTime` output in `PlanForm.tsx`.
+- Added `.datetime()` to all date fields in Zod schemas (`planSchema`, `planCreateSchema`).
+- Added input validation (`.parse()`) to `createPlan()` and `updatePlan()` for parity.
+- Fixed all test assertions and added schema-level + API-level tests for date format.
+
+**Lessons**:
+1. When hand-writing Zod schemas from an OpenAPI spec, always translate `format` constraints (e.g. `date-time` -> `z.string().datetime()`), not just the `type`.
+2. Every API mutation function should validate input with `.parse()` before sending — catch bad data client-side.
+3. Tests that assert payload shape should verify format correctness, not just structural presence.
+4. If multiple API functions follow the same pattern, audit them all for consistency (the bug existed only in `createPlan`/`updatePlan`, not in `createParticipant`/`createItem`).
+
 ## 2026-02-05: E2E Testing Best Practices
 
 **Problem**: Playwright E2E tests were flaky - checking for "Loading..." state was unreliable because data loads too fast.

--- a/src/components/PlanForm.tsx
+++ b/src/components/PlanForm.tsx
@@ -16,6 +16,15 @@ const planCreatePayloadSchema = planSchema.omit({
 
 type PlanCreatePayload = z.infer<typeof planCreatePayloadSchema>;
 
+const locationFormSchema = z
+  .object({
+    name: z.string().optional(),
+    city: z.string().optional(),
+    country: z.string().optional(),
+    region: z.string().optional(),
+  })
+  .optional();
+
 const createPlanFormSchema = planCreatePayloadSchema
   .omit({
     tags: true,
@@ -24,6 +33,7 @@ const createPlanFormSchema = planCreatePayloadSchema
     endDate: true,
     ownerParticipantId: true,
     title: true,
+    location: true,
   })
   .extend({
     title: z.string().min(1, 'Title is required'),
@@ -46,6 +56,7 @@ const createPlanFormSchema = planCreatePayloadSchema
     startDateTime: z.string().optional(),
     endDateDate: z.string().optional(),
     endDateTime: z.string().optional(),
+    location: locationFormSchema,
   })
   .refine(
     (data) => {
@@ -103,8 +114,8 @@ export default function PlanForm() {
 
   const makeDateTime = (date?: string, time?: string) => {
     if (!date) return undefined;
-    const hhmm = time ?? '00:00';
-    return `${date}T${hhmm}:00`;
+    const hhmm = time || '00:00';
+    return `${date}T${hhmm}:00Z`;
   };
 
   const UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -16,6 +16,8 @@ import {
   type ParticipantPatch,
 } from './schemas/participant';
 import {
+  planCreateSchema,
+  planPatchSchema,
   planSchema,
   planWithItemsSchema,
   type Plan,
@@ -105,9 +107,11 @@ export async function fetchPlan(planId: string): Promise<PlanWithItems> {
 }
 
 export async function createPlan(plan: PlanCreate): Promise<Plan> {
+  const validPlan = planCreateSchema.parse(plan);
+
   const data = await request<unknown>('/plans', {
     method: 'POST',
-    body: JSON.stringify(plan),
+    body: JSON.stringify(validPlan),
   });
   return planSchema.parse(data);
 }
@@ -116,9 +120,11 @@ export async function updatePlan(
   planId: string,
   updates: PlanPatch
 ): Promise<Plan> {
+  const validUpdates = planPatchSchema.parse(updates);
+
   const data = await request<unknown>(`/plans/${planId}`, {
     method: 'PATCH',
-    body: JSON.stringify(updates),
+    body: JSON.stringify(validUpdates),
   });
   return planSchema.parse(data);
 }

--- a/src/core/schemas/item.ts
+++ b/src/core/schemas/item.ts
@@ -23,12 +23,12 @@ const baseItemSchema = z.object({
   itemId: z.string(),
   planId: z.string(),
   name: z.string(),
-  quantity: z.number(),
+  quantity: z.number().int(),
   unit: unitSchema,
-  notes: z.string().optional(),
+  notes: z.string().nullish(),
   status: itemStatusSchema,
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
 });
 
 export const equipmentItemSchema = baseItemSchema.extend({

--- a/src/core/schemas/location.ts
+++ b/src/core/schemas/location.ts
@@ -1,14 +1,14 @@
 import { z } from 'zod';
 
 export const locationSchema = z.object({
-  locationId: z.string().optional(),
-  name: z.string().optional(),
-  timezone: z.string().optional(),
-  latitude: z.number().optional(),
-  longitude: z.number().optional(),
-  country: z.string().optional(),
-  region: z.string().optional(),
-  city: z.string().optional(),
+  locationId: z.string(),
+  name: z.string(),
+  timezone: z.string().nullish(),
+  latitude: z.number().nullish(),
+  longitude: z.number().nullish(),
+  country: z.string().nullish(),
+  region: z.string().nullish(),
+  city: z.string().nullish(),
 });
 
 export type Location = z.infer<typeof locationSchema>;

--- a/src/core/schemas/participant.ts
+++ b/src/core/schemas/participant.ts
@@ -9,11 +9,11 @@ export const participantSchema = z.object({
   displayName: z.string(),
   role: participantRoleSchema,
   isOwner: z.boolean().optional(),
-  avatarUrl: z.string().url().optional(),
-  contactEmail: z.string().email().optional(),
-  contactPhone: z.string().optional(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  avatarUrl: z.string().url().nullish(),
+  contactEmail: z.string().email().nullish(),
+  contactPhone: z.string().nullish(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
 });
 
 export const participantCreateSchema = z.object({

--- a/src/core/schemas/plan.ts
+++ b/src/core/schemas/plan.ts
@@ -8,17 +8,17 @@ export const planVisibilitySchema = z.enum(['public', 'unlisted', 'private']);
 export const planSchema = z.object({
   planId: z.string(),
   title: z.string(),
-  description: z.string().optional(),
+  description: z.string().nullish(),
   status: planStatusSchema,
   visibility: planVisibilitySchema,
-  ownerParticipantId: z.string(),
-  location: locationSchema.optional(),
-  startDate: z.string().optional(),
-  endDate: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  participantIds: z.array(z.string()).optional(),
-  createdAt: z.string(),
-  updatedAt: z.string(),
+  ownerParticipantId: z.string().nullish(),
+  location: locationSchema.nullish(),
+  startDate: z.string().datetime().nullish(),
+  endDate: z.string().datetime().nullish(),
+  tags: z.array(z.string()).nullish(),
+  participantIds: z.array(z.string()).nullish(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime(),
 });
 
 export const planWithItemsSchema = planSchema.extend({
@@ -26,16 +26,16 @@ export const planWithItemsSchema = planSchema.extend({
 });
 
 export const planCreateSchema = z.object({
-  title: z.string().min(1, 'Title is required'),
-  description: z.string().optional(),
+  title: z.string().min(1, 'Title is required').max(255),
+  description: z.string().nullish(),
   status: planStatusSchema.default('draft'),
   visibility: planVisibilitySchema.default('private'),
   ownerParticipantId: z.string().min(1),
-  location: locationSchema.optional(),
-  startDate: z.string().optional(),
-  endDate: z.string().optional(),
-  tags: z.array(z.string()).optional(),
-  participantIds: z.array(z.string()).optional(),
+  location: locationSchema.nullish(),
+  startDate: z.string().datetime().nullish(),
+  endDate: z.string().datetime().nullish(),
+  tags: z.array(z.string()).nullish(),
+  participantIds: z.array(z.string()).nullish(),
 });
 
 export const planPatchSchema = planCreateSchema.partial();

--- a/src/test/unit/components/CreatePlan.test.tsx
+++ b/src/test/unit/components/CreatePlan.test.tsx
@@ -179,8 +179,8 @@ describe('CreatePlan - PlanForm', () => {
         description: 'A fun day out',
         status: 'draft',
         ownerParticipantId: 'uuid-alice',
-        startDate: '2025-12-20T10:00:00',
-        endDate: '2025-12-20T16:00:00',
+        startDate: '2025-12-20T10:00:00Z',
+        endDate: '2025-12-20T16:00:00Z',
         tags: ['outdoor', 'fun'],
         participantIds: ['uuid-alice', 'uuid-bob'],
         createdAt: '2025-12-12T00:00:00Z',
@@ -233,12 +233,17 @@ describe('CreatePlan - PlanForm', () => {
             description: 'A fun day out',
             status: 'draft',
             ownerParticipantId: 'uuid-alice',
-            startDate: '2025-12-20T10:00:00',
-            endDate: '2025-12-20T16:00:00',
+            startDate: '2025-12-20T10:00:00Z',
+            endDate: '2025-12-20T16:00:00Z',
             tags: ['outdoor', 'fun'],
             participantIds: ['uuid-alice', 'uuid-bob'],
           })
         );
+
+        const payload = mockCreatePlan.mock.calls[0][0];
+        const iso8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+        expect(payload.startDate).toMatch(iso8601);
+        expect(payload.endDate).toMatch(iso8601);
       });
 
       // Check redirect
@@ -256,8 +261,8 @@ describe('CreatePlan - PlanForm', () => {
         description: 'Two day adventure',
         status: 'active',
         ownerParticipantId: 'uuid-charlie',
-        startDate: '2025-12-20T09:00:00',
-        endDate: '2025-12-22T18:00:00',
+        startDate: '2025-12-20T09:00:00Z',
+        endDate: '2025-12-22T18:00:00Z',
         tags: ['travel'],
         participantIds: ['uuid-charlie', 'uuid-dave'],
         createdAt: '2025-12-12T00:00:00Z',
@@ -302,12 +307,17 @@ describe('CreatePlan - PlanForm', () => {
             description: 'Two day adventure',
             status: 'active',
             ownerParticipantId: 'uuid-charlie',
-            startDate: '2025-12-20T09:00:00',
-            endDate: '2025-12-22T18:00:00',
+            startDate: '2025-12-20T09:00:00Z',
+            endDate: '2025-12-22T18:00:00Z',
             tags: ['travel'],
             participantIds: ['uuid-charlie', 'uuid-dave'],
           })
         );
+
+        const payload = mockCreatePlan.mock.calls[0][0];
+        const iso8601 = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z$/;
+        expect(payload.startDate).toMatch(iso8601);
+        expect(payload.endDate).toMatch(iso8601);
       });
 
       expect(window.location.href).toBe('/plan/plan-456');
@@ -323,7 +333,7 @@ describe('CreatePlan - PlanForm', () => {
         title: 'No Location Plan',
         status: 'draft',
         ownerParticipantId: 'uuid-owner',
-        startDate: '2025-12-20T00:00:00',
+        startDate: '2025-12-20T00:00:00Z',
         createdAt: '2025-12-12T00:00:00Z',
         updatedAt: '2025-12-12T00:00:00Z',
         visibility: 'public',
@@ -361,7 +371,7 @@ describe('CreatePlan - PlanForm', () => {
         title: 'Park Hangout',
         status: 'draft',
         ownerParticipantId: 'uuid-owner',
-        startDate: '2025-12-20T00:00:00',
+        startDate: '2025-12-20T00:00:00Z',
         createdAt: '2025-12-12T00:00:00Z',
         updatedAt: '2025-12-12T00:00:00Z',
         visibility: 'public',
@@ -408,6 +418,8 @@ describe('CreatePlan - PlanForm', () => {
             country: 'US',
           })
         );
+        expect(payload.location!.locationId).toBeTruthy();
+        expect(payload.location!.name).toBeTruthy();
       });
     });
 
@@ -419,7 +431,7 @@ describe('CreatePlan - PlanForm', () => {
         title: 'Beach Trip',
         status: 'draft',
         ownerParticipantId: 'uuid-owner',
-        startDate: '2025-12-20T00:00:00',
+        startDate: '2025-12-20T00:00:00Z',
         createdAt: '2025-12-12T00:00:00Z',
         updatedAt: '2025-12-12T00:00:00Z',
         visibility: 'public',
@@ -472,7 +484,7 @@ describe('CreatePlan - PlanForm', () => {
         title: 'Test',
         status: 'draft',
         ownerParticipantId: 'uuid-test-owner',
-        startDate: '2025-12-20T00:00:00',
+        startDate: '2025-12-20T00:00:00Z',
         createdAt: '2025-12-12T00:00:00Z',
         updatedAt: '2025-12-12T00:00:00Z',
         visibility: 'public',
@@ -512,7 +524,7 @@ describe('CreatePlan - PlanForm', () => {
         title: 'Test',
         status: 'draft',
         ownerParticipantId: 'uuid-owner',
-        startDate: '2025-12-20T00:00:00',
+        startDate: '2025-12-20T00:00:00Z',
         participantIds: ['uuid-anna', 'uuid-beth', 'uuid-carol'],
         createdAt: '2025-12-12T00:00:00Z',
         updatedAt: '2025-12-12T00:00:00Z',

--- a/src/test/unit/core/api.test.ts
+++ b/src/test/unit/core/api.test.ts
@@ -172,6 +172,28 @@ describe('API Client', () => {
       );
     });
 
+    it('rejects plan creation with invalid startDate format', async () => {
+      const invalidPlan = {
+        title: 'Bad Dates Plan',
+        status: 'draft' as const,
+        visibility: 'private' as const,
+        ownerParticipantId: 'p-1',
+        startDate: '2025-12-20T10:00:00',
+      };
+
+      await expect(createPlan(invalidPlan)).rejects.toThrow();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('rejects plan update with invalid startDate format', async () => {
+      const invalidUpdates = {
+        startDate: '2025-12-20T10:00:00',
+      };
+
+      await expect(updatePlan('plan-1', invalidUpdates)).rejects.toThrow();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
     it('deletes a plan', async () => {
       fetchMock.mockResolvedValueOnce(mockResponse({}, { status: 204 }));
 

--- a/src/test/unit/core/item-schema.test.ts
+++ b/src/test/unit/core/item-schema.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from 'vitest';
+import { itemSchema, itemCreateSchema } from '../../../core/schemas/item';
+
+describe('itemSchema date-time and format validation', () => {
+  const validItem = {
+    itemId: 'item-1',
+    planId: 'plan-1',
+    name: 'Tent',
+    category: 'equipment' as const,
+    quantity: 2,
+    unit: 'pcs' as const,
+    status: 'pending' as const,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+  };
+
+  it('accepts a valid item with RFC 3339 timestamps', () => {
+    const result = itemSchema.safeParse(validItem);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects createdAt without timezone designator', () => {
+    const result = itemSchema.safeParse({
+      ...validItem,
+      createdAt: '2025-01-01T00:00:00',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects updatedAt without timezone designator', () => {
+    const result = itemSchema.safeParse({
+      ...validItem,
+      updatedAt: '2025-01-01T00:00:00',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects non-integer quantity', () => {
+    const result = itemSchema.safeParse({
+      ...validItem,
+      quantity: 1.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts integer quantity', () => {
+    const result = itemSchema.safeParse({
+      ...validItem,
+      quantity: 3,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts null for notes', () => {
+    const result = itemSchema.safeParse({
+      ...validItem,
+      notes: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts string for notes', () => {
+    const result = itemSchema.safeParse({
+      ...validItem,
+      notes: 'Bring extra stakes',
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('itemCreateSchema', () => {
+  it('accepts minimal valid item create payload', () => {
+    const result = itemCreateSchema.safeParse({
+      name: 'Tent',
+      category: 'equipment',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects empty name', () => {
+    const result = itemCreateSchema.safeParse({
+      name: '',
+      category: 'equipment',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects missing category', () => {
+    const result = itemCreateSchema.safeParse({
+      name: 'Tent',
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/test/unit/core/participant-schema.test.ts
+++ b/src/test/unit/core/participant-schema.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'vitest';
+import { participantSchema } from '../../../core/schemas/participant';
+
+describe('participantSchema date-time validation', () => {
+  const validParticipant = {
+    participantId: 'p-1',
+    name: 'Test',
+    lastName: 'User',
+    displayName: 'Test User',
+    role: 'owner' as const,
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+  };
+
+  it('accepts valid participant with RFC 3339 timestamps', () => {
+    const result = participantSchema.safeParse(validParticipant);
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects createdAt without timezone designator', () => {
+    const result = participantSchema.safeParse({
+      ...validParticipant,
+      createdAt: '2025-01-01T00:00:00',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects updatedAt without timezone designator', () => {
+    const result = participantSchema.safeParse({
+      ...validParticipant,
+      updatedAt: '2025-01-01T00:00:00',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts null for nullable optional fields', () => {
+    const result = participantSchema.safeParse({
+      ...validParticipant,
+      avatarUrl: null,
+      contactEmail: null,
+      contactPhone: null,
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts valid email and URL formats', () => {
+    const result = participantSchema.safeParse({
+      ...validParticipant,
+      avatarUrl: 'https://example.com/avatar.png',
+      contactEmail: 'test@example.com',
+      contactPhone: '+1234567890',
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects invalid email format', () => {
+    const result = participantSchema.safeParse({
+      ...validParticipant,
+      contactEmail: 'not-an-email',
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects invalid URL format for avatarUrl', () => {
+    const result = participantSchema.safeParse({
+      ...validParticipant,
+      avatarUrl: 'not-a-url',
+    });
+    expect(result.success).toBe(false);
+  });
+});


### PR DESCRIPTION
Fix RFC 3339 date-time format in PlanForm, add input validation to createPlan and updatePlan API calls, update all schemas to use datetime/int/nullish where required, align mock server and mock data, and consolidate location and date format tests into CreatePlan tests.

closes #26 