### PR TITLE
Align mock API server with OpenAPI schema

### DIFF
--- a/.cursor/rules/workflow.mdc
+++ b/.cursor/rules/workflow.mdc
@@ -42,19 +42,36 @@ alwaysApply: true
 - The root route (`__root.tsx`) must always remain non-lazy
 
 ## OpenAPI Schema Alignment (Mandatory on Every Schema Change)
-When the OpenAPI spec (`src/core/openapi.json`) or any Zod schema changes, verify alignment across ALL four layers:
-1. **OpenAPI spec** (`src/core/openapi.json`) — the contract
-2. **Frontend Zod schemas** (`src/core/schemas/`) — must mirror OpenAPI format constraints (`date-time` → `.datetime()`, `nullable` → `.nullish()`, `integer` → `.int()`, `maxLength` → `.max()`)
-3. **Mock server schemas** (`api/server.ts` request validation, `api/mock.ts` data loading) — must match the same constraints
-4. **Mock data** (`api/mock-data.json`) — all values must satisfy the schemas above
-5. **Tests** — all mock data in tests must use valid formats (e.g. RFC 3339 dates with `Z` suffix)
+When the OpenAPI spec (`src/core/openapi.json`) changes, propagate those changes across ALL layers in order:
 
-Checklist per schema field:
-- `format: "date-time"` → `z.string().datetime()` everywhere (frontend, mock server, mock loader)
+### Source of truth
+`src/core/openapi.json` is the single contract. Everything else derives from it.
+
+### Layer checklist (update in this order)
+1. **Frontend Zod schemas** (`src/core/schemas/`) — mirror OpenAPI format constraints (`date-time` → `.datetime()`, `nullable` → `.nullish()`, `integer` → `.int()`, `maxLength` → `.max()`)
+2. **Mock server request schemas** (`api/server.ts`) — create/patch Zod schemas must match the OpenAPI request body definitions (same required fields, same enums, same constraints)
+3. **Mock server response behavior** (`api/server.ts`) — endpoints must return the correct HTTP status codes and response shapes defined in OpenAPI (e.g. DELETE returning `{ ok: true }` with 200, not 204)
+4. **Mock data loader schemas** (`api/mock.ts`) — Zod schemas for loading persisted data must accept the same field shapes as the OpenAPI response schemas
+5. **Mock data** (`api/mock-data.json`) — all values must satisfy the schemas above (valid UUIDs for `format: "uuid"`, RFC 3339 dates for `format: "date-time"`, `null` not `""` for nullable fields)
+6. **Tests** — all mock/fixture data in test files must use valid formats matching the schemas
+
+### Mock server endpoint alignment
+For every path in `openapi.json`, verify the mock server (`api/server.ts`):
+- **Exists** — every OpenAPI endpoint has a corresponding Fastify route
+- **Method** — GET/POST/PATCH/DELETE matches
+- **Request body validation** — Zod schema fields, required vs optional, enums, and constraints match the OpenAPI `requestBody` schema
+- **Response status code** — matches the OpenAPI success response (e.g. 200, 201)
+- **Response shape** — returned JSON matches the OpenAPI response schema (required fields present, correct types)
+- **Path parameters** — validated the same way (e.g. `format: "uuid"`)
+
+### Field-level checklist
+- `format: "date-time"` → `z.string().datetime()` everywhere
 - `nullable: true` + not required → `.nullish()` in frontend, `.nullable().optional()` in mock server
 - `type: "integer"` → `.int()` everywhere
 - `minLength` / `maxLength` → `.min()` / `.max()` everywhere
+- `format: "uuid"` → IDs in mock data must be valid UUIDs
 - Required fields in OpenAPI → NOT `.optional()` in Zod
+- Fields NOT in an OpenAPI request body → NOT accepted by the mock server's Zod schema for that endpoint
 
 ## Debugging
 - Stop on test/build failures - do not proceed

--- a/api/mock-data.json
+++ b/api/mock-data.json
@@ -1,14 +1,14 @@
 {
   "plans": [
     {
-      "planId": "plan-1",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "title": "Weekend Camping Trip",
       "description": "Two-night stay at Pine Ridge Campground with friends.",
       "status": "active",
       "visibility": "public",
-      "ownerParticipantId": "participant-1",
+      "ownerParticipantId": "1e6f5d21-b8d2-4991-9a23-8803d8aa3428",
       "location": {
-        "locationId": "location-1",
+        "locationId": "09d5ac50-de2e-4e4a-b31c-896aa574d95b",
         "name": "Pine Ridge Campground",
         "timezone": "America/Los_Angeles",
         "latitude": 37.8651,
@@ -17,10 +17,14 @@
         "region": "CA",
         "city": "Yosemite"
       },
-      "startDate": "2025-07-18T00:00:00Z",
-      "endDate": "2025-07-20T00:00:00Z",
+      "startDate": "2025-07-18T00:00:00.000Z",
+      "endDate": "2025-07-20T00:00:00.000Z",
       "tags": ["outdoors", "family", "camping"],
-      "participantIds": ["participant-1", "participant-2", "participant-3"],
+      "participantIds": [
+        "1e6f5d21-b8d2-4991-9a23-8803d8aa3428",
+        "457393e1-822f-4c1c-a081-8207aa6b9fe1",
+        "399dcf24-f8c4-45f8-96fb-4478d578908f"
+      ],
       "createdAt": "2025-05-01T12:00:00.000Z",
       "updatedAt": "2025-05-10T08:30:00.000Z"
     },
@@ -35,11 +39,11 @@
         "locationId": "d06c8578-0a10-4b7d-bddb-f07e0e306cd6",
         "name": "Park ha-Yarkon",
         "country": "Israel",
-        "region": "",
+        "region": null,
         "city": "Ramat Gan"
       },
-      "startDate": "2025-12-15T12:38:00Z",
-      "endDate": "2025-12-15T15:38:00Z",
+      "startDate": "2025-12-15T12:38:00.000Z",
+      "endDate": "2025-12-15T15:38:00.000Z",
       "participantIds": [
         "3cdcb33e-eebd-5716-8164-7da2b8158993",
         "de0bf12f-97de-534c-9930-27ebd6e0f944"
@@ -57,12 +61,12 @@
       "location": {
         "locationId": "0743c27e-873a-4d2b-9779-006d21ffb3a1",
         "name": "sdsd",
-        "country": "",
-        "region": "",
-        "city": ""
+        "country": null,
+        "region": null,
+        "city": null
       },
-      "startDate": "2025-12-15T13:40:00Z",
-      "endDate": "2025-12-24T16:41:00Z",
+      "startDate": "2025-12-15T13:40:00.000Z",
+      "endDate": "2025-12-24T16:41:00.000Z",
       "participantIds": [
         "3cdcb33e-eebd-5716-8164-7da2b8158993",
         "de0bf12f-97de-534c-9930-27ebd6e0f944",
@@ -74,7 +78,7 @@
   ],
   "participants": [
     {
-      "participantId": "participant-1",
+      "participantId": "1e6f5d21-b8d2-4991-9a23-8803d8aa3428",
       "name": "Alex",
       "lastName": "Guberman",
       "displayName": "Alex G.",
@@ -85,7 +89,7 @@
       "updatedAt": "2025-05-10T08:00:00.000Z"
     },
     {
-      "participantId": "participant-2",
+      "participantId": "457393e1-822f-4c1c-a081-8207aa6b9fe1",
       "name": "Jamie",
       "lastName": "Rivera",
       "displayName": "Jamie",
@@ -96,7 +100,7 @@
       "updatedAt": "2025-05-10T08:00:00.000Z"
     },
     {
-      "participantId": "participant-3",
+      "participantId": "399dcf24-f8c4-45f8-96fb-4478d578908f",
       "name": "Taylor",
       "lastName": "Morgan",
       "displayName": "Taylor",
@@ -108,31 +112,32 @@
   ],
   "items": [
     {
-      "itemId": "item-1",
-      "planId": "plan-1",
+      "itemId": "a83dbd25-cfda-4cea-b53b-c8163ef94c77",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Family Tent",
-      "quantity": 1,
-      "unit": "set",
+      "quantity": 3,
+      "unit": "pcs",
       "notes": "Check stakes before departure",
       "status": "packed",
       "createdAt": "2025-05-02T10:00:00.000Z",
-      "updatedAt": "2025-05-10T08:15:00.000Z",
+      "updatedAt": "2026-02-11T11:20:27.470Z",
       "category": "equipment"
     },
     {
-      "itemId": "item-2",
-      "planId": "plan-1",
+      "itemId": "404954b1-04f3-4512-abae-42683bffad2b",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Trail Mix",
       "quantity": 5,
       "unit": "pack",
+      "notes": null,
       "status": "purchased",
       "createdAt": "2025-05-03T14:20:00.000Z",
       "updatedAt": "2025-05-09T18:45:00.000Z",
       "category": "food"
     },
     {
-      "itemId": "item-3",
-      "planId": "plan-1",
+      "itemId": "4741a1b6-33b8-46d7-864c-7e61c748ff12",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Sleeping Bags",
       "quantity": 4,
       "unit": "pcs",
@@ -143,8 +148,8 @@
       "category": "equipment"
     },
     {
-      "itemId": "item-4",
-      "planId": "plan-1",
+      "itemId": "ccab3332-cc4f-449b-aec6-4130855cb0bf",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Camp Stove",
       "quantity": 1,
       "unit": "pcs",
@@ -155,8 +160,8 @@
       "category": "equipment"
     },
     {
-      "itemId": "item-5",
-      "planId": "plan-1",
+      "itemId": "bfd3aa99-197f-4b40-8607-11a7bc59e8f8",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Propane Canisters",
       "quantity": 2,
       "unit": "pcs",
@@ -167,19 +172,20 @@
       "category": "equipment"
     },
     {
-      "itemId": "item-6",
-      "planId": "plan-1",
+      "itemId": "10ad45f4-4afb-40c3-b0e7-676e293fada1",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Lantern",
       "quantity": 2,
       "unit": "pcs",
+      "notes": null,
       "status": "packed",
       "createdAt": "2025-05-07T13:30:00.000Z",
       "updatedAt": "2025-05-10T07:20:00.000Z",
       "category": "equipment"
     },
     {
-      "itemId": "item-7",
-      "planId": "plan-1",
+      "itemId": "f38b7f87-e468-4d32-9c53-bd7cd2820283",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "S'mores Kit",
       "quantity": 3,
       "unit": "pack",
@@ -190,8 +196,8 @@
       "category": "food"
     },
     {
-      "itemId": "item-8",
-      "planId": "plan-1",
+      "itemId": "7c5393a6-3450-4615-ae03-0a62447fcdaf",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Breakfast Burritos",
       "quantity": 6,
       "unit": "pcs",
@@ -202,19 +208,20 @@
       "category": "food"
     },
     {
-      "itemId": "item-9",
-      "planId": "plan-1",
+      "itemId": "59ea2733-e7cf-4700-a3ef-189c44203d68",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Coffee Beans",
       "quantity": 1,
       "unit": "lb",
+      "notes": null,
       "status": "purchased",
       "createdAt": "2025-05-07T09:10:00.000Z",
       "updatedAt": "2025-05-09T18:45:00.000Z",
       "category": "food"
     },
     {
-      "itemId": "item-10",
-      "planId": "plan-1",
+      "itemId": "fbf1ccf5-4107-416b-bd67-12b4b4868557",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Water Jugs",
       "quantity": 4,
       "unit": "l",
@@ -226,15 +233,15 @@
     },
     {
       "itemId": "90c92f2b-17b9-4406-8492-6065a9e0f212",
-      "planId": "plan-1",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Tent",
       "quantity": 1,
       "unit": "pcs",
-      "status": "pending",
       "notes": null,
-      "category": "equipment",
+      "status": "purchased",
       "createdAt": "2026-02-09T20:18:35.623Z",
-      "updatedAt": "2026-02-09T20:18:35.623Z"
+      "updatedAt": "2026-02-11T11:20:35.532Z",
+      "category": "equipment"
     }
   ]
 }

--- a/src/core/api.generated.ts
+++ b/src/core/api.generated.ts
@@ -283,6 +283,333 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/plans/{planId}/participants': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * List all participants for a plan
+     * @description Retrieve all participants belonging to a specific plan
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          planId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-18'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    put?: never;
+    /**
+     * Add a participant to a plan
+     * @description Create a new participant in the specified plan
+     */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          planId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': components['schemas']['def-19'];
+        };
+      };
+      responses: {
+        /** @description Default Response */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-17'];
+          };
+        };
+        /** @description Default Response */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/participants/{participantId}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get participant by ID
+     * @description Retrieve a single participant by its ID
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          participantId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-17'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    /**
+     * Delete a participant
+     * @description Delete a participant by its ID. Items assigned to this participant will have their assignment cleared.
+     */
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          participantId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-22'];
+          };
+        };
+        /** @description Default Response */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    options?: never;
+    head?: never;
+    /**
+     * Update a participant
+     * @description Update an existing participant by its ID
+     */
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          participantId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': components['schemas']['def-20'];
+        };
+      };
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-17'];
+          };
+        };
+        /** @description Default Response */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    trace?: never;
+  };
   '/plans/{planId}/items': {
     parameters: {
       query?: never;
@@ -615,6 +942,8 @@ export interface components {
       /** @enum {string} */
       status: 'pending' | 'purchased' | 'packed' | 'canceled';
       notes?: string | null;
+      /** Format: uuid */
+      assignedParticipantId?: string | null;
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
@@ -633,6 +962,8 @@ export interface components {
       /** @enum {string} */
       status: 'pending' | 'purchased' | 'packed' | 'canceled';
       notes?: string | null;
+      /** Format: uuid */
+      assignedParticipantId?: string | null;
     };
     /** UpdateItemBody */
     'def-14': {
@@ -645,6 +976,8 @@ export interface components {
       /** @enum {string} */
       status?: 'pending' | 'purchased' | 'packed' | 'canceled';
       notes?: string | null;
+      /** Format: uuid */
+      assignedParticipantId?: string | null;
     };
     /** ItemIdParam */
     'def-15': {
@@ -674,6 +1007,58 @@ export interface components {
       /** Format: date-time */
       updatedAt: string;
       items: components['schemas']['def-12'];
+    };
+    /** Participant */
+    'def-17': {
+      /** Format: uuid */
+      participantId: string;
+      /** Format: uuid */
+      planId: string;
+      displayName: string;
+      name?: string | null;
+      lastName?: string | null;
+      /** @enum {string} */
+      role: 'owner' | 'participant' | 'viewer';
+      avatarUrl?: string | null;
+      contactEmail?: string | null;
+      contactPhone?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+    };
+    /** ParticipantList */
+    'def-18': components['schemas']['def-17'][];
+    /** CreateParticipantBody */
+    'def-19': {
+      displayName: string;
+      /** @enum {string} */
+      role?: 'owner' | 'participant' | 'viewer';
+      name?: string;
+      lastName?: string;
+      avatarUrl?: string;
+      contactEmail?: string;
+      contactPhone?: string;
+    };
+    /** UpdateParticipantBody */
+    'def-20': {
+      displayName?: string;
+      /** @enum {string} */
+      role?: 'owner' | 'participant' | 'viewer';
+      name?: string | null;
+      lastName?: string | null;
+      avatarUrl?: string | null;
+      contactEmail?: string | null;
+      contactPhone?: string | null;
+    };
+    /** ParticipantIdParam */
+    'def-21': {
+      /** Format: uuid */
+      participantId: string;
+    };
+    /** DeleteParticipantResponse */
+    'def-22': {
+      ok: boolean;
     };
   };
   responses: never;

--- a/src/core/openapi.json
+++ b/src/core/openapi.json
@@ -346,6 +346,11 @@
             "type": "string",
             "nullable": true
           },
+          "assignedParticipantId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -402,6 +407,11 @@
           "notes": {
             "type": "string",
             "nullable": true
+          },
+          "assignedParticipantId": {
+            "type": "string",
+            "format": "uuid",
+            "nullable": true
           }
         },
         "required": ["name", "category", "quantity", "status"],
@@ -433,6 +443,11 @@
           },
           "notes": {
             "type": "string",
+            "nullable": true
+          },
+          "assignedParticipantId": {
+            "type": "string",
+            "format": "uuid",
             "nullable": true
           }
         },
@@ -525,6 +540,165 @@
           "items"
         ],
         "title": "PlanWithItems"
+      },
+      "def-17": {
+        "type": "object",
+        "properties": {
+          "participantId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "planId": {
+            "type": "string",
+            "format": "uuid"
+          },
+          "displayName": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string",
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "nullable": true
+          },
+          "role": {
+            "type": "string",
+            "enum": ["owner", "participant", "viewer"]
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactEmail": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactPhone": {
+            "type": "string",
+            "nullable": true
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          }
+        },
+        "required": [
+          "participantId",
+          "planId",
+          "displayName",
+          "role",
+          "createdAt",
+          "updatedAt"
+        ],
+        "title": "Participant"
+      },
+      "def-18": {
+        "type": "array",
+        "items": {
+          "$ref": "#/components/schemas/def-17"
+        },
+        "title": "ParticipantList"
+      },
+      "def-19": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "role": {
+            "type": "string",
+            "enum": ["owner", "participant", "viewer"]
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "lastName": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "avatarUrl": {
+            "type": "string"
+          },
+          "contactEmail": {
+            "type": "string",
+            "maxLength": 255
+          },
+          "contactPhone": {
+            "type": "string",
+            "maxLength": 50
+          }
+        },
+        "required": ["displayName"],
+        "title": "CreateParticipantBody"
+      },
+      "def-20": {
+        "type": "object",
+        "properties": {
+          "displayName": {
+            "type": "string",
+            "minLength": 1,
+            "maxLength": 255
+          },
+          "role": {
+            "type": "string",
+            "enum": ["owner", "participant", "viewer"]
+          },
+          "name": {
+            "type": "string",
+            "maxLength": 255,
+            "nullable": true
+          },
+          "lastName": {
+            "type": "string",
+            "maxLength": 255,
+            "nullable": true
+          },
+          "avatarUrl": {
+            "type": "string",
+            "nullable": true
+          },
+          "contactEmail": {
+            "type": "string",
+            "maxLength": 255,
+            "nullable": true
+          },
+          "contactPhone": {
+            "type": "string",
+            "maxLength": 50,
+            "nullable": true
+          }
+        },
+        "title": "UpdateParticipantBody"
+      },
+      "def-21": {
+        "type": "object",
+        "properties": {
+          "participantId": {
+            "type": "string",
+            "format": "uuid"
+          }
+        },
+        "required": ["participantId"],
+        "title": "ParticipantIdParam"
+      },
+      "def-22": {
+        "type": "object",
+        "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": ["ok"],
+        "title": "DeleteParticipantResponse"
       }
     }
   },
@@ -734,6 +908,348 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/def-10"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/plans/{planId}/participants": {
+      "get": {
+        "summary": "List all participants for a plan",
+        "tags": ["participants"],
+        "description": "Retrieve all participants belonging to a specific plan",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-18"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "post": {
+        "summary": "Add a participant to a plan",
+        "tags": ["participants"],
+        "description": "Create a new participant in the specified plan",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/def-19"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "planId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "201": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-17"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/participants/{participantId}": {
+      "get": {
+        "summary": "Get participant by ID",
+        "tags": ["participants"],
+        "description": "Retrieve a single participant by its ID",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "participantId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-17"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "patch": {
+        "summary": "Update a participant",
+        "tags": ["participants"],
+        "description": "Update an existing participant by its ID",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/def-20"
+              }
+            }
+          }
+        },
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "participantId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-17"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete a participant",
+        "tags": ["participants"],
+        "description": "Delete a participant by its ID. Items assigned to this participant will have their assignment cleared.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "participantId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-22"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
                 }
               }
             }

--- a/src/test/unit/api/server.test.ts
+++ b/src/test/unit/api/server.test.ts
@@ -11,6 +11,7 @@ function createTestData(): MockData {
         planId: 'plan-1',
         title: 'Test Plan',
         status: 'draft',
+        visibility: 'private',
         ownerParticipantId: 'participant-1',
         participantIds: ['participant-1'],
         createdAt: now,
@@ -50,6 +51,7 @@ describe('mock server', () => {
     const server = await buildServer({
       initialData: createTestData(),
       persist: false,
+      logger: false,
     });
     try {
       const response = await server.inject({ method: 'GET', url: '/plans' });
@@ -67,6 +69,7 @@ describe('mock server', () => {
     const server = await buildServer({
       initialData: createTestData(),
       persist: false,
+      logger: false,
     });
     try {
       const response = await server.inject({
@@ -74,18 +77,14 @@ describe('mock server', () => {
         url: '/plans',
         payload: {
           title: 'Summer Trip',
-          ownerParticipantId: 'participant-1',
-          status: 'active',
         },
       });
 
       expect(response.statusCode).toBe(201);
       const payload = response.json() as Record<string, unknown>;
       expect(payload.planId).toEqual(expect.any(String));
-      expect(payload.status).toBe('active');
-      expect(payload.participantIds).toEqual(
-        expect.arrayContaining(['participant-1'])
-      );
+      expect(payload.status).toBe('draft');
+      expect(payload.visibility).toBe('private');
     } finally {
       await server.close();
     }
@@ -95,6 +94,7 @@ describe('mock server', () => {
     const server = await buildServer({
       initialData: createTestData(),
       persist: false,
+      logger: false,
     });
     try {
       const response = await server.inject({
@@ -120,6 +120,7 @@ describe('mock server', () => {
     const server = await buildServer({
       initialData: createTestData(),
       persist: false,
+      logger: false,
     });
     try {
       const response = await server.inject({
@@ -153,6 +154,7 @@ describe('mock server', () => {
     const server = await buildServer({
       initialData: createTestData(),
       persist: false,
+      logger: false,
     });
     try {
       const response = await server.inject({
@@ -161,6 +163,8 @@ describe('mock server', () => {
         payload: {
           name: 'Lantern',
           category: 'equipment',
+          quantity: 2,
+          status: 'pending',
         },
       });
 
@@ -168,6 +172,7 @@ describe('mock server', () => {
       const payload = response.json() as Record<string, unknown>;
       expect(payload.itemId).toEqual(expect.any(String));
       expect(payload.planId).toBe('plan-1');
+      expect(payload.quantity).toBe(2);
       expect(payload.status).toBe('pending');
     } finally {
       await server.close();
@@ -178,6 +183,7 @@ describe('mock server', () => {
     const server = await buildServer({
       initialData: createTestData(),
       persist: false,
+      logger: false,
     });
     try {
       const response = await server.inject({


### PR DESCRIPTION
## Summary
- Align mock server (`api/server.ts`) endpoints, validation schemas, and response shapes with the real OpenAPI contract (`src/core/openapi.json`)
- Add `GET /health` endpoint, fix `DELETE /plans` to return `200 { ok: true }`, enforce correct required/optional fields on create/update bodies, fix CORS to allow PATCH
- Replace non-UUID mock data IDs with valid UUIDs, fix nullable fields using `null` instead of empty strings, normalize date formats
- Add compact color-coded request logging to mock server (hides OPTIONS preflight, shows request body on mutations, logs errors inline)
- Expand workflow rule with detailed mock server alignment checklist for future OpenAPI changes
- Update OpenAPI spec and auto-generated types

## Test plan
- [x] All 131 unit tests pass
- [x] TypeScript type check passes
- [x] ESLint passes
- [x] Production build succeeds
- [x] Pre-commit hooks pass (typecheck, lint-staged, tests)

Made with [Cursor](https://cursor.com)