### PR TITLE
Allow inline editing of status, unit, and quantity on item cards

### DIFF
--- a/src/components/CategorySection.tsx
+++ b/src/components/CategorySection.tsx
@@ -3,7 +3,7 @@ import {
   DisclosureButton,
   DisclosurePanel,
 } from '@headlessui/react';
-import type { Item, ItemCategory } from '../core/schemas/item';
+import type { Item, ItemCategory, ItemPatch } from '../core/schemas/item';
 import ItemCard from './ItemCard';
 
 const CATEGORY_LABELS: Record<ItemCategory, string> = {
@@ -15,12 +15,14 @@ interface CategorySectionProps {
   category: ItemCategory;
   items: Item[];
   onEditItem?: (itemId: string) => void;
+  onUpdateItem?: (itemId: string, updates: ItemPatch) => void;
 }
 
 export default function CategorySection({
   category,
   items,
   onEditItem,
+  onUpdateItem,
 }: CategorySectionProps) {
   const label = CATEGORY_LABELS[category];
 
@@ -65,6 +67,11 @@ export default function CategorySection({
                 key={item.itemId}
                 item={item}
                 onEdit={onEditItem ? () => onEditItem(item.itemId) : undefined}
+                onUpdate={
+                  onUpdateItem
+                    ? (updates) => onUpdateItem(item.itemId, updates)
+                    : undefined
+                }
               />
             ))}
           </div>

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -1,28 +1,19 @@
 import clsx from 'clsx';
-import type { Item } from '../core/schemas/item';
-
-const STATUS_CONFIG: Record<
-  Item['status'],
-  { label: string; bg: string; text: string }
-> = {
-  pending: { label: 'Pending', bg: 'bg-yellow-100', text: 'text-yellow-800' },
-  purchased: {
-    label: 'Purchased',
-    bg: 'bg-blue-100',
-    text: 'text-blue-800',
-  },
-  packed: { label: 'Packed', bg: 'bg-green-100', text: 'text-green-800' },
-  canceled: { label: 'Canceled', bg: 'bg-gray-100', text: 'text-gray-500' },
-};
+import type { Item, ItemPatch } from '../core/schemas/item';
+import { STATUS_OPTIONS, UNIT_OPTIONS } from '../core/constants/item';
+import InlineSelect from './shared/InlineSelect';
+import InlineQuantityInput from './shared/InlineQuantityInput';
 
 interface ItemCardProps {
   item: Item;
   onEdit?: () => void;
+  onUpdate?: (updates: ItemPatch) => void;
 }
 
-export default function ItemCard({ item, onEdit }: ItemCardProps) {
-  const status = STATUS_CONFIG[item.status];
+export default function ItemCard({ item, onEdit, onUpdate }: ItemCardProps) {
+  const statusOption = STATUS_OPTIONS.find((s) => s.value === item.status);
   const isCanceled = item.status === 'canceled';
+  const isEquipment = item.category === 'equipment';
 
   return (
     <div className="px-3 sm:px-5 py-3 sm:py-4">
@@ -38,14 +29,39 @@ export default function ItemCard({ item, onEdit }: ItemCardProps) {
           </span>
 
           <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
-            <span
-              className={clsx(
-                'text-xs sm:text-sm',
-                isCanceled ? 'text-gray-400' : 'text-gray-600'
-              )}
-            >
-              {item.quantity} {item.unit}
-            </span>
+            {onUpdate ? (
+              <span className="inline-flex items-center gap-x-1">
+                <InlineQuantityInput
+                  value={item.quantity}
+                  onChange={(quantity) => onUpdate({ quantity })}
+                  className={clsx(
+                    'text-xs sm:text-sm',
+                    isCanceled ? 'text-gray-400' : 'text-gray-600'
+                  )}
+                />
+                <InlineSelect
+                  value={item.unit}
+                  onChange={(unit) => onUpdate({ unit })}
+                  options={UNIT_OPTIONS}
+                  disabled={isEquipment}
+                  buttonClassName={clsx(
+                    'text-xs sm:text-sm',
+                    isCanceled ? 'text-gray-400' : 'text-gray-600',
+                    !isEquipment && 'hover:bg-gray-100 px-1'
+                  )}
+                  ariaLabel={`Change unit for ${item.name}`}
+                />
+              </span>
+            ) : (
+              <span
+                className={clsx(
+                  'text-xs sm:text-sm',
+                  isCanceled ? 'text-gray-400' : 'text-gray-600'
+                )}
+              >
+                {item.quantity} {item.unit}
+              </span>
+            )}
             {item.notes && (
               <span className="text-xs sm:text-sm text-gray-400 truncate max-w-[200px] sm:max-w-xs">
                 {item.notes}
@@ -79,15 +95,29 @@ export default function ItemCard({ item, onEdit }: ItemCardProps) {
           </button>
         )}
 
-        <span
-          className={clsx(
-            'shrink-0 inline-flex items-center px-2 sm:px-2.5 py-0.5 rounded-full text-xs font-medium',
-            status.bg,
-            status.text
-          )}
-        >
-          {status.label}
-        </span>
+        {onUpdate ? (
+          <InlineSelect
+            value={item.status}
+            onChange={(status) => onUpdate({ status })}
+            options={STATUS_OPTIONS}
+            buttonClassName={clsx(
+              'shrink-0 inline-flex items-center px-2 sm:px-2.5 py-0.5 rounded-full text-xs font-medium hover:opacity-80',
+              statusOption?.bg,
+              statusOption?.text
+            )}
+            ariaLabel={`Change status for ${item.name}`}
+          />
+        ) : (
+          <span
+            className={clsx(
+              'shrink-0 inline-flex items-center px-2 sm:px-2.5 py-0.5 rounded-full text-xs font-medium',
+              statusOption?.bg,
+              statusOption?.text
+            )}
+          >
+            {statusOption?.label ?? item.status}
+          </span>
+        )}
       </div>
     </div>
   );

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -10,6 +10,11 @@ import {
   type ItemCategory,
   type Unit,
 } from '../core/schemas/item';
+import {
+  CATEGORY_OPTIONS,
+  STATUS_OPTIONS,
+  UNIT_OPTIONS,
+} from '../core/constants/item';
 import { FormLabel } from './shared/FormLabel';
 import { FormInput, FormTextarea, FormSelect } from './shared/FormInput';
 import Autocomplete from './shared/Autocomplete';
@@ -37,36 +42,6 @@ const ITEM_FORM_DEFAULTS: ItemFormValues = {
   status: 'pending',
   notes: '',
 };
-
-const CATEGORY_OPTIONS: {
-  value: z.infer<typeof itemCategorySchema>;
-  label: string;
-}[] = [
-  { value: 'food', label: 'Food' },
-  { value: 'equipment', label: 'Equipment' },
-];
-
-const STATUS_OPTIONS: {
-  value: z.infer<typeof itemStatusSchema>;
-  label: string;
-}[] = [
-  { value: 'pending', label: 'Pending' },
-  { value: 'purchased', label: 'Purchased' },
-  { value: 'packed', label: 'Packed' },
-  { value: 'canceled', label: 'Canceled' },
-];
-
-const UNIT_OPTIONS: { value: z.infer<typeof unitSchema>; label: string }[] = [
-  { value: 'kg', label: 'kg' },
-  { value: 'g', label: 'g' },
-  { value: 'lb', label: 'lb' },
-  { value: 'oz', label: 'oz' },
-  { value: 'l', label: 'l' },
-  { value: 'ml', label: 'ml' },
-  { value: 'pcs', label: 'pcs' },
-  { value: 'pack', label: 'pack' },
-  { value: 'set', label: 'set' },
-];
 
 interface ItemFormProps {
   defaultValues?: Partial<ItemFormValues>;

--- a/src/components/shared/InlineQuantityInput.tsx
+++ b/src/components/shared/InlineQuantityInput.tsx
@@ -1,0 +1,87 @@
+import { useEffect, useRef, useState } from 'react';
+import clsx from 'clsx';
+
+interface InlineQuantityInputProps {
+  value: number;
+  onChange: (value: number) => void;
+  min?: number;
+  disabled?: boolean;
+  className?: string;
+}
+
+export default function InlineQuantityInput({
+  value,
+  onChange,
+  min = 1,
+  disabled,
+  className,
+}: InlineQuantityInputProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState(String(value));
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (editing) {
+      inputRef.current?.select();
+    }
+  }, [editing]);
+
+  function startEditing() {
+    if (disabled) return;
+    setDraft(String(value));
+    setEditing(true);
+  }
+
+  function commit() {
+    setEditing(false);
+    const parsed = parseInt(draft, 10);
+    if (!Number.isNaN(parsed) && parsed >= min && parsed !== value) {
+      onChange(parsed);
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
+    }
+    if (e.key === 'Escape') {
+      setEditing(false);
+    }
+  }
+
+  if (editing) {
+    return (
+      <input
+        ref={inputRef}
+        type="number"
+        value={draft}
+        onChange={(e) => setDraft(e.target.value)}
+        onBlur={commit}
+        onKeyDown={handleKeyDown}
+        min={min}
+        step={1}
+        autoFocus
+        className={clsx(
+          'w-12 px-1 py-0 text-xs sm:text-sm border border-gray-300 rounded focus:ring-2 focus:ring-blue-500 focus:border-transparent text-center',
+          className
+        )}
+      />
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={startEditing}
+      disabled={disabled}
+      className={clsx(
+        'cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded hover:bg-gray-100 px-1',
+        disabled && 'cursor-default',
+        className
+      )}
+    >
+      {value}
+    </button>
+  );
+}

--- a/src/components/shared/InlineSelect.tsx
+++ b/src/components/shared/InlineSelect.tsx
@@ -1,0 +1,62 @@
+import {
+  Listbox,
+  ListboxButton,
+  ListboxOption,
+  ListboxOptions,
+} from '@headlessui/react';
+import clsx from 'clsx';
+
+interface InlineSelectOption<T extends string> {
+  value: T;
+  label: string;
+}
+
+interface InlineSelectProps<T extends string> {
+  value: T;
+  onChange: (value: T) => void;
+  options: InlineSelectOption<T>[];
+  disabled?: boolean;
+  buttonClassName?: string;
+  ariaLabel?: string;
+}
+
+export default function InlineSelect<T extends string>({
+  value,
+  onChange,
+  options,
+  disabled,
+  buttonClassName,
+  ariaLabel,
+}: InlineSelectProps<T>) {
+  const selectedOption = options.find((opt) => opt.value === value);
+
+  return (
+    <Listbox value={value} onChange={onChange} disabled={disabled}>
+      <ListboxButton
+        className={clsx(
+          'cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded',
+          disabled && 'cursor-default opacity-60',
+          buttonClassName
+        )}
+        aria-label={ariaLabel}
+      >
+        {selectedOption?.label ?? value}
+      </ListboxButton>
+      <ListboxOptions
+        anchor="bottom start"
+        transition
+        className="z-10 mt-1 min-w-32 rounded-lg bg-white shadow-lg ring-1 ring-black/5 focus:outline-none origin-top transition duration-150 ease-out data-closed:scale-95 data-closed:opacity-0"
+      >
+        {options.map((opt) => (
+          <ListboxOption
+            key={opt.value}
+            value={opt.value}
+            className="cursor-pointer select-none px-3 py-2 text-sm transition-colors data-focus:bg-gray-100 data-selected:font-semibold"
+          >
+            {opt.label}
+          </ListboxOption>
+        ))}
+      </ListboxOptions>
+    </Listbox>
+  );
+}

--- a/src/core/constants/item.ts
+++ b/src/core/constants/item.ts
@@ -1,0 +1,50 @@
+import type { ItemCategory, ItemStatus, Unit } from '../schemas/item';
+
+export const CATEGORY_OPTIONS: { value: ItemCategory; label: string }[] = [
+  { value: 'food', label: 'Food' },
+  { value: 'equipment', label: 'Equipment' },
+];
+
+export const STATUS_OPTIONS: {
+  value: ItemStatus;
+  label: string;
+  bg: string;
+  text: string;
+}[] = [
+  {
+    value: 'pending',
+    label: 'Pending',
+    bg: 'bg-yellow-100',
+    text: 'text-yellow-800',
+  },
+  {
+    value: 'purchased',
+    label: 'Purchased',
+    bg: 'bg-blue-100',
+    text: 'text-blue-800',
+  },
+  {
+    value: 'packed',
+    label: 'Packed',
+    bg: 'bg-green-100',
+    text: 'text-green-800',
+  },
+  {
+    value: 'canceled',
+    label: 'Canceled',
+    bg: 'bg-gray-100',
+    text: 'text-gray-500',
+  },
+];
+
+export const UNIT_OPTIONS: { value: Unit; label: string }[] = [
+  { value: 'kg', label: 'kg' },
+  { value: 'g', label: 'g' },
+  { value: 'lb', label: 'lb' },
+  { value: 'oz', label: 'oz' },
+  { value: 'l', label: 'l' },
+  { value: 'ml', label: 'ml' },
+  { value: 'pcs', label: 'pcs' },
+  { value: 'pack', label: 'pack' },
+  { value: 'set', label: 'set' },
+];

--- a/src/routes/plan.$planId.lazy.tsx
+++ b/src/routes/plan.$planId.lazy.tsx
@@ -67,28 +67,28 @@ function PlanDetails() {
     setShowItemForm(true);
   }
 
-  async function handleUpdateItem(values: ItemFormValues) {
-    if (!editingItemId) return;
-    const payload: ItemPatch = {
-      name: values.name,
-      category: values.category,
-      quantity: values.quantity,
-      unit: values.unit,
-      status: values.status,
-      notes: values.notes || null,
-    };
+  async function updateItem(itemId: string, updates: ItemPatch) {
     try {
-      await updateItemMutation.mutateAsync({
-        itemId: editingItemId,
-        updates: payload,
-      });
-      setEditingItemId(null);
+      await updateItemMutation.mutateAsync({ itemId, updates });
     } catch (err) {
       const { title, message } = getApiErrorMessage(
         err instanceof Error ? err : new Error(String(err))
       );
       toast.error(`${title}: ${message}`);
     }
+  }
+
+  async function handleFormSubmit(values: ItemFormValues) {
+    if (!editingItemId) return;
+    await updateItem(editingItemId, {
+      name: values.name,
+      category: values.category,
+      quantity: values.quantity,
+      unit: values.unit,
+      status: values.status,
+      notes: values.notes || null,
+    });
+    setEditingItemId(null);
   }
 
   const editingItem = editingItemId
@@ -168,6 +168,7 @@ function PlanDetails() {
                   category={category}
                   items={items}
                   onEditItem={handleStartEdit}
+                  onUpdateItem={updateItem}
                 />
               ))}
             </div>
@@ -184,7 +185,7 @@ function PlanDetails() {
                 status: editingItem.status,
                 notes: editingItem.notes ?? '',
               }}
-              onSubmit={handleUpdateItem}
+              onSubmit={handleFormSubmit}
               onCancel={() => setEditingItemId(null)}
               isSubmitting={updateItemMutation.isPending}
               submitLabel="Update Item"

--- a/src/test/unit/components/shared/InlineQuantityInput.test.tsx
+++ b/src/test/unit/components/shared/InlineQuantityInput.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InlineQuantityInput from '../../../../components/shared/InlineQuantityInput';
+
+describe('InlineQuantityInput', () => {
+  it('renders the value as a button in display mode', () => {
+    render(<InlineQuantityInput value={5} onChange={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: '5' })).toBeInTheDocument();
+  });
+
+  it('enters edit mode on click and shows an input', async () => {
+    const user = userEvent.setup();
+    render(<InlineQuantityInput value={3} onChange={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: '3' }));
+
+    expect(screen.getByRole('spinbutton')).toBeInTheDocument();
+  });
+
+  it('calls onChange with new value on blur', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<InlineQuantityInput value={2} onChange={handleChange} />);
+
+    await user.click(screen.getByRole('button', { name: '2' }));
+
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '7');
+    await user.tab();
+
+    expect(handleChange).toHaveBeenCalledWith(7);
+  });
+
+  it('calls onChange on Enter key', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<InlineQuantityInput value={1} onChange={handleChange} />);
+
+    await user.click(screen.getByRole('button', { name: '1' }));
+
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '10');
+    await user.keyboard('{Enter}');
+
+    expect(handleChange).toHaveBeenCalledWith(10);
+  });
+
+  it('reverts on Escape without calling onChange', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<InlineQuantityInput value={4} onChange={handleChange} />);
+
+    await user.click(screen.getByRole('button', { name: '4' }));
+    await user.keyboard('{Escape}');
+
+    expect(handleChange).not.toHaveBeenCalled();
+    expect(screen.getByRole('button', { name: '4' })).toBeInTheDocument();
+  });
+
+  it('does not call onChange when value is unchanged', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<InlineQuantityInput value={5} onChange={handleChange} />);
+
+    await user.click(screen.getByRole('button', { name: '5' }));
+    await user.tab();
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('does not call onChange when value is below min', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(<InlineQuantityInput value={2} onChange={handleChange} min={1} />);
+
+    await user.click(screen.getByRole('button', { name: '2' }));
+
+    const input = screen.getByRole('spinbutton');
+    await user.clear(input);
+    await user.type(input, '0');
+    await user.tab();
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it('does not enter edit mode when disabled', async () => {
+    const user = userEvent.setup();
+    render(<InlineQuantityInput value={3} onChange={vi.fn()} disabled />);
+
+    await user.click(screen.getByRole('button', { name: '3' }));
+
+    expect(screen.queryByRole('spinbutton')).not.toBeInTheDocument();
+  });
+});

--- a/src/test/unit/components/shared/InlineSelect.test.tsx
+++ b/src/test/unit/components/shared/InlineSelect.test.tsx
@@ -1,0 +1,78 @@
+import { beforeAll, describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import InlineSelect from '../../../../components/shared/InlineSelect';
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
+
+const OPTIONS = [
+  { value: 'a', label: 'Alpha' },
+  { value: 'b', label: 'Bravo' },
+  { value: 'c', label: 'Charlie' },
+];
+
+describe('InlineSelect', () => {
+  it('renders the selected option label as the button text', () => {
+    render(<InlineSelect value="b" onChange={vi.fn()} options={OPTIONS} />);
+
+    expect(screen.getByRole('button', { name: /bravo/i })).toBeInTheDocument();
+  });
+
+  it('opens dropdown and shows all options on click', async () => {
+    const user = userEvent.setup();
+    render(<InlineSelect value="a" onChange={vi.fn()} options={OPTIONS} />);
+
+    await user.click(screen.getByRole('button', { name: /alpha/i }));
+
+    expect(screen.getByRole('option', { name: /alpha/i })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: /bravo/i })).toBeInTheDocument();
+    expect(
+      screen.getByRole('option', { name: /charlie/i })
+    ).toBeInTheDocument();
+  });
+
+  it('calls onChange with the selected value', async () => {
+    const user = userEvent.setup();
+    const handleChange = vi.fn();
+    render(
+      <InlineSelect value="a" onChange={handleChange} options={OPTIONS} />
+    );
+
+    await user.click(screen.getByRole('button', { name: /alpha/i }));
+    await user.click(screen.getByRole('option', { name: /charlie/i }));
+
+    expect(handleChange).toHaveBeenCalledWith('c');
+  });
+
+  it('does not open dropdown when disabled', async () => {
+    const user = userEvent.setup();
+    render(
+      <InlineSelect value="a" onChange={vi.fn()} options={OPTIONS} disabled />
+    );
+
+    await user.click(screen.getByRole('button', { name: /alpha/i }));
+
+    expect(screen.queryByRole('option')).not.toBeInTheDocument();
+  });
+
+  it('applies custom buttonClassName', () => {
+    render(
+      <InlineSelect
+        value="a"
+        onChange={vi.fn()}
+        options={OPTIONS}
+        buttonClassName="text-red-500"
+      />
+    );
+
+    expect(screen.getByRole('button', { name: /alpha/i })).toHaveClass(
+      'text-red-500'
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Add inline editing for **status**, **unit**, and **quantity** fields directly on item cards without opening the full edit form
- Status badge is now a clickable dropdown (Headless UI Listbox) that persists changes immediately
- Unit text is a clickable dropdown; quantity is a click-to-edit number input
- Unified all item updates through a single `updateItem(itemId, updates)` function -- both the full edit form and inline edits use the same mutation path
- Extracted shared constants (`STATUS_OPTIONS`, `UNIT_OPTIONS`, `CATEGORY_OPTIONS`) into `src/core/constants/item.ts`

## Test plan
- [x] Build passes
- [x] Lint passes
- [x] All 144 tests pass (13 new tests for InlineSelect and InlineQuantityInput)
- [ ] Manual: click status badge on an item card, verify dropdown appears and selecting a new status persists immediately
- [ ] Manual: click unit text, verify dropdown appears and selecting a new unit persists
- [ ] Manual: click quantity number, verify input appears, change value, blur/Enter to persist
- [ ] Manual: verify equipment items have unit locked to "pcs" (dropdown disabled)
- [ ] Manual: verify full edit form still works as before

Closes #49

Made with [Cursor](https://cursor.com)