### PR TITLE
feat: create update item UI (#31)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ See [Tailwind CSS v4 documentation](https://tailwindcss.com/docs) for more custo
 - ESLint + Prettier
 - Husky (pre-commit hooks)
 
+## Documentation
+
+- [docs/toast.md](docs/toast.md) – Toast notifications and how to show error messages app-wide.
+
 ---
 
 # Backend API Specification

--- a/dev-lessons.md
+++ b/dev-lessons.md
@@ -6,6 +6,12 @@ A log of bugs fixed and problems solved in this project.
 
 <!-- Add new entries at the top -->
 
+## Toast notifications and error messages
+
+**Context**: The app uses `react-hot-toast` for non-blocking feedback. The Toaster is in the root layout, so any screen can show toasts.
+
+**How to show error messages**: In mutation handlers (e.g. create/update item), wrap the call in try/catch and use `getApiErrorMessage()` from `src/core/error-utils.ts` to get user-friendly `{ title, message }`, then call `toast.error(\`${title}: ${message}\`)`. This keeps error copy consistent and avoids exposing raw API messages. See [docs/toast.md](docs/toast.md) for full instructions and examples.
+
 ## 2026-02-08: Zod Schemas Must Mirror OpenAPI Format Constraints
 
 **Problem**: Creating a new plan failed with `body/startDate must match format "date-time"`. The `makeDateTime` helper produced `2025-12-20T10:00:00` (no timezone designator), which is not valid RFC 3339.

--- a/docs/toast.md
+++ b/docs/toast.md
@@ -1,0 +1,40 @@
+# Toast Notifications
+
+The app uses [react-hot-toast](https://github.com/timolins/react-hot-toast) for non-blocking notifications. The `<Toaster>` is mounted once in the root layout ([`src/routes/__root.tsx`](../src/routes/__root.tsx)), so toasts are available app-wide.
+
+## Showing error messages
+
+Use `toast.error()` when an operation fails (e.g. API mutation). Prefer the shared error helper so messages are consistent and user-friendly:
+
+```typescript
+import toast from 'react-hot-toast';
+import { getApiErrorMessage } from '../core/error-utils';
+
+try {
+  await someMutation.mutateAsync(payload);
+  // success handling
+} catch (err) {
+  const { title, message } = getApiErrorMessage(
+    err instanceof Error ? err : new Error(String(err))
+  );
+  toast.error(`${title}: ${message}`);
+}
+```
+
+`getApiErrorMessage()` (from `src/core/error-utils.ts`) maps API status codes and common errors to `{ title, message, canRetry }`. Use it so users see clear, consistent error text instead of raw API messages.
+
+## Other toast types
+
+- **Success:** `toast.success('Item updated')`
+- **Loading (dismiss later):** `const id = toast.loading('Saving…');` then `toast.success('Saved', { id })` or `toast.error('Failed', { id })`
+- **Custom duration:** `toast('Message', { duration: 2000 })`
+- **Promise-based:** `toast.promise(myPromise, { loading: 'Saving…', success: 'Saved', error: 'Failed' })`
+
+## Defaults (root layout)
+
+- Position: `top-right`
+- Default duration: 4 seconds
+- Error duration: 5 seconds; red-tinted style
+- Success: green-tinted style
+
+To change global behavior, edit the `<Toaster>` props in `src/routes/__root.tsx`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.68.0",
+        "react-hot-toast": "2.6.0",
         "react-router-dom": "^7.9.5",
         "uuid": "^13.0.0"
       },
@@ -3723,7 +3724,6 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/data-urls": {
@@ -4533,6 +4533,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/goober": {
+      "version": "2.1.18",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
+      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "csstype": "^3.0.10"
       }
     },
     "node_modules/graceful-fs": {
@@ -6145,6 +6154,23 @@
       },
       "peerDependencies": {
         "react": "^16.8.0 || ^17 || ^18 || ^19"
+      }
+    },
+    "node_modules/react-hot-toast": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/react-hot-toast/-/react-hot-toast-2.6.0.tgz",
+      "integrity": "sha512-bH+2EBMZ4sdyou/DPrfgIouFpcRLCJ+HoCA32UoAYHn6T3Ur5yfcDCeSr5mwldl6pFOsiocmrXMuoCJ1vV8bWg==",
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.1.3",
+        "goober": "^2.1.16"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16",
+        "react-dom": ">=16"
       }
     },
     "node_modules/react-is": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.68.0",
+    "react-hot-toast": "2.6.0",
     "react-router-dom": "^7.9.5",
     "uuid": "^13.0.0"
   },

--- a/src/components/CategorySection.tsx
+++ b/src/components/CategorySection.tsx
@@ -14,11 +14,13 @@ const CATEGORY_LABELS: Record<ItemCategory, string> = {
 interface CategorySectionProps {
   category: ItemCategory;
   items: Item[];
+  onEditItem?: (itemId: string) => void;
 }
 
 export default function CategorySection({
   category,
   items,
+  onEditItem,
 }: CategorySectionProps) {
   const label = CATEGORY_LABELS[category];
 
@@ -59,7 +61,11 @@ export default function CategorySection({
         {items.length > 0 ? (
           <div className="border-t border-gray-200 divide-y divide-gray-200">
             {items.map((item) => (
-              <ItemCard key={item.itemId} item={item} />
+              <ItemCard
+                key={item.itemId}
+                item={item}
+                onEdit={onEditItem ? () => onEditItem(item.itemId) : undefined}
+              />
             ))}
           </div>
         ) : (

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -17,15 +17,16 @@ const STATUS_CONFIG: Record<
 
 interface ItemCardProps {
   item: Item;
+  onEdit?: () => void;
 }
 
-export default function ItemCard({ item }: ItemCardProps) {
+export default function ItemCard({ item, onEdit }: ItemCardProps) {
   const status = STATUS_CONFIG[item.status];
   const isCanceled = item.status === 'canceled';
 
   return (
     <div className="px-3 sm:px-5 py-3 sm:py-4">
-      <div className="flex items-start sm:items-center justify-between gap-3">
+      <div className="flex items-center justify-between gap-3">
         <div className="flex-1 min-w-0">
           <span
             className={clsx(
@@ -52,6 +53,31 @@ export default function ItemCard({ item }: ItemCardProps) {
             )}
           </div>
         </div>
+
+        {onEdit && (
+          <button
+            type="button"
+            onClick={onEdit}
+            className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-600 bg-blue-50 rounded-lg border border-blue-200 hover:bg-blue-100 hover:text-blue-700 active:bg-blue-200 transition-colors cursor-pointer"
+            aria-label={`Edit ${item.name}`}
+          >
+            <svg
+              className="w-4 h-4"
+              fill="none"
+              viewBox="0 0 24 24"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+              />
+            </svg>
+            Edit
+          </button>
+        )}
 
         <span
           className={clsx(

--- a/src/hooks/useUpdateItem.ts
+++ b/src/hooks/useUpdateItem.ts
@@ -1,0 +1,46 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { updateItem } from '../core/api';
+import type { ItemPatch } from '../core/schemas/item';
+import type { PlanWithItems } from '../core/schemas/plan';
+
+interface UpdateItemVariables {
+  itemId: string;
+  updates: ItemPatch;
+}
+
+export function useUpdateItem(planId: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ itemId, updates }: UpdateItemVariables) =>
+      updateItem(itemId, updates),
+    onMutate: async ({ itemId, updates }) => {
+      await queryClient.cancelQueries({ queryKey: ['plan', planId] });
+
+      const previousPlan = queryClient.getQueryData<PlanWithItems>([
+        'plan',
+        planId,
+      ]);
+
+      queryClient.setQueryData<PlanWithItems>(['plan', planId], (old) => {
+        if (!old) return old;
+        return {
+          ...old,
+          items: old.items.map((item) =>
+            item.itemId === itemId ? { ...item, ...updates } : item
+          ),
+        };
+      });
+
+      return { previousPlan };
+    },
+    onError: (_err, _variables, context) => {
+      if (context?.previousPlan) {
+        queryClient.setQueryData(['plan', planId], context.previousPlan);
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
+    },
+  });
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,4 +1,5 @@
 import { createRootRoute, Outlet, redirect } from '@tanstack/react-router';
+import { Toaster } from 'react-hot-toast';
 import NotFound from './not-found.lazy';
 import Header from '../components/Header';
 import { ErrorPage } from './ErrorPage';
@@ -44,6 +45,27 @@ export const Route = createRootRoute({
   component: () => {
     return (
       <div className="min-h-screen flex flex-col bg-gray-50">
+        <Toaster
+          position="top-right"
+          toastOptions={{
+            duration: 4000,
+            error: {
+              duration: 5000,
+              style: {
+                background: '#FEF2F2',
+                color: '#991B1B',
+                border: '1px solid #FECACA',
+              },
+            },
+            success: {
+              style: {
+                background: '#F0FDF4',
+                color: '#166534',
+                border: '1px solid #BBF7D0',
+              },
+            },
+          }}
+        />
         <Header />
         <main className="flex-1 w-full max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-2 sm:py-6 lg:py-8">
           <Outlet />


### PR DESCRIPTION
## Summary
- Add an Edit button (centered in each item card, blue pill style) that opens the existing ItemForm pre-filled with the item's current values
- Create `useUpdateItem` hook with optimistic cache updates (instant UI feedback, rollback on failure, background reconciliation)
- Install `react-hot-toast` app-wide with `<Toaster>` in root layout; show user-friendly error toast on update failure using `getApiErrorMessage()`
- Document the toast system in `docs/toast.md`, `dev-lessons.md`, and `README.md`

Closes #31

## Test plan
- [x] TypeScript compiles cleanly (`npm run typecheck`)
- [x] ESLint passes (`npm run lint`)
- [x] All 131 unit tests pass (`npm test`)
- [x] Pre-commit hooks pass (typecheck + lint-staged + tests)
- [ ] Manual: click Edit on an item card, verify form is pre-filled with item values
- [ ] Manual: submit an update, verify optimistic UI and no page reload
- [ ] Manual: simulate API error, verify toast error message appears


Made with [Cursor](https://cursor.com)