### PR TITLE
add item status filter and align schemas with OpenAPI spec (#41)

### DIFF
--- a/api/mock.ts
+++ b/api/mock.ts
@@ -58,6 +58,7 @@ const equipmentItemSchema = z.object({
   unit: z.enum(['pcs', 'kg', 'g', 'lb', 'oz', 'l', 'ml', 'pack', 'set']),
   notes: z.string().nullish(),
   status: z.enum(['pending', 'purchased', 'packed', 'canceled']),
+  assignedParticipantId: z.string().nullish(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
   category: z.literal('equipment'),

--- a/api/server.ts
+++ b/api/server.ts
@@ -98,6 +98,7 @@ const itemCreateSchema = z.object({
   unit: unitSchema.optional(),
   status: itemStatusSchema,
   notes: z.string().nullable().optional(),
+  assignedParticipantId: z.string().nullable().optional(),
 });
 
 const itemPatchSchema = itemCreateSchema.partial();
@@ -504,6 +505,7 @@ export async function buildServer(
         unit: parsed.unit ?? 'pcs',
         status: parsed.status,
         notes: parsed.notes,
+        assignedParticipantId: parsed.assignedParticipantId,
         createdAt: now,
         updatedAt: now,
       };
@@ -553,7 +555,7 @@ export async function buildServer(
 
       await persistData(store, shouldPersist, filePath);
 
-      void reply.status(204).send();
+      void reply.send({ ok: true });
     }
   );
 

--- a/src/components/StatusFilter.tsx
+++ b/src/components/StatusFilter.tsx
@@ -1,0 +1,92 @@
+import clsx from 'clsx';
+import type { ItemStatus } from '../core/schemas/item';
+
+const STATUS_OPTIONS: {
+  value: ItemStatus | null;
+  label: string;
+  activeBg: string;
+  activeText: string;
+}[] = [
+  {
+    value: null,
+    label: 'All',
+    activeBg: 'bg-gray-800',
+    activeText: 'text-white',
+  },
+  {
+    value: 'pending',
+    label: 'Pending',
+    activeBg: 'bg-yellow-100',
+    activeText: 'text-yellow-800',
+  },
+  {
+    value: 'purchased',
+    label: 'Purchased',
+    activeBg: 'bg-blue-100',
+    activeText: 'text-blue-800',
+  },
+  {
+    value: 'packed',
+    label: 'Packed',
+    activeBg: 'bg-green-100',
+    activeText: 'text-green-800',
+  },
+  {
+    value: 'canceled',
+    label: 'Canceled',
+    activeBg: 'bg-gray-200',
+    activeText: 'text-gray-600',
+  },
+];
+
+interface StatusFilterProps {
+  selected: ItemStatus | null;
+  onChange: (status: ItemStatus | null) => void;
+  counts: Record<ItemStatus, number>;
+  total: number;
+}
+
+export default function StatusFilter({
+  selected,
+  onChange,
+  counts,
+  total,
+}: StatusFilterProps) {
+  return (
+    <div
+      className="flex flex-wrap gap-2"
+      role="group"
+      aria-label="Filter by status"
+    >
+      {STATUS_OPTIONS.map((option) => {
+        const isActive = selected === option.value;
+        const count = option.value === null ? total : counts[option.value];
+
+        return (
+          <button
+            key={option.value ?? 'all'}
+            type="button"
+            onClick={() => onChange(option.value)}
+            className={clsx(
+              'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors cursor-pointer',
+              isActive
+                ? [option.activeBg, option.activeText]
+                : 'bg-white text-gray-600 border border-gray-300 hover:bg-gray-50 active:bg-gray-100'
+            )}
+            aria-pressed={isActive}
+          >
+            {option.label}
+            <span
+              className={clsx(
+                'text-xs tabular-nums',
+                isActive ? 'opacity-75' : 'text-gray-400'
+              )}
+            >
+              {count}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/core/api.generated.ts
+++ b/src/core/api.generated.ts
@@ -182,7 +182,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-16'];
+            'application/json': components['schemas']['def-17'];
           };
         };
         /** @description Default Response */
@@ -311,7 +311,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-18'];
+            'application/json': components['schemas']['def-19'];
           };
         };
         /** @description Default Response */
@@ -359,7 +359,7 @@ export interface paths {
       };
       requestBody?: {
         content: {
-          'application/json': components['schemas']['def-19'];
+          'application/json': components['schemas']['def-20'];
         };
       };
       responses: {
@@ -369,7 +369,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-17'];
+            'application/json': components['schemas']['def-18'];
           };
         };
         /** @description Default Response */
@@ -444,7 +444,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-17'];
+            'application/json': components['schemas']['def-18'];
           };
         };
         /** @description Default Response */
@@ -499,7 +499,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-22'];
+            'application/json': components['schemas']['def-23'];
           };
         };
         /** @description Default Response */
@@ -557,7 +557,7 @@ export interface paths {
       };
       requestBody?: {
         content: {
-          'application/json': components['schemas']['def-20'];
+          'application/json': components['schemas']['def-21'];
         };
       };
       responses: {
@@ -567,7 +567,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-17'];
+            'application/json': components['schemas']['def-18'];
           };
         };
         /** @description Default Response */
@@ -753,7 +753,59 @@ export interface paths {
     get?: never;
     put?: never;
     post?: never;
-    delete?: never;
+    /**
+     * Delete an item
+     * @description Delete an item by its ID. Cascade delete handles related assignments.
+     */
+    delete: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          itemId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-16'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
     options?: never;
     head?: never;
     /**
@@ -984,8 +1036,12 @@ export interface components {
       /** Format: uuid */
       itemId: string;
     };
-    /** PlanWithItems */
+    /** DeleteItemResponse */
     'def-16': {
+      ok: boolean;
+    };
+    /** PlanWithItems */
+    'def-17': {
       /** Format: uuid */
       planId: string;
       title: string;
@@ -1009,7 +1065,7 @@ export interface components {
       items: components['schemas']['def-12'];
     };
     /** Participant */
-    'def-17': {
+    'def-18': {
       /** Format: uuid */
       participantId: string;
       /** Format: uuid */
@@ -1028,9 +1084,9 @@ export interface components {
       updatedAt: string;
     };
     /** ParticipantList */
-    'def-18': components['schemas']['def-17'][];
+    'def-19': components['schemas']['def-18'][];
     /** CreateParticipantBody */
-    'def-19': {
+    'def-20': {
       displayName: string;
       /** @enum {string} */
       role?: 'owner' | 'participant' | 'viewer';
@@ -1041,7 +1097,7 @@ export interface components {
       contactPhone?: string;
     };
     /** UpdateParticipantBody */
-    'def-20': {
+    'def-21': {
       displayName?: string;
       /** @enum {string} */
       role?: 'owner' | 'participant' | 'viewer';
@@ -1052,12 +1108,12 @@ export interface components {
       contactPhone?: string | null;
     };
     /** ParticipantIdParam */
-    'def-21': {
+    'def-22': {
       /** Format: uuid */
       participantId: string;
     };
     /** DeleteParticipantResponse */
-    'def-22': {
+    'def-23': {
       ok: boolean;
     };
   };

--- a/src/core/openapi.json
+++ b/src/core/openapi.json
@@ -467,6 +467,16 @@
       "def-16": {
         "type": "object",
         "properties": {
+          "ok": {
+            "type": "boolean"
+          }
+        },
+        "required": ["ok"],
+        "title": "DeleteItemResponse"
+      },
+      "def-17": {
+        "type": "object",
+        "properties": {
           "planId": {
             "type": "string",
             "format": "uuid"
@@ -541,7 +551,7 @@
         ],
         "title": "PlanWithItems"
       },
-      "def-17": {
+      "def-18": {
         "type": "object",
         "properties": {
           "participantId": {
@@ -598,14 +608,14 @@
         ],
         "title": "Participant"
       },
-      "def-18": {
+      "def-19": {
         "type": "array",
         "items": {
-          "$ref": "#/components/schemas/def-17"
+          "$ref": "#/components/schemas/def-18"
         },
         "title": "ParticipantList"
       },
-      "def-19": {
+      "def-20": {
         "type": "object",
         "properties": {
           "displayName": {
@@ -640,7 +650,7 @@
         "required": ["displayName"],
         "title": "CreateParticipantBody"
       },
-      "def-20": {
+      "def-21": {
         "type": "object",
         "properties": {
           "displayName": {
@@ -679,7 +689,7 @@
         },
         "title": "UpdateParticipantBody"
       },
-      "def-21": {
+      "def-22": {
         "type": "object",
         "properties": {
           "participantId": {
@@ -690,7 +700,7 @@
         "required": ["participantId"],
         "title": "ParticipantIdParam"
       },
-      "def-22": {
+      "def-23": {
         "type": "object",
         "properties": {
           "ok": {
@@ -839,7 +849,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-16"
+                  "$ref": "#/components/schemas/def-17"
                 }
               }
             }
@@ -967,7 +977,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-18"
+                  "$ref": "#/components/schemas/def-19"
                 }
               }
             }
@@ -1012,7 +1022,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-19"
+                "$ref": "#/components/schemas/def-20"
               }
             }
           }
@@ -1034,7 +1044,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-17"
+                  "$ref": "#/components/schemas/def-18"
                 }
               }
             }
@@ -1104,7 +1114,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-17"
+                  "$ref": "#/components/schemas/def-18"
                 }
               }
             }
@@ -1149,7 +1159,7 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/def-20"
+                "$ref": "#/components/schemas/def-21"
               }
             }
           }
@@ -1171,7 +1181,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-17"
+                  "$ref": "#/components/schemas/def-18"
                 }
               }
             }
@@ -1239,7 +1249,7 @@
             "content": {
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/def-22"
+                  "$ref": "#/components/schemas/def-23"
                 }
               }
             }
@@ -1466,6 +1476,64 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-0"
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "summary": "Delete an item",
+        "tags": ["items"],
+        "description": "Delete an item by its ID. Cascade delete handles related assignments.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "string",
+              "format": "uuid"
+            },
+            "in": "path",
+            "name": "itemId",
+            "required": true
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/def-16"
                 }
               }
             }

--- a/src/core/schemas/item.ts
+++ b/src/core/schemas/item.ts
@@ -27,6 +27,7 @@ const baseItemSchema = z.object({
   unit: unitSchema,
   notes: z.string().nullish(),
   status: itemStatusSchema,
+  assignedParticipantId: z.string().nullish(),
   createdAt: z.string().datetime(),
   updatedAt: z.string().datetime(),
 });
@@ -51,6 +52,7 @@ export const itemCreateSchema = z.object({
   unit: unitSchema.optional(),
   status: itemStatusSchema,
   notes: z.string().nullish(),
+  assignedParticipantId: z.string().nullish(),
 });
 
 export const itemPatchSchema = itemCreateSchema.partial();

--- a/src/test/unit/core/api.test.ts
+++ b/src/test/unit/core/api.test.ts
@@ -375,7 +375,7 @@ describe('API Client', () => {
     });
 
     it('deletes an item', async () => {
-      fetchMock.mockResolvedValueOnce(mockResponse({}, { status: 204 }));
+      fetchMock.mockResolvedValueOnce(mockResponse({ ok: true }));
 
       await deleteItem('item-1');
       expect(fetchMock).toHaveBeenCalledWith(


### PR DESCRIPTION
## Summary
- Add toggle buttons to filter plan items by status (All, Pending, Purchased, Packed, Canceled) with count badges
- Align all schema layers with updated OpenAPI spec: add `assignedParticipantId` field to item schemas, add DELETE item endpoint, fix mock server delete item response to return 200 with `{ ok: true }` per spec

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] All 131 tests pass
- [x] Pre-commit hooks pass (typecheck, lint-staged, tests)

Closes #41

Made with [Cursor](https://cursor.com)