### PR TITLE
feat: add checklist mode to item cards for buying/packing filters

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",

--- a/src/components/CategorySection.tsx
+++ b/src/components/CategorySection.tsx
@@ -5,6 +5,7 @@ import {
 } from '@headlessui/react';
 import type { Item, ItemCategory, ItemPatch } from '../core/schemas/item';
 import type { Participant } from '../core/schemas/participant';
+import type { ListFilter } from '../core/schemas/plan-search';
 import ItemCard from './ItemCard';
 
 const CATEGORY_LABELS: Record<ItemCategory, string> = {
@@ -16,6 +17,7 @@ interface CategorySectionProps {
   category: ItemCategory;
   items: Item[];
   participants?: Participant[];
+  listFilter?: ListFilter | null;
   onEditItem?: (itemId: string) => void;
   onUpdateItem?: (itemId: string, updates: ItemPatch) => void;
 }
@@ -24,6 +26,7 @@ export default function CategorySection({
   category,
   items,
   participants = [],
+  listFilter,
   onEditItem,
   onUpdateItem,
 }: CategorySectionProps) {
@@ -70,6 +73,7 @@ export default function CategorySection({
                 key={item.itemId}
                 item={item}
                 participants={participants}
+                listFilter={listFilter}
                 onEdit={onEditItem ? () => onEditItem(item.itemId) : undefined}
                 onUpdate={
                   onUpdateItem

--- a/src/routes/plan.$planId.lazy.tsx
+++ b/src/routes/plan.$planId.lazy.tsx
@@ -244,6 +244,7 @@ function PlanDetails() {
                   category={category}
                   items={items}
                   participants={plan.participants}
+                  listFilter={listFilter}
                   onEditItem={handleStartEdit}
                   onUpdateItem={updateItem}
                 />


### PR DESCRIPTION
## Summary
- When Buying List or Packing List filter is active, item cards switch to a clean checklist layout
- Checkbox on the left replaces the status dropdown — clicking it (or the item name) advances the status
- Strikethrough + fade animation (300ms) provides visual feedback before the item leaves the filtered list
- Details (quantity, notes, assignment) are shown read-only in checklist mode — no distracting inline editors

## Files changed
- `src/components/ItemCard.tsx` — checklist mode with early return when `quickAction` is active
- `src/components/CategorySection.tsx` — passes `listFilter` prop to ItemCard
- `src/routes/plan.$planId.lazy.tsx` — passes `listFilter` to CategorySection
- `package.json` — version bump 1.0.0 → 1.1.0

Closes #64

Made with [Cursor](https://cursor.com)