### PR TITLE
feat: redesign item filters into action-oriented list tabs and improve card layout

### DIFF
--- a/api/mock-data.json
+++ b/api/mock-data.json
@@ -84,8 +84,8 @@
       "location": {
         "locationId": "81c0ce94-8c9d-5b07-bc80-50ad5db9ea58",
         "name": "Kfir house",
-        "country": "",
-        "region": "",
+        "country": null,
+        "region": null,
         "city": "hulon"
       },
       "startDate": "2026-02-20T19:24:00Z",
@@ -103,19 +103,23 @@
   "participants": [
     {
       "participantId": "1e6f5d21-b8d2-4991-9a23-8803d8aa3428",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Alex",
       "lastName": "Guberman",
+      "contactPhone": "0541234567",
       "displayName": "Alex G.",
       "role": "owner",
-      "isOwner": true,
+      "avatarUrl": null,
       "contactEmail": "alex@example.com",
       "createdAt": "2025-05-01T12:00:00.000Z",
       "updatedAt": "2025-05-10T08:00:00.000Z"
     },
     {
       "participantId": "457393e1-822f-4c1c-a081-8207aa6b9fe1",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Jamie",
       "lastName": "Rivera",
+      "contactPhone": "0529876543",
       "displayName": "Jamie",
       "role": "participant",
       "avatarUrl": "https://example.com/avatars/jamie.png",
@@ -125,11 +129,14 @@
     },
     {
       "participantId": "399dcf24-f8c4-45f8-96fb-4478d578908f",
+      "planId": "030a5978-d76a-4817-a0eb-346e38a45c63",
       "name": "Taylor",
       "lastName": "Morgan",
       "contactPhone": "+1-310-555-0198",
       "displayName": "Taylor",
       "role": "viewer",
+      "avatarUrl": null,
+      "contactEmail": null,
       "createdAt": "2025-05-04T16:45:00.000Z",
       "updatedAt": "2025-05-10T08:05:00.000Z"
     },
@@ -235,8 +242,9 @@
       "notes": "Check stakes before departure",
       "status": "packed",
       "createdAt": "2025-05-02T10:00:00.000Z",
-      "updatedAt": "2026-02-11T11:20:27.470Z",
-      "category": "equipment"
+      "updatedAt": "2026-02-15T07:48:16.012Z",
+      "category": "equipment",
+      "assignedParticipantId": "457393e1-822f-4c1c-a081-8207aa6b9fe1"
     },
     {
       "itemId": "404954b1-04f3-4512-abae-42683bffad2b",
@@ -259,8 +267,9 @@
       "notes": "Two rated for 20°F",
       "status": "packed",
       "createdAt": "2025-05-04T11:05:00.000Z",
-      "updatedAt": "2025-05-10T07:50:00.000Z",
-      "category": "equipment"
+      "updatedAt": "2026-02-15T07:48:19.630Z",
+      "category": "equipment",
+      "assignedParticipantId": "1e6f5d21-b8d2-4991-9a23-8803d8aa3428"
     },
     {
       "itemId": "ccab3332-cc4f-449b-aec6-4130855cb0bf",
@@ -271,8 +280,9 @@
       "notes": "Need to borrow from Taylor",
       "status": "pending",
       "createdAt": "2025-05-06T09:40:00.000Z",
-      "updatedAt": "2025-05-09T12:10:00.000Z",
-      "category": "equipment"
+      "updatedAt": "2026-02-15T07:48:17.808Z",
+      "category": "equipment",
+      "assignedParticipantId": "1e6f5d21-b8d2-4991-9a23-8803d8aa3428"
     },
     {
       "itemId": "bfd3aa99-197f-4b40-8607-11a7bc59e8f8",
@@ -283,8 +293,9 @@
       "notes": "Pick up at REI on Thursday",
       "status": "pending",
       "createdAt": "2025-05-06T09:45:00.000Z",
-      "updatedAt": "2025-05-09T12:10:00.000Z",
-      "category": "equipment"
+      "updatedAt": "2026-02-15T07:48:21.196Z",
+      "category": "equipment",
+      "assignedParticipantId": "457393e1-822f-4c1c-a081-8207aa6b9fe1"
     },
     {
       "itemId": "10ad45f4-4afb-40c3-b0e7-676e293fada1",
@@ -518,14 +529,14 @@
       "itemId": "b59a06d7-3de6-46e5-80c0-0b6b9cc53632",
       "planId": "f0619158-c528-43cc-931b-2b73ea0bcb1e",
       "name": "Shower Tent",
-      "category": "equipment",
       "quantity": 1,
       "unit": "pcs",
-      "status": "pending",
       "notes": null,
+      "status": "pending",
       "assignedParticipantId": "42205c9b-9242-489b-a367-232528213b7d",
       "createdAt": "2026-02-14T19:41:47.035Z",
-      "updatedAt": "2026-02-14T19:41:47.035Z"
+      "updatedAt": "2026-02-14T19:41:47.035Z",
+      "category": "equipment"
     },
     {
       "itemId": "aa01bb02-cc03-dd04-ee05-ff0611111111",

--- a/api/mock.ts
+++ b/api/mock.ts
@@ -38,13 +38,12 @@ const planSchema = z.object({
 
 const participantSchema = z.object({
   participantId: z.string(),
-  planId: z.string().optional(),
+  planId: z.string(),
   name: z.string(),
   lastName: z.string(),
-  contactPhone: z.string().nullable().optional(),
+  contactPhone: z.string(),
   displayName: z.string().nullable().optional(),
   role: z.enum(['owner', 'participant', 'viewer']),
-  isOwner: z.boolean().optional(),
   avatarUrl: z.string().url().nullish(),
   contactEmail: z.string().email().nullish(),
   createdAt: z.string().datetime(),

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -6,6 +6,13 @@ import { STATUS_OPTIONS, UNIT_OPTIONS } from '../core/constants/item';
 import InlineSelect from './shared/InlineSelect';
 import InlineQuantityInput from './shared/InlineQuantityInput';
 
+const STATUS_ACCENT: Record<string, string> = {
+  pending: 'border-l-amber-400',
+  purchased: 'border-l-blue-400',
+  packed: 'border-l-green-400',
+  canceled: 'border-l-gray-300',
+};
+
 interface ItemCardProps {
   item: Item;
   participants?: Participant[];
@@ -41,144 +48,167 @@ export default function ItemCard({
   }, [participants]);
 
   return (
-    <div className="px-3 sm:px-5 py-3 sm:py-4">
-      <div className="flex items-center justify-between gap-3">
-        <div className="flex-1 min-w-0">
+    <div
+      className={clsx(
+        'border-l-4 px-4 sm:px-5 py-3 sm:py-4 transition-colors hover:bg-gray-50/80',
+        STATUS_ACCENT[item.status] ?? 'border-l-gray-300'
+      )}
+    >
+      <div className="flex items-center justify-between gap-3 mb-2">
+        <span
+          className={clsx(
+            'text-sm sm:text-base font-semibold truncate',
+            isCanceled ? 'text-gray-400 line-through' : 'text-gray-900'
+          )}
+        >
+          {item.name}
+        </span>
+
+        <div className="flex items-center gap-2 shrink-0">
+          {onUpdate ? (
+            <InlineSelect
+              value={item.status}
+              onChange={(status) => onUpdate({ status })}
+              options={STATUS_OPTIONS}
+              buttonClassName={clsx(
+                'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium hover:opacity-80 transition-opacity',
+                statusOption?.bg,
+                statusOption?.text
+              )}
+              ariaLabel={`Change status for ${item.name}`}
+            />
+          ) : (
+            <span
+              className={clsx(
+                'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium',
+                statusOption?.bg,
+                statusOption?.text
+              )}
+            >
+              {statusOption?.label ?? item.status}
+            </span>
+          )}
+
+          {onEdit && (
+            <button
+              type="button"
+              onClick={onEdit}
+              className="inline-flex items-center justify-center w-8 h-8 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-lg transition-colors cursor-pointer"
+              aria-label={`Edit ${item.name}`}
+            >
+              <svg
+                className="w-4 h-4"
+                fill="none"
+                viewBox="0 0 24 24"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
+                />
+              </svg>
+            </button>
+          )}
+        </div>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-2">
+        {onUpdate ? (
           <span
             className={clsx(
-              'text-sm sm:text-base font-medium',
-              isCanceled ? 'text-gray-400 line-through' : 'text-gray-800'
+              'inline-flex items-center gap-1 rounded-md px-2 py-0.5',
+              isCanceled
+                ? 'bg-gray-100 text-gray-400'
+                : 'bg-gray-100 text-gray-700'
             )}
           >
-            {item.name}
+            <InlineQuantityInput
+              value={item.quantity}
+              onChange={(quantity) => onUpdate({ quantity })}
+              className="text-xs sm:text-sm font-medium"
+            />
+            <InlineSelect
+              value={item.unit}
+              onChange={(unit) => onUpdate({ unit })}
+              options={UNIT_OPTIONS}
+              disabled={isEquipment}
+              buttonClassName={clsx(
+                'text-xs sm:text-sm font-medium',
+                !isEquipment && 'hover:bg-gray-200 rounded px-0.5'
+              )}
+              ariaLabel={`Change unit for ${item.name}`}
+            />
           </span>
-
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1 mt-1">
-            {onUpdate ? (
-              <span className="inline-flex items-center gap-x-1">
-                <InlineQuantityInput
-                  value={item.quantity}
-                  onChange={(quantity) => onUpdate({ quantity })}
-                  className={clsx(
-                    'text-xs sm:text-sm',
-                    isCanceled ? 'text-gray-400' : 'text-gray-600'
-                  )}
-                />
-                <InlineSelect
-                  value={item.unit}
-                  onChange={(unit) => onUpdate({ unit })}
-                  options={UNIT_OPTIONS}
-                  disabled={isEquipment}
-                  buttonClassName={clsx(
-                    'text-xs sm:text-sm',
-                    isCanceled ? 'text-gray-400' : 'text-gray-600',
-                    !isEquipment && 'hover:bg-gray-100 px-1'
-                  )}
-                  ariaLabel={`Change unit for ${item.name}`}
-                />
-              </span>
-            ) : (
-              <span
-                className={clsx(
-                  'text-xs sm:text-sm',
-                  isCanceled ? 'text-gray-400' : 'text-gray-600'
-                )}
-              >
-                {item.quantity} {item.unit}
-              </span>
-            )}
-            {item.notes && (
-              <span className="text-xs sm:text-sm text-gray-400 truncate max-w-[200px] sm:max-w-xs">
-                {item.notes}
-              </span>
-            )}
-
-            {participants.length > 0 && (
-              <>
-                <span className="text-gray-300">|</span>
-                {onUpdate ? (
-                  <InlineSelect
-                    value={item.assignedParticipantId ?? ''}
-                    onChange={(participantId) =>
-                      onUpdate({
-                        assignedParticipantId: participantId || null,
-                      })
-                    }
-                    options={assignmentOptions}
-                    buttonClassName={clsx(
-                      'text-xs sm:text-sm px-1.5 py-0.5 rounded',
-                      item.assignedParticipantId
-                        ? 'text-indigo-600 bg-indigo-50 hover:bg-indigo-100'
-                        : 'text-gray-400 hover:bg-gray-100'
-                    )}
-                    ariaLabel={`Assign ${item.name} to participant`}
-                  />
-                ) : (
-                  <span
-                    className={clsx(
-                      'text-xs sm:text-sm px-1.5 py-0.5 rounded',
-                      assignedParticipant
-                        ? 'text-indigo-600 bg-indigo-50'
-                        : 'text-gray-400'
-                    )}
-                  >
-                    {assignedParticipant
-                      ? `${assignedParticipant.name} ${assignedParticipant.lastName}`
-                      : 'Unassigned'}
-                  </span>
-                )}
-              </>
-            )}
-          </div>
-        </div>
-
-        {onEdit && (
-          <button
-            type="button"
-            onClick={onEdit}
-            className="shrink-0 inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-blue-600 bg-blue-50 rounded-lg border border-blue-200 hover:bg-blue-100 hover:text-blue-700 active:bg-blue-200 transition-colors cursor-pointer"
-            aria-label={`Edit ${item.name}`}
-          >
-            <svg
-              className="w-4 h-4"
-              fill="none"
-              viewBox="0 0 24 24"
-              stroke="currentColor"
-              aria-hidden="true"
-            >
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-              />
-            </svg>
-            Edit
-          </button>
-        )}
-
-        {onUpdate ? (
-          <InlineSelect
-            value={item.status}
-            onChange={(status) => onUpdate({ status })}
-            options={STATUS_OPTIONS}
-            buttonClassName={clsx(
-              'shrink-0 inline-flex items-center px-2 sm:px-2.5 py-0.5 rounded-full text-xs font-medium hover:opacity-80',
-              statusOption?.bg,
-              statusOption?.text
-            )}
-            ariaLabel={`Change status for ${item.name}`}
-          />
         ) : (
           <span
             className={clsx(
-              'shrink-0 inline-flex items-center px-2 sm:px-2.5 py-0.5 rounded-full text-xs font-medium',
-              statusOption?.bg,
-              statusOption?.text
+              'inline-flex items-center rounded-md px-2 py-0.5 text-xs sm:text-sm font-medium',
+              isCanceled
+                ? 'bg-gray-100 text-gray-400'
+                : 'bg-gray-100 text-gray-700'
             )}
           >
-            {statusOption?.label ?? item.status}
+            {item.quantity} {item.unit}
           </span>
+        )}
+
+        {item.notes && (
+          <span className="inline-flex items-center rounded-md bg-gray-50 px-2 py-0.5 text-xs sm:text-sm text-gray-500 truncate max-w-[180px] sm:max-w-xs border border-gray-200">
+            {item.notes}
+          </span>
+        )}
+
+        {participants.length > 0 && (
+          <>
+            {onUpdate ? (
+              <InlineSelect
+                value={item.assignedParticipantId ?? ''}
+                onChange={(participantId) =>
+                  onUpdate({
+                    assignedParticipantId: participantId || null,
+                  })
+                }
+                options={assignmentOptions}
+                buttonClassName={clsx(
+                  'inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs sm:text-sm font-medium transition-colors',
+                  item.assignedParticipantId
+                    ? 'bg-indigo-50 text-indigo-700 border border-indigo-200'
+                    : 'bg-gray-50 text-gray-400 border border-dashed border-gray-300 hover:border-gray-400'
+                )}
+                ariaLabel={`Assign ${item.name} to participant`}
+              />
+            ) : (
+              <span
+                className={clsx(
+                  'inline-flex items-center gap-1 rounded-md px-2 py-0.5 text-xs sm:text-sm font-medium',
+                  assignedParticipant
+                    ? 'bg-indigo-50 text-indigo-700 border border-indigo-200'
+                    : 'bg-gray-50 text-gray-400 border border-dashed border-gray-300'
+                )}
+              >
+                <svg
+                  className="w-3 h-3"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M16 7a4 4 0 11-8 0 4 4 0 018 0zM12 14a7 7 0 00-7 7h14a7 7 0 00-7-7z"
+                  />
+                </svg>
+                {assignedParticipant
+                  ? `${assignedParticipant.name} ${assignedParticipant.lastName}`
+                  : 'Unassigned'}
+              </span>
+            )}
+          </>
         )}
       </div>
     </div>

--- a/src/components/StatusFilter.tsx
+++ b/src/components/StatusFilter.tsx
@@ -1,85 +1,168 @@
 import clsx from 'clsx';
-import type { ItemStatus } from '../core/schemas/item';
+import type { ListFilter } from '../core/schemas/plan-search';
 
-const STATUS_OPTIONS: {
-  value: ItemStatus | null;
+interface ListTabOption {
+  value: ListFilter | null;
   label: string;
+  icon: React.ReactNode;
   activeBg: string;
   activeText: string;
-}[] = [
+  activeBorder: string;
+}
+
+const ShoppingCartIcon = () => (
+  <svg
+    className="w-4 h-4"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 100 4 2 2 0 000-4z"
+    />
+  </svg>
+);
+
+const BoxIcon = () => (
+  <svg
+    className="w-4 h-4"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4"
+    />
+  </svg>
+);
+
+const UserPlusIcon = () => (
+  <svg
+    className="w-4 h-4"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M18 9v3m0 0v3m0-3h3m-3 0h-3m-2-5a4 4 0 11-8 0 4 4 0 018 0zM3 20a6 6 0 0112 0v1H3v-1z"
+    />
+  </svg>
+);
+
+const ListIcon = () => (
+  <svg
+    className="w-4 h-4"
+    fill="none"
+    viewBox="0 0 24 24"
+    stroke="currentColor"
+    aria-hidden="true"
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      strokeWidth={2}
+      d="M4 6h16M4 10h16M4 14h16M4 18h16"
+    />
+  </svg>
+);
+
+const LIST_TABS: ListTabOption[] = [
   {
     value: null,
     label: 'All',
+    icon: <ListIcon />,
     activeBg: 'bg-gray-800',
     activeText: 'text-white',
+    activeBorder: 'border-gray-800',
   },
   {
-    value: 'pending',
-    label: 'Pending',
-    activeBg: 'bg-yellow-100',
-    activeText: 'text-yellow-800',
+    value: 'buying',
+    label: 'Buying List',
+    icon: <ShoppingCartIcon />,
+    activeBg: 'bg-amber-50',
+    activeText: 'text-amber-700',
+    activeBorder: 'border-amber-300',
   },
   {
-    value: 'purchased',
-    label: 'Purchased',
-    activeBg: 'bg-blue-100',
-    activeText: 'text-blue-800',
+    value: 'packing',
+    label: 'Packing List',
+    icon: <BoxIcon />,
+    activeBg: 'bg-blue-50',
+    activeText: 'text-blue-700',
+    activeBorder: 'border-blue-300',
   },
   {
-    value: 'packed',
-    label: 'Packed',
-    activeBg: 'bg-green-100',
-    activeText: 'text-green-800',
-  },
-  {
-    value: 'canceled',
-    label: 'Canceled',
-    activeBg: 'bg-gray-200',
-    activeText: 'text-gray-600',
+    value: 'assigning',
+    label: 'Assigning List',
+    icon: <UserPlusIcon />,
+    activeBg: 'bg-violet-50',
+    activeText: 'text-violet-700',
+    activeBorder: 'border-violet-300',
   },
 ];
 
-interface StatusFilterProps {
-  selected: ItemStatus | null;
-  onChange: (status: ItemStatus | null) => void;
-  counts: Record<ItemStatus, number>;
+interface ListTabsProps {
+  selected: ListFilter | null;
+  onChange: (filter: ListFilter | null) => void;
+  counts: Record<ListFilter, number>;
   total: number;
 }
 
-export default function StatusFilter({
+export default function ListTabs({
   selected,
   onChange,
   counts,
   total,
-}: StatusFilterProps) {
+}: ListTabsProps) {
   return (
     <div
-      className="flex flex-wrap gap-2"
-      role="group"
-      aria-label="Filter by status"
+      className="inline-flex rounded-xl border border-gray-200 bg-gray-50 p-1 gap-1"
+      role="tablist"
+      aria-label="Filter items by list"
     >
-      {STATUS_OPTIONS.map((option) => {
-        const isActive = selected === option.value;
-        const count = option.value === null ? total : counts[option.value];
+      {LIST_TABS.map((tab) => {
+        const isActive = selected === tab.value;
+        const count = tab.value === null ? total : counts[tab.value];
 
         return (
           <button
-            key={option.value ?? 'all'}
+            key={tab.value ?? 'all'}
             type="button"
-            onClick={() => onChange(option.value)}
+            role="tab"
+            onClick={() => onChange(tab.value)}
             className={clsx(
-              'inline-flex items-center gap-1.5 px-3 py-1.5 rounded-full text-sm font-medium transition-colors cursor-pointer',
+              'inline-flex items-center gap-1.5 px-3 py-2 rounded-lg text-sm font-medium transition-all cursor-pointer',
               isActive
-                ? [option.activeBg, option.activeText]
-                : 'bg-white text-gray-600 border border-gray-300 hover:bg-gray-50 active:bg-gray-100'
+                ? [
+                    tab.activeBg,
+                    tab.activeText,
+                    'shadow-sm border',
+                    tab.activeBorder,
+                  ]
+                : 'text-gray-500 hover:text-gray-700 hover:bg-white border border-transparent'
             )}
-            aria-pressed={isActive}
+            aria-selected={isActive}
           >
-            {option.label}
+            {tab.icon}
+            <span className="hidden sm:inline">{tab.label}</span>
             <span
               className={clsx(
-                'text-xs tabular-nums',
-                isActive ? 'opacity-75' : 'text-gray-400'
+                'inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-xs font-semibold tabular-nums',
+                isActive
+                  ? 'bg-white/30 backdrop-blur-sm'
+                  : 'bg-gray-200/70 text-gray-500'
               )}
             >
               {count}

--- a/src/core/schemas/plan-search.ts
+++ b/src/core/schemas/plan-search.ts
@@ -1,7 +1,9 @@
 import { z } from 'zod';
-import { itemStatusSchema } from './item';
+
+export const listFilterSchema = z.enum(['buying', 'packing', 'assigning']);
+export type ListFilter = z.infer<typeof listFilterSchema>;
 
 export const planSearchSchema = z.object({
-  status: itemStatusSchema.optional().catch(undefined),
+  list: listFilterSchema.optional().catch(undefined),
   participant: z.string().optional().catch(undefined),
 });

--- a/src/test/unit/routes/planSearchSchema.test.ts
+++ b/src/test/unit/routes/planSearchSchema.test.ts
@@ -2,43 +2,45 @@ import { describe, it, expect } from 'vitest';
 import { planSearchSchema } from '../../../core/schemas/plan-search';
 
 describe('planSearchSchema', () => {
-  describe('status param', () => {
-    it('parses a valid status', () => {
-      const result = planSearchSchema.parse({ status: 'pending' });
-      expect(result.status).toBe('pending');
+  describe('list param', () => {
+    it('parses "buying"', () => {
+      const result = planSearchSchema.parse({ list: 'buying' });
+      expect(result.list).toBe('buying');
     });
 
-    it('parses each valid status value', () => {
-      const statuses = ['pending', 'purchased', 'packed', 'canceled'] as const;
-      for (const status of statuses) {
-        const result = planSearchSchema.parse({ status });
-        expect(result.status).toBe(status);
-      }
+    it('parses "packing"', () => {
+      const result = planSearchSchema.parse({ list: 'packing' });
+      expect(result.list).toBe('packing');
     });
 
-    it('defaults to undefined when status is missing', () => {
+    it('parses "assigning"', () => {
+      const result = planSearchSchema.parse({ list: 'assigning' });
+      expect(result.list).toBe('assigning');
+    });
+
+    it('defaults to undefined when list is missing', () => {
       const result = planSearchSchema.parse({});
-      expect(result.status).toBeUndefined();
+      expect(result.list).toBeUndefined();
     });
 
-    it('defaults to undefined when status is undefined', () => {
-      const result = planSearchSchema.parse({ status: undefined });
-      expect(result.status).toBeUndefined();
+    it('defaults to undefined when list is undefined', () => {
+      const result = planSearchSchema.parse({ list: undefined });
+      expect(result.list).toBeUndefined();
     });
 
-    it('defaults to undefined when status is null', () => {
-      const result = planSearchSchema.parse({ status: null });
-      expect(result.status).toBeUndefined();
+    it('defaults to undefined when list is null', () => {
+      const result = planSearchSchema.parse({ list: null });
+      expect(result.list).toBeUndefined();
     });
 
-    it('defaults to undefined for an invalid status string', () => {
-      const result = planSearchSchema.parse({ status: 'invalid' });
-      expect(result.status).toBeUndefined();
+    it('defaults to undefined for an invalid list string', () => {
+      const result = planSearchSchema.parse({ list: 'invalid' });
+      expect(result.list).toBeUndefined();
     });
 
-    it('defaults to undefined for a numeric status', () => {
-      const result = planSearchSchema.parse({ status: 123 });
-      expect(result.status).toBeUndefined();
+    it('defaults to undefined for a numeric list', () => {
+      const result = planSearchSchema.parse({ list: 123 });
+      expect(result.list).toBeUndefined();
     });
   });
 
@@ -75,28 +77,28 @@ describe('planSearchSchema', () => {
   });
 
   describe('combined params', () => {
-    it('parses both status and participant together', () => {
+    it('parses both list and participant together', () => {
       const result = planSearchSchema.parse({
-        status: 'packed',
+        list: 'packing',
         participant: 'p-456',
       });
-      expect(result.status).toBe('packed');
+      expect(result.list).toBe('packing');
       expect(result.participant).toBe('p-456');
     });
 
     it('defaults both when empty object', () => {
       const result = planSearchSchema.parse({});
-      expect(result.status).toBeUndefined();
+      expect(result.list).toBeUndefined();
       expect(result.participant).toBeUndefined();
     });
 
     it('ignores extra properties', () => {
       const result = planSearchSchema.parse({
-        status: 'packed',
+        list: 'buying',
         participant: 'p-1',
         foo: 'bar',
       });
-      expect(result.status).toBe('packed');
+      expect(result.list).toBe('buying');
       expect(result.participant).toBe('p-1');
     });
   });


### PR DESCRIPTION
## Summary
- Replace flat status pill buttons (Pending/Purchased/Packed/Canceled) with action-oriented list tabs: All, Buying List, Packing List, Assigning List
- Move person filter above list tabs so selecting a person scopes the tab counts to that person's items
- Redesign ItemCard with left color accent bar indicating status, two-row layout, and chip-style metadata fields
- Update mock data and participant schema alignment (planId, contactPhone required, remove isOwner)
- Fix type errors: typed useNavigate with `from`, direct search objects instead of callbacks

## Test plan
- [x] `planSearchSchema` tests updated for new `list` param (buying/packing/assigning)
- [x] All 174 unit tests pass
- [x] TypeScript typecheck passes
- [x] ESLint + Prettier pass
- [x] Pre-commit hooks pass


Made with [Cursor](https://cursor.com)