### PR TITLE
feat: add Supabase auth UI with sign-up, sign-in, Google OAuth, profile completion, and user menu

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,13 @@ MOCK_SERVER_PORT=3333
 # Local development (mock server)
 VITE_API_URL=http://localhost:3333
 
+# Auth mock (set to "true" for fully offline local dev, no real Supabase needed)
+VITE_AUTH_MOCK=true
+
+# Supabase Auth (required when VITE_AUTH_MOCK is not "true")
+VITE_SUPABASE_URL=https://your-project.supabase.co
+VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+
 # Production API (uncomment to use instead of mock server)
 # VITE_API_URL=https://chillist-be-prod-production.up.railway.app
 

--- a/api/server.ts
+++ b/api/server.ts
@@ -666,6 +666,30 @@ export async function buildServer(
     }
   );
 
+  app.get('/auth/me', async (request, reply) => {
+    const authHeader = request.headers.authorization;
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+      void reply.status(401).send({ message: 'Unauthorized' });
+      return;
+    }
+
+    const token = authHeader.slice(7);
+    let email = 'test@chillist.dev';
+    let sub = '00000000-0000-0000-0000-000000000001';
+
+    try {
+      const payload = JSON.parse(atob(token.split('.')[1]));
+      if (payload.email) email = payload.email;
+      if (payload.sub) sub = payload.sub;
+    } catch {
+      // malformed token — fall back to defaults
+    }
+
+    void reply.send({
+      user: { id: sub, email, role: 'authenticated' },
+    });
+  });
+
   app.post('/_reset', async (_request, reply) => {
     const fresh = cloneData(initialData);
     store.plans = fresh.plans;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,31 +1,29 @@
 {
-  "name": "react",
-  "version": "0.0.0",
+  "name": "chillist-fe",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "react",
-      "version": "0.0.0",
+      "name": "chillist-fe",
+      "version": "1.2.0",
       "dependencies": {
-        "@fastify/cors": "^11.0.1",
         "@headlessui/react": "2.2.9",
         "@hookform/resolvers": "^5.2.2",
+        "@supabase/supabase-js": "2.95.3",
         "@tanstack/react-query": "^5.90.7",
         "@tanstack/react-router": "^1.134.15",
-        "@tanstack/router": "^0.0.1-beta.53",
         "clsx": "2.1.1",
-        "fastify": "^5.1.0",
         "openapi-fetch": "^0.15.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.68.0",
         "react-hot-toast": "2.6.0",
-        "react-router-dom": "^7.9.5",
         "uuid": "^13.0.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.36.0",
+        "@fastify/cors": "^11.0.1",
         "@playwright/test": "^1.58.1",
         "@tailwindcss/vite": "^4.1.16",
         "@testing-library/jest-dom": "^6.9.1",
@@ -41,11 +39,11 @@
         "eslint-plugin-prettier": "^5.5.4",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.22",
+        "fastify": "^5.1.0",
         "globals": "^16.4.0",
         "husky": "^9.1.7",
         "jsdom": "^27.1.0",
         "lint-staged": "^16.2.6",
-        "nodemon": "^3.1.9",
         "openapi-typescript": "^7.10.1",
         "prettier": "^3.6.2",
         "tailwindcss": "^4.1.16",
@@ -364,6 +362,7 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1155,6 +1154,7 @@
       "version": "4.0.5",
       "resolved": "https://registry.npmjs.org/@fastify/ajv-compiler/-/ajv-compiler-4.0.5.tgz",
       "integrity": "sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1176,6 +1176,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -1192,12 +1193,14 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@fastify/cors": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/cors/-/cors-11.1.0.tgz",
       "integrity": "sha512-sUw8ed8wP2SouWZTIbA7V2OQtMNpLj2W6qJOYhNdcmINTu6gsxVYXjQiM9mdi8UUDlcoDDJ/W2syPo1WB2QjYA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1218,6 +1221,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/@fastify/error/-/error-4.2.0.tgz",
       "integrity": "sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1234,6 +1238,7 @@
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@fastify/fast-json-stringify-compiler/-/fast-json-stringify-compiler-5.0.3.tgz",
       "integrity": "sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1253,6 +1258,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@fastify/forwarded/-/forwarded-3.0.1.tgz",
       "integrity": "sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1269,6 +1275,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/@fastify/merge-json-schemas/-/merge-json-schemas-0.2.1.tgz",
       "integrity": "sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1288,6 +1295,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@fastify/proxy-addr/-/proxy-addr-5.1.0.tgz",
       "integrity": "sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -1533,6 +1541,7 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@pinojs/redact/-/redact-0.4.0.tgz",
       "integrity": "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@pkgr/core": {
@@ -2072,6 +2081,86 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@supabase/auth-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/auth-js/-/auth-js-2.95.3.tgz",
+      "integrity": "sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/functions-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/functions-js/-/functions-js-2.95.3.tgz",
+      "integrity": "sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/postgrest-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/postgrest-js/-/postgrest-js-2.95.3.tgz",
+      "integrity": "sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/realtime-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/realtime-js/-/realtime-js-2.95.3.tgz",
+      "integrity": "sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/phoenix": "^1.6.6",
+        "@types/ws": "^8.18.1",
+        "tslib": "2.8.1",
+        "ws": "^8.18.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/storage-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/storage-js/-/storage-js-2.95.3.tgz",
+      "integrity": "sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==",
+      "license": "MIT",
+      "dependencies": {
+        "iceberg-js": "^0.8.1",
+        "tslib": "2.8.1"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@supabase/supabase-js": {
+      "version": "2.95.3",
+      "resolved": "https://registry.npmjs.org/@supabase/supabase-js/-/supabase-js-2.95.3.tgz",
+      "integrity": "sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==",
+      "license": "MIT",
+      "dependencies": {
+        "@supabase/auth-js": "2.95.3",
+        "@supabase/functions-js": "2.95.3",
+        "@supabase/postgrest-js": "2.95.3",
+        "@supabase/realtime-js": "2.95.3",
+        "@supabase/storage-js": "2.95.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@swc/helpers": {
       "version": "0.5.18",
       "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.18.tgz",
@@ -2452,24 +2541,6 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@tanstack/router": {
-      "version": "0.0.1-beta.53",
-      "resolved": "https://registry.npmjs.org/@tanstack/router/-/router-0.0.1-beta.53.tgz",
-      "integrity": "sha512-nX1avh939ufOCoXhJ5wihX/ft6sn50ARrj4FAhRYn50KKzo9fXsYSmPyVgqVdW0hJ4n9XXKIMkwwpzEhLQmqrA==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.16.7",
-        "@tanstack/store": "0.0.1-beta.52",
-        "tiny-invariant": "^1.3.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
     "node_modules/@tanstack/router-core": {
       "version": "1.136.5",
       "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.136.5.tgz",
@@ -2483,22 +2554,6 @@
         "seroval-plugins": "^1.3.2",
         "tiny-invariant": "^1.3.3",
         "tiny-warning": "^1.0.3"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "type": "github",
-        "url": "https://github.com/sponsors/tannerlinsley"
-      }
-    },
-    "node_modules/@tanstack/router/node_modules/@tanstack/store": {
-      "version": "0.0.1-beta.52",
-      "resolved": "https://registry.npmjs.org/@tanstack/store/-/store-0.0.1-beta.52.tgz",
-      "integrity": "sha512-3/5XqeG09sCJnakHpq8qgXjdVpm97aITbi1wfbjLGXdVsss62zpJAvc4vL8ccHf+J/OmoS4dJTNuEZ0alywZtg==",
-      "license": "MIT",
-      "dependencies": {
-        "immer": "^9.0.15"
       },
       "engines": {
         "node": ">=12"
@@ -2707,11 +2762,16 @@
       "version": "24.9.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.9.2.tgz",
       "integrity": "sha512-uWN8YqxXxqFMX2RqGOrumsKeti4LlmIMIyV0lgut4jx7KQBcBiW6vkDtIBvHnHIquwNfJhk8v2OtmO8zXWHfPA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
       }
+    },
+    "node_modules/@types/phoenix": {
+      "version": "1.6.7",
+      "resolved": "https://registry.npmjs.org/@types/phoenix/-/phoenix-1.6.7.tgz",
+      "integrity": "sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==",
+      "license": "MIT"
     },
     "node_modules/@types/react": {
       "version": "19.2.2",
@@ -2748,6 +2808,15 @@
       "license": "MIT",
       "optional": true,
       "peer": true
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.46.2",
@@ -3156,6 +3225,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/abstract-logging/-/abstract-logging-2.0.1.tgz",
       "integrity": "sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/acorn": {
@@ -3212,6 +3282,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
       "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.0.0"
@@ -3229,6 +3300,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -3245,6 +3317,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/ansi-colors": {
@@ -3300,20 +3373,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/anymatch": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
-      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "normalize-path": "^3.0.0",
-        "picomatch": "^2.0.4"
-      },
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -3345,6 +3404,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
       "integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.0.0"
@@ -3354,6 +3414,7 @@
       "version": "9.1.0",
       "resolved": "https://registry.npmjs.org/avvio/-/avvio-9.1.0.tgz",
       "integrity": "sha512-fYASnYi600CsH/j9EQov7lECAniYiBFiiAtBNuZYLA2leLe9qOvZzqYHFjtIj6gD2VMoMLP14834LFWvr4IfDw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/error": "^4.0.0",
@@ -3385,19 +3446,6 @@
       "license": "MIT",
       "dependencies": {
         "require-from-string": "^2.0.2"
-      }
-    },
-    "node_modules/binary-extensions": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
-      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/brace-expansion": {
@@ -3523,44 +3571,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/chokidar": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
-      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "anymatch": "~3.1.2",
-        "braces": "~3.0.2",
-        "glob-parent": "~5.1.2",
-        "is-binary-path": "~2.1.0",
-        "is-glob": "~4.0.1",
-        "normalize-path": "~3.0.0",
-        "readdirp": "~3.6.0"
-      },
-      "engines": {
-        "node": ">= 8.10.0"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
-      },
-      "optionalDependencies": {
-        "fsevents": "~2.3.2"
-      }
-    },
-    "node_modules/chokidar/node_modules/glob-parent": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
-      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "is-glob": "^4.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/cli-cursor": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
@@ -3658,6 +3668,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.0.2.tgz",
       "integrity": "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -3776,6 +3787,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
       "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -4180,12 +4192,14 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz",
       "integrity": "sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-diff": {
@@ -4236,6 +4250,7 @@
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/fast-json-stringify/-/fast-json-stringify-6.1.1.tgz",
       "integrity": "sha512-DbgptncYEXZqDUOEl4krff4mUiVrTZZVI7BBrQR/T3BqMj/eM1flTC1Uk2uUoLcWCxjT95xKulV/Lc6hhOZsBQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4260,6 +4275,7 @@
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
       "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4276,6 +4292,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/fast-levenshtein": {
@@ -4289,6 +4306,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/fast-querystring/-/fast-querystring-1.1.2.tgz",
       "integrity": "sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-decode-uri-component": "^1.0.1"
@@ -4298,6 +4316,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
       "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4314,6 +4333,7 @@
       "version": "5.6.1",
       "resolved": "https://registry.npmjs.org/fastify/-/fastify-5.6.1.tgz",
       "integrity": "sha512-WjjlOciBF0K8pDUPZoGPhqhKrQJ02I8DKaDIfO51EL0kbSMwQFl85cRwhOvmSDWoukNOdTo27gLN549pLCcH7Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4347,6 +4367,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/fastify-plugin/-/fastify-plugin-5.1.0.tgz",
       "integrity": "sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -4363,6 +4384,7 @@
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
       "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -4375,6 +4397,7 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
       "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4410,6 +4433,7 @@
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/find-my-way/-/find-my-way-9.3.0.tgz",
       "integrity": "sha512-eRoFWQw+Yv2tuYlK2pjFS2jGXSxSppAs3hSQjfxVKxM5amECzIgYYc1FEI8ZmhSh/Ig+FrKEz43NLRKJjYCZVg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
@@ -4675,6 +4699,15 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/iceberg-js": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/iceberg-js/-/iceberg-js-0.8.1.tgz",
+      "integrity": "sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -4696,23 +4729,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/ignore-by-default": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
-      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
-      "dev": true,
-      "license": "ISC"
-    },
-    "node_modules/immer": {
-      "version": "9.0.21",
-      "resolved": "https://registry.npmjs.org/immer/-/immer-9.0.21.tgz",
-      "integrity": "sha512-bc4NBHqOqSfRW7POMkHd51LvClaeMXpm8dx0e8oE2GORbq5aRK7Bxl4FyzVLdGtLmvLKL7BTDBG5ACQm4HWjTA==",
-      "license": "MIT",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/immer"
       }
     },
     "node_modules/import-fresh": {
@@ -4769,22 +4785,10 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.2.0.tgz",
       "integrity": "sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10"
-      }
-    },
-    "node_modules/is-binary-path": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
-      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "binary-extensions": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/is-extglob": {
@@ -4963,6 +4967,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-schema-ref-resolver/-/json-schema-ref-resolver-3.0.0.tgz",
       "integrity": "sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5033,6 +5038,7 @@
       "version": "6.6.0",
       "resolved": "https://registry.npmjs.org/light-my-request/-/light-my-request-6.6.0.tgz",
       "integrity": "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5054,6 +5060,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-4.0.1.tgz",
       "integrity": "sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5564,85 +5571,11 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/nodemon": {
-      "version": "3.1.10",
-      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
-      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "chokidar": "^3.5.2",
-        "debug": "^4",
-        "ignore-by-default": "^1.0.1",
-        "minimatch": "^3.1.2",
-        "pstree.remy": "^1.1.8",
-        "semver": "^7.5.3",
-        "simple-update-notifier": "^2.0.0",
-        "supports-color": "^5.5.0",
-        "touch": "^3.1.0",
-        "undefsafe": "^2.0.5"
-      },
-      "bin": {
-        "nodemon": "bin/nodemon.js"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/nodemon"
-      }
-    },
-    "node_modules/nodemon/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/nodemon/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/nodemon/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/normalize-path": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
-      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/on-exit-leak-free": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/on-exit-leak-free/-/on-exit-leak-free-2.1.2.tgz",
       "integrity": "sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
@@ -5871,6 +5804,7 @@
       "version": "9.14.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-9.14.0.tgz",
       "integrity": "sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@pinojs/redact": "^0.4.0",
@@ -5893,6 +5827,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pino-abstract-transport/-/pino-abstract-transport-2.0.0.tgz",
       "integrity": "sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "split2": "^4.0.0"
@@ -5902,6 +5837,7 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-7.0.0.tgz",
       "integrity": "sha512-e906FRY0+tV27iq4juKzSYPbUj2do2X2JX4EzSca1631EB2QJQUqGbDuERal7LCtOpxl6x3+nvo9NPZcmjkiFA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/playwright": {
@@ -6063,6 +5999,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/process-warning/-/process-warning-5.0.0.tgz",
       "integrity": "sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6073,13 +6010,6 @@
           "url": "https://opencollective.com/fastify"
         }
       ],
-      "license": "MIT"
-    },
-    "node_modules/pstree.remy": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
-      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -6117,6 +6047,7 @@
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-4.0.4.tgz",
       "integrity": "sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/react": {
@@ -6191,61 +6122,11 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-router": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.9.6.tgz",
-      "integrity": "sha512-Y1tUp8clYRXpfPITyuifmSoE2vncSME18uVLgaqyxh9H35JWpIfzHo+9y3Fzh5odk/jxPW29IgLgzcdwxGqyNA==",
-      "license": "MIT",
-      "dependencies": {
-        "cookie": "^1.0.1",
-        "set-cookie-parser": "^2.6.0"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      },
-      "peerDependenciesMeta": {
-        "react-dom": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/react-router-dom": {
-      "version": "7.9.6",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.9.6.tgz",
-      "integrity": "sha512-2MkC2XSXq6HjGcihnx1s0DBWQETI4mlis4Ux7YTLvP67xnGxCvq+BcCQSO81qQHVUTM1V53tl4iVVaY5sReCOA==",
-      "license": "MIT",
-      "dependencies": {
-        "react-router": "7.9.6"
-      },
-      "engines": {
-        "node": ">=20.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=18",
-        "react-dom": ">=18"
-      }
-    },
-    "node_modules/readdirp": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
-      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8.10.0"
-      }
-    },
     "node_modules/real-require": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz",
       "integrity": "sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 12.13.0"
@@ -6269,6 +6150,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
       "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -6315,6 +6197,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.5.0.tgz",
       "integrity": "sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6324,6 +6207,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
       "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "iojs": ">=1.0.0",
@@ -6334,6 +6218,7 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
       "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/rollup": {
@@ -6406,6 +6291,7 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/safe-regex2/-/safe-regex2-5.0.0.tgz",
       "integrity": "sha512-YwJwe5a51WlK7KbOJREPdjNrpViQBI3p4T50lfwPuDhZnE3XGVTlGvi+aolc5+RvxDD6bnUmjVsU9n1eboLUYw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6425,6 +6311,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/safe-stable-stringify/-/safe-stable-stringify-2.5.0.tgz",
       "integrity": "sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -6460,6 +6347,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/secure-json-parse/-/secure-json-parse-4.1.0.tgz",
       "integrity": "sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6507,6 +6395,7 @@
       "version": "2.7.2",
       "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
       "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/shebang-command": {
@@ -6552,32 +6441,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/simple-update-notifier": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
-      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "semver": "^7.5.3"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/simple-update-notifier/node_modules/semver": {
-      "version": "7.7.3",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
-      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/slice-ansi": {
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
@@ -6612,6 +6475,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-4.2.0.tgz",
       "integrity": "sha512-INb7TM37/mAcsGmc9hyyI6+QR3rR1zVRu36B0NeGXKnOOLiZOfER5SA+N7X7k3yUYRzLWafduTDvJAfDswwEww==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "atomic-sleep": "^1.0.0"
@@ -6631,6 +6495,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">= 10.x"
@@ -6799,6 +6664,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/thread-stream/-/thread-stream-3.1.0.tgz",
       "integrity": "sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "real-require": "^0.2.0"
@@ -6925,19 +6791,10 @@
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/toad-cache/-/toad-cache-3.7.0.tgz",
       "integrity": "sha512-/m8M+2BJUpoJdgAHoG+baCwBT+tf2VraSfkBgl0Y00qIWt41DJ8R5B8nsEw0I58YwF5IZH6z24/2TobDKnqSWw==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/touch": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
-      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
-      "dev": true,
-      "license": "ISC",
-      "bin": {
-        "nodetouch": "bin/nodetouch.js"
       }
     },
     "node_modules/tough-cookie": {
@@ -7069,18 +6926,10 @@
         "typescript": ">=4.8.4 <6.0.0"
       }
     },
-    "node_modules/undefsafe": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
-      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici-types": {
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
@@ -7499,7 +7348,6 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.3.0",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",
@@ -27,6 +27,7 @@
   "dependencies": {
     "@headlessui/react": "2.2.9",
     "@hookform/resolvers": "^5.2.2",
+    "@supabase/supabase-js": "2.95.3",
     "@tanstack/react-query": "^5.90.7",
     "@tanstack/react-router": "^1.134.15",
     "clsx": "2.1.1",

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,8 +1,54 @@
 import { Link } from '@tanstack/react-router';
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
+import { useAuth } from '../contexts/useAuth';
+
+function getUserDisplayName(user: {
+  email?: string;
+  user_metadata?: Record<string, unknown>;
+}): string {
+  const meta = user.user_metadata ?? {};
+  if (meta.first_name) return meta.first_name as string;
+  if (meta.full_name) return (meta.full_name as string).split(' ')[0];
+  return user.email?.split('@')[0] ?? '';
+}
+
+function getUserInitials(user: {
+  email?: string;
+  user_metadata?: Record<string, unknown>;
+}): string {
+  const meta = user.user_metadata ?? {};
+  const first = (meta.first_name as string) ?? '';
+  const last = (meta.last_name as string) ?? '';
+  if (first && last) return `${first[0]}${last[0]}`.toUpperCase();
+  if (meta.full_name) {
+    const parts = (meta.full_name as string).trim().split(/\s+/);
+    return parts
+      .map((p) => p[0])
+      .join('')
+      .slice(0, 2)
+      .toUpperCase();
+  }
+  return (user.email?.[0] ?? '?').toUpperCase();
+}
 
 export default function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
+  const userMenuRef = useRef<HTMLDivElement>(null);
+  const { user, loading, signOut } = useAuth();
+
+  useEffect(() => {
+    function handleClickOutside(e: MouseEvent) {
+      if (
+        userMenuRef.current &&
+        !userMenuRef.current.contains(e.target as Node)
+      ) {
+        setIsUserMenuOpen(false);
+      }
+    }
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => document.removeEventListener('mousedown', handleClickOutside);
+  }, []);
 
   return (
     <header className="bg-white shadow-sm sticky top-0 z-50">
@@ -59,30 +105,114 @@ export default function Header() {
             )}
           </button>
 
-          <ul className="hidden sm:flex gap-6 list-none m-0 p-0">
-            <li>
-              <Link
-                to="/plans"
-                className="block px-3 py-2 text-base sm:text-lg font-medium text-gray-700 hover:text-blue-600 transition-colors"
-              >
-                Plans
-              </Link>
-            </li>
-            <li>
-              <Link
-                to="/about"
-                className="block px-3 py-2 text-base sm:text-lg font-medium text-gray-700 hover:text-blue-600 transition-colors"
-              >
-                About
-              </Link>
-            </li>
-          </ul>
+          <div className="hidden sm:flex items-center gap-6">
+            <ul className="flex gap-6 list-none m-0 p-0">
+              <li>
+                <Link
+                  to="/plans"
+                  className="block px-3 py-2 text-base sm:text-lg font-medium text-gray-700 hover:text-blue-600 transition-colors"
+                >
+                  Plans
+                </Link>
+              </li>
+              <li>
+                <Link
+                  to="/about"
+                  className="block px-3 py-2 text-base sm:text-lg font-medium text-gray-700 hover:text-blue-600 transition-colors"
+                >
+                  About
+                </Link>
+              </li>
+            </ul>
+
+            {!loading && (
+              <>
+                {user ? (
+                  <div className="relative" ref={userMenuRef}>
+                    <button
+                      onClick={() => setIsUserMenuOpen(!isUserMenuOpen)}
+                      className="flex items-center gap-2 rounded-full p-1 hover:bg-gray-100 transition-colors focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+                      aria-label="User menu"
+                      aria-expanded={isUserMenuOpen}
+                    >
+                      <span className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600 text-sm font-semibold text-white">
+                        {getUserInitials(user)}
+                      </span>
+                      <span className="hidden lg:block text-sm font-medium text-gray-700 max-w-[140px] truncate">
+                        {getUserDisplayName(user)}
+                      </span>
+                    </button>
+
+                    {isUserMenuOpen && (
+                      <div className="absolute right-0 mt-2 w-64 rounded-lg bg-white shadow-lg ring-1 ring-black/5 z-50">
+                        <div className="px-4 py-3 border-b border-gray-100">
+                          <p
+                            className="text-sm font-medium text-gray-900"
+                            data-testid="menu-display-name"
+                          >
+                            {getUserDisplayName(user) || 'User'}
+                          </p>
+                          <p
+                            className="text-xs text-gray-500 truncate mt-0.5"
+                            data-testid="menu-email"
+                          >
+                            {user.email}
+                          </p>
+                          {user.user_metadata?.phone && (
+                            <p
+                              className="text-xs text-gray-500 mt-0.5"
+                              data-testid="menu-phone"
+                            >
+                              {user.user_metadata.phone as string}
+                            </p>
+                          )}
+                        </div>
+                        <div className="py-1">
+                          <Link
+                            to="/complete-profile"
+                            onClick={() => setIsUserMenuOpen(false)}
+                            className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                          >
+                            Edit Profile
+                          </Link>
+                          <button
+                            onClick={() => {
+                              setIsUserMenuOpen(false);
+                              signOut();
+                            }}
+                            className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                          >
+                            Sign Out
+                          </button>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ) : (
+                  <div className="flex items-center gap-3">
+                    <Link
+                      to="/signin"
+                      className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors"
+                    >
+                      Sign In
+                    </Link>
+                    <Link
+                      to="/signup"
+                      className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
+                    >
+                      Sign Up
+                    </Link>
+                  </div>
+                )}
+              </>
+            )}
+          </div>
         </div>
 
         {isMenuOpen && (
           <div className="absolute top-full left-0 right-0 bg-white shadow-lg z-50 sm:hidden border-t border-gray-200 transition-opacity duration-200">
             <ul className="list-none m-0 p-0">
-              <li className="border-b border-gray-100 last:border-b-0">
+              <li className="border-b border-gray-100">
                 <Link
                   to="/plans"
                   onClick={() => setIsMenuOpen(false)}
@@ -91,7 +221,7 @@ export default function Header() {
                   Plans
                 </Link>
               </li>
-              <li className="border-b border-gray-100 last:border-b-0">
+              <li className="border-b border-gray-100">
                 <Link
                   to="/about"
                   onClick={() => setIsMenuOpen(false)}
@@ -100,6 +230,65 @@ export default function Header() {
                   About
                 </Link>
               </li>
+              {!loading && (
+                <li className="border-b border-gray-100 last:border-b-0">
+                  {user ? (
+                    <div className="px-4 py-3">
+                      <div className="flex items-center gap-3 mb-3">
+                        <span className="flex h-9 w-9 items-center justify-center rounded-full bg-blue-600 text-sm font-semibold text-white">
+                          {getUserInitials(user)}
+                        </span>
+                        <div className="min-w-0">
+                          <p className="text-sm font-medium text-gray-900 truncate">
+                            {getUserDisplayName(user) || 'User'}
+                          </p>
+                          <p className="text-xs text-gray-500 truncate">
+                            {user.email}
+                          </p>
+                        </div>
+                      </div>
+                      {user.user_metadata?.phone && (
+                        <p className="text-xs text-gray-500 mb-2">
+                          {user.user_metadata.phone as string}
+                        </p>
+                      )}
+                      <Link
+                        to="/complete-profile"
+                        onClick={() => setIsMenuOpen(false)}
+                        className="block w-full text-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors"
+                      >
+                        Edit Profile
+                      </Link>
+                      <button
+                        onClick={() => {
+                          setIsMenuOpen(false);
+                          signOut();
+                        }}
+                        className="mt-2 w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors"
+                      >
+                        Sign Out
+                      </button>
+                    </div>
+                  ) : (
+                    <div>
+                      <Link
+                        to="/signin"
+                        onClick={() => setIsMenuOpen(false)}
+                        className="block px-4 py-3 text-base font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 transition-colors"
+                      >
+                        Sign In
+                      </Link>
+                      <Link
+                        to="/signup"
+                        onClick={() => setIsMenuOpen(false)}
+                        className="block px-4 py-3 text-base font-medium text-blue-600 hover:bg-gray-50 transition-colors border-t border-gray-100"
+                      >
+                        Sign Up
+                      </Link>
+                    </div>
+                  )}
+                </li>
+              )}
             </ul>
           </div>
         )}

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -1,0 +1,59 @@
+import { useEffect, useState, useCallback, type ReactNode } from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+import toast from 'react-hot-toast';
+import { supabase } from '../lib/supabase';
+import { fetchAuthMe } from '../core/api';
+import { AuthContext } from './auth-context';
+
+export default function AuthProvider({ children }: { children: ReactNode }) {
+  const [session, setSession] = useState<Session | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    supabase.auth.getSession().then(({ data: { session: initial } }) => {
+      setSession(initial);
+      setUser(initial?.user ?? null);
+      setLoading(false);
+    });
+
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, newSession) => {
+      setSession(newSession);
+      setUser(newSession?.user ?? null);
+
+      if (event === 'SIGNED_IN') {
+        fetchAuthMe()
+          .then((res) => {
+            toast.success(`Signed in as ${res.user.email}`);
+          })
+          .catch(() => {
+            toast.success('Signed in');
+          });
+      }
+
+      if (event === 'SIGNED_OUT') {
+        setSession(null);
+        setUser(null);
+      }
+    });
+
+    return () => {
+      subscription.unsubscribe();
+    };
+  }, []);
+
+  const signOut = useCallback(async () => {
+    const { error } = await supabase.auth.signOut();
+    if (error) {
+      toast.error(`Sign out failed: ${error.message}`);
+    }
+  }, []);
+
+  return (
+    <AuthContext.Provider value={{ session, user, loading, signOut }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -1,0 +1,13 @@
+import { createContext } from 'react';
+import type { Session, User } from '@supabase/supabase-js';
+
+export interface AuthContextValue {
+  session: Session | null;
+  user: User | null;
+  loading: boolean;
+  signOut: () => Promise<void>;
+}
+
+export const AuthContext = createContext<AuthContextValue | undefined>(
+  undefined
+);

--- a/src/contexts/useAuth.ts
+++ b/src/contexts/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext, type AuthContextValue } from './auth-context';
+
+export function useAuth(): AuthContextValue {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+}

--- a/src/core/api.generated.ts
+++ b/src/core/api.generated.ts
@@ -94,8 +94,8 @@ export interface paths {
     };
     put?: never;
     /**
-     * Create a new plan
-     * @description Create a new plan with the provided details
+     * [DEPRECATED] Create a plan without owner
+     * @description Deprecated: Use POST /plans/with-owner instead. Creates a plan without an owner participant.
      */
     post: {
       parameters: {
@@ -106,7 +106,7 @@ export interface paths {
       };
       requestBody?: {
         content: {
-          'application/json': components['schemas']['def-7'];
+          'application/json': components['schemas']['def-8'];
         };
       };
       responses: {
@@ -154,6 +154,76 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/plans/with-owner': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * [NEW] Create a plan with owner participant
+     * @description Creates a plan and its owner participant in a single transaction. Returns the plan with participants[] and items[]. Replaces POST /plans for new FE integration.
+     */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': components['schemas']['def-9'];
+        };
+      };
+      responses: {
+        /** @description Default Response */
+        201: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-25'];
+          };
+        };
+        /** @description Default Response */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/plans/{planId}': {
     parameters: {
       query?: never;
@@ -162,8 +232,8 @@ export interface paths {
       cookie?: never;
     };
     /**
-     * Get plan by ID
-     * @description Retrieve a single plan by its ID with associated items
+     * Get plan by ID (now includes participants)
+     * @description Retrieve a single plan by its ID with associated items and participants. Response now includes participants[] array alongside items[].
      */
     get: {
       parameters: {
@@ -182,7 +252,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-17'];
+            'application/json': components['schemas']['def-25'];
           };
         };
         /** @description Default Response */
@@ -246,7 +316,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-10'];
+            'application/json': components['schemas']['def-12'];
           };
         };
         /** @description Default Response */
@@ -280,7 +350,72 @@ export interface paths {
     };
     options?: never;
     head?: never;
-    patch?: never;
+    /**
+     * Update a plan
+     * @description Update an existing plan by its ID
+     */
+    patch: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          planId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: {
+        content: {
+          'application/json': components['schemas']['def-10'];
+        };
+      };
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-5'];
+          };
+        };
+        /** @description Default Response */
+        400: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
     trace?: never;
   };
   '/plans/{planId}/participants': {
@@ -311,7 +446,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-19'];
+            'application/json': components['schemas']['def-20'];
           };
         };
         /** @description Default Response */
@@ -345,8 +480,8 @@ export interface paths {
     };
     put?: never;
     /**
-     * Add a participant to a plan
-     * @description Create a new participant in the specified plan
+     * [UPDATED] Add a participant to a plan
+     * @description Create a new participant in the specified plan. Required fields changed: now requires name, lastName, contactPhone instead of displayName.
      */
     post: {
       parameters: {
@@ -359,7 +494,7 @@ export interface paths {
       };
       requestBody?: {
         content: {
-          'application/json': components['schemas']['def-20'];
+          'application/json': components['schemas']['def-21'];
         };
       };
       responses: {
@@ -369,7 +504,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-18'];
+            'application/json': components['schemas']['def-19'];
           };
         };
         /** @description Default Response */
@@ -444,7 +579,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-18'];
+            'application/json': components['schemas']['def-19'];
           };
         };
         /** @description Default Response */
@@ -499,7 +634,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-23'];
+            'application/json': components['schemas']['def-24'];
           };
         };
         /** @description Default Response */
@@ -557,7 +692,7 @@ export interface paths {
       };
       requestBody?: {
         content: {
-          'application/json': components['schemas']['def-21'];
+          'application/json': components['schemas']['def-22'];
         };
       };
       responses: {
@@ -567,7 +702,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-18'];
+            'application/json': components['schemas']['def-19'];
           };
         };
         /** @description Default Response */
@@ -638,7 +773,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-12'];
+            'application/json': components['schemas']['def-14'];
           };
         };
         /** @description Default Response */
@@ -686,7 +821,7 @@ export interface paths {
       };
       requestBody?: {
         content: {
-          'application/json': components['schemas']['def-13'];
+          'application/json': components['schemas']['def-15'];
         };
       };
       responses: {
@@ -696,7 +831,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-11'];
+            'application/json': components['schemas']['def-13'];
           };
         };
         /** @description Default Response */
@@ -774,7 +909,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-16'];
+            'application/json': components['schemas']['def-18'];
           };
         };
         /** @description Default Response */
@@ -823,7 +958,7 @@ export interface paths {
       };
       requestBody?: {
         content: {
-          'application/json': components['schemas']['def-14'];
+          'application/json': components['schemas']['def-16'];
         };
       };
       responses: {
@@ -833,7 +968,7 @@ export interface paths {
             [name: string]: unknown;
           };
           content: {
-            'application/json': components['schemas']['def-11'];
+            'application/json': components['schemas']['def-13'];
           };
         };
         /** @description Default Response */
@@ -874,6 +1009,189 @@ export interface paths {
         };
       };
     };
+    trace?: never;
+  };
+  '/plans/{planId}/invite/{inviteToken}': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Access a plan via invite link
+     * @description Public endpoint. Validates the invite token and returns plan data with items. Participant PII is stripped — only displayName and role are included.
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          planId: string;
+          inviteToken: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-29'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/plans/{planId}/participants/{participantId}/regenerate-token': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * Regenerate invite token for a participant
+     * @description Generates a new invite token for the specified participant, invalidating the previous one. Requires API key (owner action).
+     */
+    post: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path: {
+          planId: string;
+          participantId: string;
+        };
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-31'];
+          };
+        };
+        /** @description Default Response */
+        404: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        500: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+        /** @description Default Response */
+        503: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
+          };
+        };
+      };
+    };
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/auth/me': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * Get current user from JWT
+     * @description Returns the authenticated user identity extracted from the JWT. Returns 401 if no valid JWT is provided.
+     */
+    get: {
+      parameters: {
+        query?: never;
+        header?: never;
+        path?: never;
+        cookie?: never;
+      };
+      requestBody?: never;
+      responses: {
+        /** @description Default Response */
+        200: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': {
+              user: {
+                id: string;
+                email: string;
+                role: string;
+              };
+            };
+          };
+        };
+      };
+    };
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
     trace?: never;
   };
 }
@@ -942,8 +1260,17 @@ export interface components {
     };
     /** PlanList */
     'def-6': components['schemas']['def-5'][];
-    /** CreatePlanBody */
+    /** OwnerBody */
     'def-7': {
+      name: string;
+      lastName: string;
+      contactPhone: string;
+      displayName?: string;
+      avatarUrl?: string;
+      contactEmail?: string;
+    };
+    /** CreatePlanBodyLegacy */
+    'def-8': {
       title: string;
       description?: string | null;
       /** @enum {string} */
@@ -955,8 +1282,23 @@ export interface components {
       endDate?: string | null;
       tags?: string[] | null;
     };
+    /** CreatePlanBody */
+    'def-9': {
+      title: string;
+      description?: string | null;
+      /** @enum {string} */
+      visibility?: 'public' | 'unlisted' | 'private';
+      location?: components['schemas']['def-4'] | null;
+      /** Format: date-time */
+      startDate?: string | null;
+      /** Format: date-time */
+      endDate?: string | null;
+      tags?: string[] | null;
+      owner: components['schemas']['def-7'];
+      participants?: components['schemas']['def-21'][];
+    };
     /** UpdatePlanBody */
-    'def-8': {
+    'def-10': {
       title?: string;
       description?: string | null;
       /** @enum {string} */
@@ -971,16 +1313,16 @@ export interface components {
       tags?: string[] | null;
     };
     /** PlanIdParam */
-    'def-9': {
+    'def-11': {
       /** Format: uuid */
       planId: string;
     };
     /** DeletePlanResponse */
-    'def-10': {
+    'def-12': {
       ok: boolean;
     };
     /** Item */
-    'def-11': {
+    'def-13': {
       /** Format: uuid */
       itemId: string;
       /** Format: uuid */
@@ -1002,9 +1344,9 @@ export interface components {
       updatedAt: string;
     };
     /** ItemList */
-    'def-12': components['schemas']['def-11'][];
+    'def-14': components['schemas']['def-13'][];
     /** CreateItemBody */
-    'def-13': {
+    'def-15': {
       name: string;
       /** @enum {string} */
       category: 'equipment' | 'food';
@@ -1018,7 +1360,7 @@ export interface components {
       assignedParticipantId?: string | null;
     };
     /** UpdateItemBody */
-    'def-14': {
+    'def-16': {
       name?: string;
       /** @enum {string} */
       category?: 'equipment' | 'food';
@@ -1032,16 +1374,69 @@ export interface components {
       assignedParticipantId?: string | null;
     };
     /** ItemIdParam */
-    'def-15': {
+    'def-17': {
       /** Format: uuid */
       itemId: string;
     };
     /** DeleteItemResponse */
-    'def-16': {
+    'def-18': {
       ok: boolean;
     };
-    /** PlanWithItems */
-    'def-17': {
+    /** Participant */
+    'def-19': {
+      /** Format: uuid */
+      participantId: string;
+      /** Format: uuid */
+      planId: string;
+      name: string;
+      lastName: string;
+      contactPhone: string;
+      displayName?: string | null;
+      /** @enum {string} */
+      role: 'owner' | 'participant' | 'viewer';
+      avatarUrl?: string | null;
+      contactEmail?: string | null;
+      inviteToken?: string | null;
+      /** Format: date-time */
+      createdAt: string;
+      /** Format: date-time */
+      updatedAt: string;
+    };
+    /** ParticipantList */
+    'def-20': components['schemas']['def-19'][];
+    /** CreateParticipantBody */
+    'def-21': {
+      name: string;
+      lastName: string;
+      contactPhone: string;
+      displayName?: string;
+      /** @enum {string} */
+      role?: 'participant' | 'viewer';
+      avatarUrl?: string;
+      contactEmail?: string;
+    };
+    /** UpdateParticipantBody */
+    'def-22': {
+      name?: string;
+      lastName?: string;
+      contactPhone?: string;
+      displayName?: string | null;
+      /** @enum {string} */
+      role?: 'participant' | 'viewer';
+      avatarUrl?: string | null;
+      contactEmail?: string | null;
+    };
+    /** ParticipantIdParam */
+    'def-23': {
+      /** Format: uuid */
+      participantId: string;
+    };
+    /** DeleteParticipantResponse */
+    'def-24': {
+      ok: boolean;
+    };
+    /** PlanWithDetails */
+    'def-25': {
       /** Format: uuid */
       planId: string;
       title: string;
@@ -1062,59 +1457,56 @@ export interface components {
       createdAt: string;
       /** Format: date-time */
       updatedAt: string;
-      items: components['schemas']['def-12'];
+      items: components['schemas']['def-14'];
+      participants: components['schemas']['def-20'];
     };
-    /** Participant */
-    'def-18': {
-      /** Format: uuid */
-      participantId: string;
+    /** InviteParams */
+    'def-26': {
       /** Format: uuid */
       planId: string;
-      displayName: string;
-      name?: string | null;
-      lastName?: string | null;
+      inviteToken: string;
+    };
+    /** InviteParticipant */
+    'def-27': {
+      /** Format: uuid */
+      participantId: string;
+      displayName?: string | null;
       /** @enum {string} */
       role: 'owner' | 'participant' | 'viewer';
-      avatarUrl?: string | null;
-      contactEmail?: string | null;
-      contactPhone?: string | null;
+    };
+    /** InviteParticipantList */
+    'def-28': components['schemas']['def-27'][];
+    /** InvitePlanResponse */
+    'def-29': {
+      /** Format: uuid */
+      planId: string;
+      title: string;
+      description?: string | null;
+      /** @enum {string} */
+      status: 'draft' | 'active' | 'archived';
+      location?: components['schemas']['def-4'] | null;
+      /** Format: date-time */
+      startDate?: string | null;
+      /** Format: date-time */
+      endDate?: string | null;
+      tags?: string[] | null;
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
       updatedAt: string;
+      items: components['schemas']['def-14'];
+      participants: components['schemas']['def-28'];
     };
-    /** ParticipantList */
-    'def-19': components['schemas']['def-18'][];
-    /** CreateParticipantBody */
-    'def-20': {
-      displayName: string;
-      /** @enum {string} */
-      role?: 'owner' | 'participant' | 'viewer';
-      name?: string;
-      lastName?: string;
-      avatarUrl?: string;
-      contactEmail?: string;
-      contactPhone?: string;
-    };
-    /** UpdateParticipantBody */
-    'def-21': {
-      displayName?: string;
-      /** @enum {string} */
-      role?: 'owner' | 'participant' | 'viewer';
-      name?: string | null;
-      lastName?: string | null;
-      avatarUrl?: string | null;
-      contactEmail?: string | null;
-      contactPhone?: string | null;
-    };
-    /** ParticipantIdParam */
-    'def-22': {
+    /** RegenerateTokenParams */
+    'def-30': {
+      /** Format: uuid */
+      planId: string;
       /** Format: uuid */
       participantId: string;
     };
-    /** DeleteParticipantResponse */
-    'def-23': {
-      ok: boolean;
+    /** RegenerateTokenResponse */
+    'def-31': {
+      inviteToken: string;
     };
   };
   responses: never;

--- a/src/core/auth-api.ts
+++ b/src/core/auth-api.ts
@@ -1,0 +1,13 @@
+import { z } from 'zod';
+
+const authMeResponseSchema = z.object({
+  user: z.object({
+    id: z.string(),
+    email: z.string(),
+    role: z.string(),
+  }),
+});
+
+export type AuthMeResponse = z.infer<typeof authMeResponseSchema>;
+
+export { authMeResponseSchema };

--- a/src/lib/mock-supabase-auth.ts
+++ b/src/lib/mock-supabase-auth.ts
@@ -1,0 +1,139 @@
+type AuthChangeCallback = (event: string, session: MockSession | null) => void;
+
+interface MockUser {
+  id: string;
+  email: string;
+  user_metadata: Record<string, unknown>;
+  aud: string;
+  role: string;
+}
+
+interface MockSession {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+  user: MockUser;
+}
+
+const STORAGE_KEY = 'mock-auth-session';
+const listeners: Set<AuthChangeCallback> = new Set();
+
+function makeFakeJwt(email: string, userId: string): string {
+  const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const payload = btoa(
+    JSON.stringify({
+      sub: userId,
+      email,
+      role: 'authenticated',
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    })
+  );
+  return `${header}.${payload}.mock-signature`;
+}
+
+function buildSession(email: string): MockSession {
+  const userId = crypto.randomUUID();
+  return {
+    access_token: makeFakeJwt(email, userId),
+    refresh_token: `mock-refresh-${userId}`,
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: {
+      id: userId,
+      email,
+      user_metadata: { full_name: email.split('@')[0] },
+      aud: 'authenticated',
+      role: 'authenticated',
+    },
+  };
+}
+
+function saveSession(session: MockSession | null) {
+  if (session) {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(session));
+  } else {
+    localStorage.removeItem(STORAGE_KEY);
+  }
+}
+
+function loadSession(): MockSession | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+function notify(event: string, session: MockSession | null) {
+  listeners.forEach((cb) => cb(event, session));
+}
+
+export const mockAuth = {
+  async getSession() {
+    const session = loadSession();
+    return { data: { session }, error: null };
+  },
+
+  async signUp({ email }: { email: string; password: string }) {
+    const session = buildSession(email);
+    saveSession(session);
+    notify('SIGNED_IN', session);
+    return { data: { session, user: session.user }, error: null };
+  },
+
+  async signInWithPassword({ email }: { email: string; password: string }) {
+    const session = buildSession(email);
+    saveSession(session);
+    notify('SIGNED_IN', session);
+    return { data: { session, user: session.user }, error: null };
+  },
+
+  async signInWithOAuth(_options: {
+    provider: string;
+    options?: { redirectTo?: string };
+  }) {
+    const session = buildSession('google-user@mock.dev');
+    saveSession(session);
+    notify('SIGNED_IN', session);
+    return {
+      data: { provider: _options.provider, url: '' },
+      error: null,
+    };
+  },
+
+  async updateUser({ data }: { data: Record<string, unknown> }) {
+    const session = loadSession();
+    if (!session) {
+      return {
+        data: { user: null },
+        error: { message: 'Not authenticated' },
+      };
+    }
+    session.user.user_metadata = { ...session.user.user_metadata, ...data };
+    saveSession(session);
+    notify('USER_UPDATED', session);
+    return { data: { user: session.user }, error: null };
+  },
+
+  async signOut() {
+    saveSession(null);
+    notify('SIGNED_OUT', null);
+    return { error: null };
+  },
+
+  onAuthStateChange(callback: AuthChangeCallback) {
+    listeners.add(callback);
+    return {
+      data: {
+        subscription: {
+          unsubscribe: () => {
+            listeners.delete(callback);
+          },
+        },
+      },
+    };
+  },
+};

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,0 +1,21 @@
+import { createClient, type SupabaseClient } from '@supabase/supabase-js';
+import { mockAuth } from './mock-supabase-auth';
+
+const isMockAuth = import.meta.env.VITE_AUTH_MOCK === 'true';
+
+function createRealClient(): SupabaseClient {
+  const url = import.meta.env.VITE_SUPABASE_URL;
+  const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) {
+    throw new Error('Missing VITE_SUPABASE_URL or VITE_SUPABASE_ANON_KEY');
+  }
+  return createClient(url, anonKey);
+}
+
+function createMockClient() {
+  return { auth: mockAuth } as unknown as SupabaseClient;
+}
+
+export const supabase: SupabaseClient = isMockAuth
+  ? createMockClient()
+  : createRealClient();

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -14,11 +14,24 @@ import { Route as rootRouteImport } from './routes/__root';
 import { Route as CreatePlanRouteImport } from './routes/create-plan';
 import { Route as PlanPlanIdRouteImport } from './routes/plan.$planId';
 
+const SignupLazyRouteImport = createFileRoute('/signup')();
+const SigninLazyRouteImport = createFileRoute('/signin')();
 const PlansLazyRouteImport = createFileRoute('/plans')();
 const NotFoundLazyRouteImport = createFileRoute('/not-found')();
+const CompleteProfileLazyRouteImport = createFileRoute('/complete-profile')();
 const AboutLazyRouteImport = createFileRoute('/about')();
 const IndexLazyRouteImport = createFileRoute('/')();
 
+const SignupLazyRoute = SignupLazyRouteImport.update({
+  id: '/signup',
+  path: '/signup',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() => import('./routes/signup.lazy').then((d) => d.Route));
+const SigninLazyRoute = SigninLazyRouteImport.update({
+  id: '/signin',
+  path: '/signin',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() => import('./routes/signin.lazy').then((d) => d.Route));
 const PlansLazyRoute = PlansLazyRouteImport.update({
   id: '/plans',
   path: '/plans',
@@ -29,6 +42,13 @@ const NotFoundLazyRoute = NotFoundLazyRouteImport.update({
   path: '/not-found',
   getParentRoute: () => rootRouteImport,
 } as any).lazy(() => import('./routes/not-found.lazy').then((d) => d.Route));
+const CompleteProfileLazyRoute = CompleteProfileLazyRouteImport.update({
+  id: '/complete-profile',
+  path: '/complete-profile',
+  getParentRoute: () => rootRouteImport,
+} as any).lazy(() =>
+  import('./routes/complete-profile.lazy').then((d) => d.Route)
+);
 const AboutLazyRoute = AboutLazyRouteImport.update({
   id: '/about',
   path: '/about',
@@ -54,16 +74,22 @@ export interface FileRoutesByFullPath {
   '/': typeof IndexLazyRoute;
   '/create-plan': typeof CreatePlanRoute;
   '/about': typeof AboutLazyRoute;
+  '/complete-profile': typeof CompleteProfileLazyRoute;
   '/not-found': typeof NotFoundLazyRoute;
   '/plans': typeof PlansLazyRoute;
+  '/signin': typeof SigninLazyRoute;
+  '/signup': typeof SignupLazyRoute;
   '/plan/$planId': typeof PlanPlanIdRoute;
 }
 export interface FileRoutesByTo {
   '/': typeof IndexLazyRoute;
   '/create-plan': typeof CreatePlanRoute;
   '/about': typeof AboutLazyRoute;
+  '/complete-profile': typeof CompleteProfileLazyRoute;
   '/not-found': typeof NotFoundLazyRoute;
   '/plans': typeof PlansLazyRoute;
+  '/signin': typeof SigninLazyRoute;
+  '/signup': typeof SignupLazyRoute;
   '/plan/$planId': typeof PlanPlanIdRoute;
 }
 export interface FileRoutesById {
@@ -71,8 +97,11 @@ export interface FileRoutesById {
   '/': typeof IndexLazyRoute;
   '/create-plan': typeof CreatePlanRoute;
   '/about': typeof AboutLazyRoute;
+  '/complete-profile': typeof CompleteProfileLazyRoute;
   '/not-found': typeof NotFoundLazyRoute;
   '/plans': typeof PlansLazyRoute;
+  '/signin': typeof SigninLazyRoute;
+  '/signup': typeof SignupLazyRoute;
   '/plan/$planId': typeof PlanPlanIdRoute;
 }
 export interface FileRouteTypes {
@@ -81,24 +110,33 @@ export interface FileRouteTypes {
     | '/'
     | '/create-plan'
     | '/about'
+    | '/complete-profile'
     | '/not-found'
     | '/plans'
+    | '/signin'
+    | '/signup'
     | '/plan/$planId';
   fileRoutesByTo: FileRoutesByTo;
   to:
     | '/'
     | '/create-plan'
     | '/about'
+    | '/complete-profile'
     | '/not-found'
     | '/plans'
+    | '/signin'
+    | '/signup'
     | '/plan/$planId';
   id:
     | '__root__'
     | '/'
     | '/create-plan'
     | '/about'
+    | '/complete-profile'
     | '/not-found'
     | '/plans'
+    | '/signin'
+    | '/signup'
     | '/plan/$planId';
   fileRoutesById: FileRoutesById;
 }
@@ -106,13 +144,30 @@ export interface RootRouteChildren {
   IndexLazyRoute: typeof IndexLazyRoute;
   CreatePlanRoute: typeof CreatePlanRoute;
   AboutLazyRoute: typeof AboutLazyRoute;
+  CompleteProfileLazyRoute: typeof CompleteProfileLazyRoute;
   NotFoundLazyRoute: typeof NotFoundLazyRoute;
   PlansLazyRoute: typeof PlansLazyRoute;
+  SigninLazyRoute: typeof SigninLazyRoute;
+  SignupLazyRoute: typeof SignupLazyRoute;
   PlanPlanIdRoute: typeof PlanPlanIdRoute;
 }
 
 declare module '@tanstack/react-router' {
   interface FileRoutesByPath {
+    '/signup': {
+      id: '/signup';
+      path: '/signup';
+      fullPath: '/signup';
+      preLoaderRoute: typeof SignupLazyRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    '/signin': {
+      id: '/signin';
+      path: '/signin';
+      fullPath: '/signin';
+      preLoaderRoute: typeof SigninLazyRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
     '/plans': {
       id: '/plans';
       path: '/plans';
@@ -125,6 +180,13 @@ declare module '@tanstack/react-router' {
       path: '/not-found';
       fullPath: '/not-found';
       preLoaderRoute: typeof NotFoundLazyRouteImport;
+      parentRoute: typeof rootRouteImport;
+    };
+    '/complete-profile': {
+      id: '/complete-profile';
+      path: '/complete-profile';
+      fullPath: '/complete-profile';
+      preLoaderRoute: typeof CompleteProfileLazyRouteImport;
       parentRoute: typeof rootRouteImport;
     };
     '/about': {
@@ -162,8 +224,11 @@ const rootRouteChildren: RootRouteChildren = {
   IndexLazyRoute: IndexLazyRoute,
   CreatePlanRoute: CreatePlanRoute,
   AboutLazyRoute: AboutLazyRoute,
+  CompleteProfileLazyRoute: CompleteProfileLazyRoute,
   NotFoundLazyRoute: NotFoundLazyRoute,
   PlansLazyRoute: PlansLazyRoute,
+  SigninLazyRoute: SigninLazyRoute,
+  SignupLazyRoute: SignupLazyRoute,
   PlanPlanIdRoute: PlanPlanIdRoute,
 };
 export const routeTree = rootRouteImport

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -1,8 +1,9 @@
-import { createRootRoute, Outlet, redirect } from '@tanstack/react-router';
+import { createRootRoute, Outlet } from '@tanstack/react-router';
 import { Toaster } from 'react-hot-toast';
 import NotFound from './not-found.lazy';
 import Header from '../components/Header';
 import { ErrorPage } from './ErrorPage';
+import AuthProvider from '../contexts/AuthProvider';
 
 function logError(error: Error, context?: string) {
   const errorInfo = {
@@ -22,14 +23,6 @@ function logError(error: Error, context?: string) {
 }
 
 export const Route = createRootRoute({
-  loader: ({ location }) => {
-    if (location.pathname === '/' || location.pathname === '') {
-      throw redirect({
-        to: '/plans',
-        replace: true,
-      });
-    }
-  },
   notFoundComponent: NotFound,
   errorComponent: ({ error }) => {
     logError(error, 'RootErrorBoundary');
@@ -44,33 +37,35 @@ export const Route = createRootRoute({
   },
   component: () => {
     return (
-      <div className="min-h-screen flex flex-col bg-gray-50">
-        <Toaster
-          position="top-right"
-          toastOptions={{
-            duration: 4000,
-            error: {
-              duration: 5000,
-              style: {
-                background: '#FEF2F2',
-                color: '#991B1B',
-                border: '1px solid #FECACA',
+      <AuthProvider>
+        <div className="min-h-screen flex flex-col bg-gray-50">
+          <Toaster
+            position="bottom-center"
+            toastOptions={{
+              duration: 2000,
+              error: {
+                duration: 4000,
+                style: {
+                  background: '#FEF2F2',
+                  color: '#991B1B',
+                  border: '1px solid #FECACA',
+                },
               },
-            },
-            success: {
-              style: {
-                background: '#F0FDF4',
-                color: '#166534',
-                border: '1px solid #BBF7D0',
+              success: {
+                style: {
+                  background: '#F0FDF4',
+                  color: '#166534',
+                  border: '1px solid #BBF7D0',
+                },
               },
-            },
-          }}
-        />
-        <Header />
-        <main className="flex-1 w-full max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-2 sm:py-6 lg:py-8">
-          <Outlet />
-        </main>
-      </div>
+            }}
+          />
+          <Header />
+          <main className="flex-1 w-full max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-2 sm:py-6 lg:py-8">
+            <Outlet />
+          </main>
+        </div>
+      </AuthProvider>
     );
   },
 });

--- a/src/routes/complete-profile.lazy.tsx
+++ b/src/routes/complete-profile.lazy.tsx
@@ -1,0 +1,188 @@
+import { createLazyFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import toast from 'react-hot-toast';
+import { useAuth } from '../contexts/useAuth';
+import { supabase } from '../lib/supabase';
+
+const profileSchema = z.object({
+  firstName: z.string().max(100).optional().or(z.literal('')),
+  lastName: z.string().max(100).optional().or(z.literal('')),
+  phone: z.string().max(50).optional().or(z.literal('')),
+});
+
+type ProfileForm = z.infer<typeof profileSchema>;
+
+function splitFullName(fullName?: string): { first: string; last: string } {
+  if (!fullName) return { first: '', last: '' };
+  const parts = fullName.trim().split(/\s+/);
+  return {
+    first: parts[0] ?? '',
+    last: parts.slice(1).join(' '),
+  };
+}
+
+export function CompleteProfile() {
+  const navigate = useNavigate();
+  const { user, loading } = useAuth();
+
+  if (!loading && !user) {
+    navigate({ to: '/plans' });
+    return null;
+  }
+
+  if (loading) {
+    return null;
+  }
+
+  return <CompleteProfileForm user={user!} />;
+}
+
+function CompleteProfileForm({
+  user,
+}: {
+  user: { user_metadata: Record<string, unknown> };
+}) {
+  const navigate = useNavigate();
+  const metadata = user.user_metadata;
+  const { first, last } = splitFullName(metadata.full_name as string);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<ProfileForm>({
+    resolver: zodResolver(profileSchema),
+    defaultValues: {
+      firstName: (metadata.first_name as string) ?? first,
+      lastName: (metadata.last_name as string) ?? last,
+      phone: (metadata.phone as string) ?? '',
+    },
+  });
+
+  async function onSubmit(values: ProfileForm) {
+    const data: Record<string, string> = {};
+    if (values.firstName) data.first_name = values.firstName;
+    if (values.lastName) data.last_name = values.lastName;
+    if (values.phone) data.phone = values.phone;
+
+    if (Object.keys(data).length === 0) {
+      navigate({ to: '/plans' });
+      return;
+    }
+
+    const { error } = await supabase.auth.updateUser({ data });
+
+    if (error) {
+      toast.error(error.message);
+      return;
+    }
+
+    toast.success('Profile updated');
+    navigate({ to: '/plans' });
+  }
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-sm sm:p-8">
+        <h1 className="text-2xl font-semibold text-gray-900">
+          Complete your profile
+        </h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Add your details so your trip buddies know who you are. All fields are
+          optional.
+        </p>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-4">
+          <div>
+            <label
+              htmlFor="firstName"
+              className="block text-sm font-medium text-gray-700"
+            >
+              First name
+            </label>
+            <input
+              id="firstName"
+              type="text"
+              autoComplete="given-name"
+              {...register('firstName')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              placeholder="Alex"
+            />
+            {errors.firstName && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.firstName.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="lastName"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Last name
+            </label>
+            <input
+              id="lastName"
+              type="text"
+              autoComplete="family-name"
+              {...register('lastName')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              placeholder="Guberman"
+            />
+            {errors.lastName && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.lastName.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="phone"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Phone
+            </label>
+            <input
+              id="phone"
+              type="tel"
+              autoComplete="tel"
+              {...register('phone')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              placeholder="+1 234 567 890"
+            />
+            {errors.phone && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.phone.message}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? 'Saving...' : 'Save & Continue'}
+          </button>
+        </form>
+
+        <p className="mt-4 text-center">
+          <Link
+            to="/plans"
+            className="text-sm font-medium text-gray-500 hover:text-gray-700"
+          >
+            Skip for now
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export const Route = createLazyFileRoute('/complete-profile')({
+  component: CompleteProfile,
+});

--- a/src/routes/signin.lazy.tsx
+++ b/src/routes/signin.lazy.tsx
@@ -1,0 +1,171 @@
+import { createLazyFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import toast from 'react-hot-toast';
+import { supabase } from '../lib/supabase';
+
+const signInSchema = z.object({
+  email: z.string().email('Please enter a valid email'),
+  password: z.string().min(6, 'Password must be at least 6 characters'),
+});
+
+type SignInForm = z.infer<typeof signInSchema>;
+
+export function SignIn() {
+  const navigate = useNavigate();
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SignInForm>({
+    resolver: zodResolver(signInSchema),
+  });
+
+  async function onSubmit(values: SignInForm) {
+    const { error } = await supabase.auth.signInWithPassword({
+      email: values.email,
+      password: values.password,
+    });
+
+    if (error) {
+      toast.error(error.message);
+      return;
+    }
+
+    navigate({ to: '/plans' });
+  }
+
+  async function handleGoogleSignIn() {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/plans`,
+      },
+    });
+
+    if (error) {
+      toast.error(error.message);
+      return;
+    }
+
+    if (!data.url) {
+      navigate({ to: '/plans' });
+    }
+  }
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-sm sm:p-8">
+        <h1 className="text-2xl font-semibold text-gray-900">Sign in</h1>
+        <p className="mt-1 text-sm text-gray-600">Welcome back to Chillist.</p>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              {...register('email')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              placeholder="you@example.com"
+            />
+            {errors.email && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              {...register('password')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              placeholder="Your password"
+            />
+            {errors.password && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? 'Signing in...' : 'Sign In'}
+          </button>
+        </form>
+
+        <div className="mt-6">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-300" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="bg-white px-2 text-gray-500">or</span>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleGoogleSignIn}
+            className="mt-4 flex w-full items-center justify-center gap-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24">
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+              />
+            </svg>
+            Sign in with Google
+          </button>
+        </div>
+
+        <p className="mt-6 text-center text-sm text-gray-600">
+          Don&apos;t have an account?{' '}
+          <Link
+            to="/signup"
+            className="font-medium text-blue-600 hover:text-blue-500"
+          >
+            Sign up
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export const Route = createLazyFileRoute('/signin')({
+  component: SignIn,
+});

--- a/src/routes/signup.lazy.tsx
+++ b/src/routes/signup.lazy.tsx
@@ -1,0 +1,220 @@
+import { createLazyFileRoute, Link, useNavigate } from '@tanstack/react-router';
+import { useForm } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { z } from 'zod';
+import toast from 'react-hot-toast';
+import { useState } from 'react';
+import { supabase } from '../lib/supabase';
+
+const signUpSchema = z.object({
+  email: z.string().email('Please enter a valid email'),
+  password: z.string().min(6, 'Password must be at least 6 characters'),
+});
+
+type SignUpForm = z.infer<typeof signUpSchema>;
+
+export function SignUp() {
+  const navigate = useNavigate();
+  const [confirmationSent, setConfirmationSent] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<SignUpForm>({
+    resolver: zodResolver(signUpSchema),
+  });
+
+  async function onSubmit(values: SignUpForm) {
+    const { data, error } = await supabase.auth.signUp({
+      email: values.email,
+      password: values.password,
+    });
+
+    if (error) {
+      toast.error(error.message);
+      return;
+    }
+
+    if (data.session) {
+      navigate({ to: '/complete-profile' });
+    } else {
+      setConfirmationSent(true);
+    }
+  }
+
+  async function handleGoogleSignUp() {
+    const { data, error } = await supabase.auth.signInWithOAuth({
+      provider: 'google',
+      options: {
+        redirectTo: `${window.location.origin}/complete-profile`,
+      },
+    });
+
+    if (error) {
+      toast.error(error.message);
+      return;
+    }
+
+    if (!data.url) {
+      navigate({ to: '/complete-profile' });
+    }
+  }
+
+  if (confirmationSent) {
+    return (
+      <div className="flex min-h-[60vh] items-center justify-center">
+        <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-sm sm:p-8">
+          <div className="text-center">
+            <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-green-100">
+              <svg
+                className="h-6 w-6 text-green-600"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth="1.5"
+                stroke="currentColor"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  d="M21.75 6.75v10.5a2.25 2.25 0 01-2.25 2.25h-15a2.25 2.25 0 01-2.25-2.25V6.75m19.5 0A2.25 2.25 0 0019.5 4.5h-15a2.25 2.25 0 00-2.25 2.25m19.5 0v.243a2.25 2.25 0 01-1.07 1.916l-7.5 4.615a2.25 2.25 0 01-2.36 0L3.32 8.91a2.25 2.25 0 01-1.07-1.916V6.75"
+                />
+              </svg>
+            </div>
+            <h2 className="text-xl font-semibold text-gray-900">
+              Check your email
+            </h2>
+            <p className="mt-2 text-sm text-gray-600">
+              We sent a confirmation link to your email. Please check your inbox
+              and click the link to activate your account.
+            </p>
+            <Link
+              to="/signin"
+              className="mt-6 inline-block text-sm font-medium text-blue-600 hover:text-blue-500"
+            >
+              Go to Sign In
+            </Link>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex min-h-[60vh] items-center justify-center">
+      <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-sm sm:p-8">
+        <h1 className="text-2xl font-semibold text-gray-900">
+          Create an account
+        </h1>
+        <p className="mt-1 text-sm text-gray-600">
+          Sign up to start planning with Chillist.
+        </p>
+
+        <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-4">
+          <div>
+            <label
+              htmlFor="email"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Email
+            </label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              {...register('email')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              placeholder="you@example.com"
+            />
+            {errors.email && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.email.message}
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label
+              htmlFor="password"
+              className="block text-sm font-medium text-gray-700"
+            >
+              Password
+            </label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="new-password"
+              {...register('password')}
+              className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+              placeholder="At least 6 characters"
+            />
+            {errors.password && (
+              <p className="mt-1 text-sm text-red-600">
+                {errors.password.message}
+              </p>
+            )}
+          </div>
+
+          <button
+            type="submit"
+            disabled={isSubmitting}
+            className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? 'Creating account...' : 'Sign Up'}
+          </button>
+        </form>
+
+        <div className="mt-6">
+          <div className="relative">
+            <div className="absolute inset-0 flex items-center">
+              <div className="w-full border-t border-gray-300" />
+            </div>
+            <div className="relative flex justify-center text-sm">
+              <span className="bg-white px-2 text-gray-500">or</span>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={handleGoogleSignUp}
+            className="mt-4 flex w-full items-center justify-center gap-3 rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none"
+          >
+            <svg className="h-5 w-5" viewBox="0 0 24 24">
+              <path
+                d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92a5.06 5.06 0 01-2.2 3.32v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.1z"
+                fill="#4285F4"
+              />
+              <path
+                d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z"
+                fill="#34A853"
+              />
+              <path
+                d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l2.85-2.22.81-.62z"
+                fill="#FBBC05"
+              />
+              <path
+                d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z"
+                fill="#EA4335"
+              />
+            </svg>
+            Sign up with Google
+          </button>
+        </div>
+
+        <p className="mt-6 text-center text-sm text-gray-600">
+          Already have an account?{' '}
+          <Link
+            to="/signin"
+            className="font-medium text-blue-600 hover:text-blue-500"
+          >
+            Sign in
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}
+
+export const Route = createLazyFileRoute('/signup')({
+  component: SignUp,
+});

--- a/tests/helpers/supabase-mock.ts
+++ b/tests/helpers/supabase-mock.ts
@@ -1,0 +1,61 @@
+import { vi } from 'vitest';
+
+interface MockSession {
+  access_token: string;
+  refresh_token: string;
+  user: {
+    id: string;
+    email: string;
+    user_metadata: Record<string, unknown>;
+  };
+}
+
+const DEFAULT_SESSION: MockSession = {
+  access_token: 'mock-access-token-xyz',
+  refresh_token: 'mock-refresh-token-xyz',
+  user: {
+    id: '00000000-0000-0000-0000-000000000001',
+    email: 'test@chillist.dev',
+    user_metadata: { full_name: 'Test User' },
+  },
+};
+
+export function createSupabaseMock(
+  overrides?: Partial<{ session: MockSession | null }>
+) {
+  const session = overrides?.session === undefined ? null : overrides.session;
+
+  return {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: { session },
+        error: null,
+      }),
+      signUp: vi.fn().mockResolvedValue({
+        data: { session: null, user: null },
+        error: null,
+      }),
+      signInWithPassword: vi.fn().mockResolvedValue({
+        data: { session, user: session?.user ?? null },
+        error: null,
+      }),
+      signInWithOAuth: vi.fn().mockResolvedValue({
+        data: { provider: 'google', url: 'https://accounts.google.com' },
+        error: null,
+      }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
+      updateUser: vi.fn().mockResolvedValue({
+        data: { user: session?.user ?? null },
+        error: null,
+      }),
+      onAuthStateChange: vi.fn().mockReturnValue({
+        data: {
+          subscription: { unsubscribe: vi.fn() },
+        },
+      }),
+    },
+  };
+}
+
+export { DEFAULT_SESSION };
+export type { MockSession };

--- a/tests/integration/auth-flow.test.tsx
+++ b/tests/integration/auth-flow.test.tsx
@@ -1,0 +1,519 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  vi,
+} from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { FastifyInstance } from 'fastify';
+import { buildServer } from '../../api/server';
+import { supabase } from '../../src/lib/supabase';
+import AuthProvider from '../../src/contexts/AuthProvider';
+import Header from '../../src/components/Header';
+import { SignUp } from '../../src/routes/signup.lazy';
+import { SignIn } from '../../src/routes/signin.lazy';
+import { CompleteProfile } from '../../src/routes/complete-profile.lazy';
+
+const mockSupabase = vi.mocked(supabase);
+
+vi.mock('react-hot-toast', () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  createLazyFileRoute: () => () => ({ component: undefined }),
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => vi.fn(),
+}));
+
+import toast from 'react-hot-toast';
+
+function makeFakeJwt(email: string, userId: string): string {
+  const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
+  const payload = btoa(
+    JSON.stringify({
+      sub: userId,
+      email,
+      role: 'authenticated',
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 3600,
+    })
+  );
+  return `${header}.${payload}.mock-signature`;
+}
+
+interface MockSession {
+  access_token: string;
+  refresh_token: string;
+  expires_in: number;
+  token_type: string;
+  user: {
+    id: string;
+    email: string;
+    user_metadata: Record<string, unknown>;
+    aud: string;
+    role: string;
+  };
+}
+
+function buildMockSession(email: string): MockSession {
+  const userId = crypto.randomUUID();
+  return {
+    access_token: makeFakeJwt(email, userId),
+    refresh_token: `mock-refresh-${userId}`,
+    expires_in: 3600,
+    token_type: 'bearer',
+    user: {
+      id: userId,
+      email,
+      user_metadata: { full_name: email.split('@')[0] },
+      aud: 'authenticated',
+      role: 'authenticated',
+    },
+  };
+}
+
+let server: FastifyInstance;
+let authChangeCallback: (...args: unknown[]) => void;
+let currentSession: MockSession | null;
+
+beforeAll(async () => {
+  server = await buildServer({ persist: false, logger: false });
+  await server.listen({ port: 0, host: '127.0.0.1' });
+  const addr = server.server.address() as { port: number };
+  vi.stubEnv('VITE_API_URL', `http://127.0.0.1:${addr.port}`);
+});
+
+afterAll(async () => {
+  vi.unstubAllEnvs();
+  await server.close();
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  currentSession = null;
+  authChangeCallback = () => {};
+
+  mockSupabase.auth.getSession.mockImplementation(async () => ({
+    data: { session: currentSession },
+    error: null,
+  }));
+
+  mockSupabase.auth.onAuthStateChange.mockImplementation(
+    (cb: (...args: unknown[]) => void) => {
+      authChangeCallback = cb;
+      return { data: { subscription: { unsubscribe: vi.fn() } } } as never;
+    }
+  );
+
+  mockSupabase.auth.signUp.mockImplementation(
+    async ({ email }: { email: string }) => {
+      const session = buildMockSession(email);
+      currentSession = session;
+      setTimeout(() => authChangeCallback('SIGNED_IN', session), 0);
+      return { data: { session, user: session.user }, error: null } as never;
+    }
+  );
+
+  mockSupabase.auth.signInWithPassword.mockImplementation(
+    async ({ email }: { email: string }) => {
+      const session = buildMockSession(email);
+      currentSession = session;
+      setTimeout(() => authChangeCallback('SIGNED_IN', session), 0);
+      return { data: { session, user: session.user }, error: null } as never;
+    }
+  );
+
+  mockSupabase.auth.signInWithOAuth.mockImplementation(async () => {
+    const session = buildMockSession('google-user@example.com');
+    currentSession = session;
+    setTimeout(() => authChangeCallback('SIGNED_IN', session), 0);
+    return { data: { provider: 'google', url: '' }, error: null } as never;
+  });
+
+  mockSupabase.auth.signOut.mockImplementation(async () => {
+    currentSession = null;
+    setTimeout(() => authChangeCallback('SIGNED_OUT', null), 0);
+    return { error: null } as never;
+  });
+
+  mockSupabase.auth.updateUser.mockImplementation(
+    async ({ data }: { data: Record<string, unknown> }) => {
+      if (currentSession) {
+        currentSession.user.user_metadata = {
+          ...currentSession.user.user_metadata,
+          ...data,
+        };
+        setTimeout(() => authChangeCallback('USER_UPDATED', currentSession), 0);
+      }
+      return {
+        data: { user: currentSession?.user ?? null },
+        error: null,
+      } as never;
+    }
+  );
+});
+
+function renderWithAuth(ui: React.ReactNode) {
+  return render(
+    <AuthProvider>
+      {ui}
+      <Header />
+    </AuthProvider>
+  );
+}
+
+describe('Auth Flow Integration', () => {
+  describe('Sign Up', () => {
+    it('email/password: Header and toast show same email after sign-up', async () => {
+      const testEmail = 'newuser@chillist.dev';
+      const user = userEvent.setup();
+
+      renderWithAuth(<SignUp />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByLabelText(/email/i), testEmail);
+      await user.type(screen.getByLabelText(/password/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /^sign up$/i }));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith(`Signed in as ${testEmail}`);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('User menu')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText('User menu'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('menu-email')).toHaveTextContent(testEmail);
+      });
+    });
+
+    it('Google OAuth: Header and toast show same email after sign-up', async () => {
+      const user = userEvent.setup();
+
+      renderWithAuth(<SignUp />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/sign up with google/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText(/sign up with google/i));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith(
+          'Signed in as google-user@example.com'
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('User menu')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText('User menu'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('menu-email')).toHaveTextContent(
+          'google-user@example.com'
+        );
+      });
+    });
+  });
+
+  describe('Sign In', () => {
+    it('email/password: Header and toast show same email after sign-in', async () => {
+      const testEmail = 'returning@chillist.dev';
+      const user = userEvent.setup();
+
+      renderWithAuth(<SignIn />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByLabelText(/email/i), testEmail);
+      await user.type(screen.getByLabelText(/password/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /^sign in$/i }));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith(`Signed in as ${testEmail}`);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('User menu')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText('User menu'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('menu-email')).toHaveTextContent(testEmail);
+      });
+    });
+
+    it('Google OAuth: Header and toast show same email after sign-in', async () => {
+      const user = userEvent.setup();
+
+      renderWithAuth(<SignIn />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/sign in with google/i)).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByText(/sign in with google/i));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith(
+          'Signed in as google-user@example.com'
+        );
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('User menu')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText('User menu'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('menu-email')).toHaveTextContent(
+          'google-user@example.com'
+        );
+      });
+    });
+  });
+
+  describe('Sign Out', () => {
+    it('clears auth state and shows Sign In / Sign Up links', async () => {
+      const testEmail = 'active@chillist.dev';
+      const session = buildMockSession(testEmail);
+      currentSession = session;
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session },
+        error: null,
+      } as never);
+
+      const user = userEvent.setup();
+
+      render(
+        <AuthProvider>
+          <Header />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('User menu')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText('User menu'));
+      await user.click(screen.getByText('Sign Out'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Sign In')).toBeInTheDocument();
+        expect(screen.getByText('Sign Up')).toBeInTheDocument();
+      });
+
+      expect(screen.queryByLabelText('User menu')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Complete Profile', () => {
+    it('email sign-up -> fill profile -> updateUser called with correct data', async () => {
+      const testEmail = 'fresh@chillist.dev';
+      const session = buildMockSession(testEmail);
+      currentSession = session;
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session },
+        error: null,
+      } as never);
+
+      const user = userEvent.setup();
+
+      renderWithAuth(<CompleteProfile />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
+      });
+
+      await user.clear(screen.getByLabelText(/first name/i));
+      await user.type(screen.getByLabelText(/first name/i), 'Fresh');
+      await user.clear(screen.getByLabelText(/last name/i));
+      await user.type(screen.getByLabelText(/last name/i), 'User');
+      await user.type(screen.getByLabelText(/phone/i), '+1234567890');
+      await user.click(
+        screen.getByRole('button', { name: /save & continue/i })
+      );
+
+      await waitFor(() => {
+        expect(mockSupabase.auth.updateUser).toHaveBeenCalledWith({
+          data: {
+            first_name: 'Fresh',
+            last_name: 'User',
+            phone: '+1234567890',
+          },
+        });
+      });
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Profile updated');
+      });
+    });
+
+    it('full flow: sign up -> complete profile -> updateUser -> toast', async () => {
+      const testEmail = 'fullflow@chillist.dev';
+      const user = userEvent.setup();
+
+      renderWithAuth(<SignUp />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+      });
+
+      await user.type(screen.getByLabelText(/email/i), testEmail);
+      await user.type(screen.getByLabelText(/password/i), 'password123');
+      await user.click(screen.getByRole('button', { name: /^sign up$/i }));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith(`Signed in as ${testEmail}`);
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('User menu')).toBeInTheDocument();
+      });
+
+      vi.mocked(toast.success).mockClear();
+
+      const { unmount } = render(
+        <AuthProvider>
+          <CompleteProfile />
+        </AuthProvider>
+      );
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
+      });
+
+      await user.clear(screen.getByLabelText(/first name/i));
+      await user.type(screen.getByLabelText(/first name/i), 'Full');
+      await user.type(screen.getByLabelText(/last name/i), 'Flow');
+      await user.click(
+        screen.getByRole('button', { name: /save & continue/i })
+      );
+
+      await waitFor(() => {
+        expect(mockSupabase.auth.updateUser).toHaveBeenCalledWith({
+          data: { first_name: 'Full', last_name: 'Flow' },
+        });
+        expect(toast.success).toHaveBeenCalledWith('Profile updated');
+      });
+
+      unmount();
+    });
+
+    it('update profile -> Header reflects new name in dropdown', async () => {
+      const testEmail = 'reflect@chillist.dev';
+      const session = buildMockSession(testEmail);
+      currentSession = session;
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session },
+        error: null,
+      } as never);
+
+      const user = userEvent.setup();
+
+      renderWithAuth(<CompleteProfile />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
+      });
+
+      await user.clear(screen.getByLabelText(/first name/i));
+      await user.type(screen.getByLabelText(/first name/i), 'Reflected');
+      await user.clear(screen.getByLabelText(/last name/i));
+      await user.type(screen.getByLabelText(/last name/i), 'Name');
+      await user.click(
+        screen.getByRole('button', { name: /save & continue/i })
+      );
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith('Profile updated');
+      });
+
+      await waitFor(() => {
+        expect(screen.getByLabelText('User menu')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByLabelText('User menu'));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('menu-display-name')).toHaveTextContent(
+          'Reflected'
+        );
+      });
+    });
+
+    it('Google sign-up -> pre-fills name from metadata -> skip navigates away', async () => {
+      const session = buildMockSession('google-user@example.com');
+      session.user.user_metadata = {
+        full_name: 'Google User',
+        avatar_url: 'https://photo.example.com/pic.jpg',
+      };
+      currentSession = session;
+
+      mockSupabase.auth.getSession.mockResolvedValue({
+        data: { session },
+        error: null,
+      } as never);
+
+      renderWithAuth(<CompleteProfile />);
+
+      await waitFor(() => {
+        expect(screen.getByLabelText(/first name/i)).toHaveValue('Google');
+        expect(screen.getByLabelText(/last name/i)).toHaveValue('User');
+      });
+
+      expect(screen.getByText(/skip for now/i).closest('a')).toHaveAttribute(
+        'href',
+        '/plans'
+      );
+    });
+  });
+
+  describe('Email consistency', () => {
+    it('JWT email decoded by /auth/me matches session email for any address', async () => {
+      const emails = [
+        'alice@test.com',
+        'bob+tag@example.org',
+        'user.name@sub.domain.co',
+      ];
+
+      for (const email of emails) {
+        const session = buildMockSession(email);
+
+        const response = await server.inject({
+          method: 'GET',
+          url: '/auth/me',
+          headers: {
+            authorization: `Bearer ${session.access_token}`,
+          },
+        });
+
+        const body = response.json() as { user: { email: string } };
+        expect(body.user.email).toBe(email);
+        expect(body.user.email).toBe(session.user.email);
+      }
+    });
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,1 +1,33 @@
 import '@testing-library/jest-dom';
+import { vi } from 'vitest';
+
+vi.mock('../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: { session: null },
+        error: null,
+      }),
+      signUp: vi.fn().mockResolvedValue({
+        data: { session: null, user: null },
+        error: null,
+      }),
+      signInWithPassword: vi.fn().mockResolvedValue({
+        data: { session: null, user: null },
+        error: null,
+      }),
+      signInWithOAuth: vi.fn().mockResolvedValue({
+        data: { provider: 'google', url: '' },
+        error: null,
+      }),
+      signOut: vi.fn().mockResolvedValue({ error: null }),
+      updateUser: vi.fn().mockResolvedValue({
+        data: { user: null },
+        error: null,
+      }),
+      onAuthStateChange: vi.fn().mockReturnValue({
+        data: { subscription: { unsubscribe: vi.fn() } },
+      }),
+    },
+  },
+}));

--- a/tests/unit/components/Header.test.tsx
+++ b/tests/unit/components/Header.test.tsx
@@ -1,0 +1,281 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('../../../src/contexts/useAuth');
+
+import { useAuth } from '../../../src/contexts/useAuth';
+import Header from '../../../src/components/Header';
+
+const mockUseAuth = vi.mocked(useAuth);
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    ...props
+  }: {
+    children: React.ReactNode;
+    to: string;
+    onClick?: () => void;
+  }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+function authUser(overrides?: {
+  email?: string;
+  user_metadata?: Record<string, unknown>;
+}) {
+  return {
+    session: {} as never,
+    user: {
+      email: overrides?.email ?? 'test@chillist.dev',
+      user_metadata: overrides?.user_metadata ?? {},
+    } as never,
+    loading: false,
+    signOut: vi.fn(),
+  };
+}
+
+describe('Header', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('unauthenticated', () => {
+    it('shows Sign In and Sign Up links', () => {
+      mockUseAuth.mockReturnValue({
+        session: null,
+        user: null,
+        loading: false,
+        signOut: vi.fn(),
+      });
+
+      render(<Header />);
+
+      expect(screen.getByText('Sign In')).toBeInTheDocument();
+      expect(screen.getByText('Sign Up')).toBeInTheDocument();
+    });
+
+    it('hides auth UI while loading', () => {
+      mockUseAuth.mockReturnValue({
+        session: null,
+        user: null,
+        loading: true,
+        signOut: vi.fn(),
+      });
+
+      render(<Header />);
+
+      expect(screen.queryByText('Sign In')).not.toBeInTheDocument();
+      expect(screen.queryByText('Sign Out')).not.toBeInTheDocument();
+    });
+
+    it('Sign In link points to /signin', () => {
+      mockUseAuth.mockReturnValue({
+        session: null,
+        user: null,
+        loading: false,
+        signOut: vi.fn(),
+      });
+
+      render(<Header />);
+      expect(screen.getByText('Sign In').closest('a')).toHaveAttribute(
+        'href',
+        '/signin'
+      );
+    });
+
+    it('Sign Up link points to /signup', () => {
+      mockUseAuth.mockReturnValue({
+        session: null,
+        user: null,
+        loading: false,
+        signOut: vi.fn(),
+      });
+
+      render(<Header />);
+      expect(screen.getByText('Sign Up').closest('a')).toHaveAttribute(
+        'href',
+        '/signup'
+      );
+    });
+  });
+
+  describe('authenticated - avatar button', () => {
+    it('shows initials from first_name + last_name', () => {
+      mockUseAuth.mockReturnValue(
+        authUser({
+          user_metadata: { first_name: 'Alex', last_name: 'Guberman' },
+        })
+      );
+
+      render(<Header />);
+      expect(screen.getByText('AG')).toBeInTheDocument();
+    });
+
+    it('shows initials from full_name when no first/last', () => {
+      mockUseAuth.mockReturnValue(
+        authUser({ user_metadata: { full_name: 'Jane Doe' } })
+      );
+
+      render(<Header />);
+      expect(screen.getByText('JD')).toBeInTheDocument();
+    });
+
+    it('shows first letter of email when no metadata', () => {
+      mockUseAuth.mockReturnValue(authUser({ email: 'test@chillist.dev' }));
+
+      render(<Header />);
+      expect(screen.getByText('T')).toBeInTheDocument();
+    });
+
+    it('does not show Sign In or Sign Up when authenticated', () => {
+      mockUseAuth.mockReturnValue(authUser());
+
+      render(<Header />);
+
+      expect(screen.queryByText('Sign In')).not.toBeInTheDocument();
+      expect(screen.queryByText('Sign Up')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('authenticated - user dropdown', () => {
+    it('opens dropdown on avatar click showing user details', async () => {
+      mockUseAuth.mockReturnValue(
+        authUser({
+          email: 'alex@chillist.dev',
+          user_metadata: {
+            first_name: 'Alex',
+            last_name: 'Guberman',
+            phone: '+972501234567',
+          },
+        })
+      );
+
+      const user = userEvent.setup();
+      render(<Header />);
+
+      await user.click(screen.getByLabelText('User menu'));
+
+      expect(screen.getByTestId('menu-display-name')).toHaveTextContent('Alex');
+      expect(screen.getByTestId('menu-email')).toHaveTextContent(
+        'alex@chillist.dev'
+      );
+      expect(screen.getByTestId('menu-phone')).toHaveTextContent(
+        '+972501234567'
+      );
+    });
+
+    it('hides phone when not set in metadata', async () => {
+      mockUseAuth.mockReturnValue(authUser({ email: 'no-phone@test.com' }));
+
+      const user = userEvent.setup();
+      render(<Header />);
+
+      await user.click(screen.getByLabelText('User menu'));
+
+      expect(screen.getByTestId('menu-email')).toHaveTextContent(
+        'no-phone@test.com'
+      );
+      expect(screen.queryByTestId('menu-phone')).not.toBeInTheDocument();
+    });
+
+    it('shows Edit Profile link pointing to /complete-profile', async () => {
+      mockUseAuth.mockReturnValue(authUser());
+
+      const user = userEvent.setup();
+      render(<Header />);
+
+      await user.click(screen.getByLabelText('User menu'));
+
+      const editLink = screen.getByText('Edit Profile');
+      expect(editLink.closest('a')).toHaveAttribute(
+        'href',
+        '/complete-profile'
+      );
+    });
+
+    it('shows Sign Out option in dropdown', async () => {
+      mockUseAuth.mockReturnValue(authUser());
+
+      const user = userEvent.setup();
+      render(<Header />);
+
+      await user.click(screen.getByLabelText('User menu'));
+
+      expect(screen.getByText('Sign Out')).toBeInTheDocument();
+    });
+
+    it('calls signOut when Sign Out is clicked in dropdown', async () => {
+      const signOutFn = vi.fn();
+      mockUseAuth.mockReturnValue({
+        ...authUser(),
+        signOut: signOutFn,
+      });
+
+      const user = userEvent.setup();
+      render(<Header />);
+
+      await user.click(screen.getByLabelText('User menu'));
+      await user.click(screen.getByText('Sign Out'));
+
+      expect(signOutFn).toHaveBeenCalledOnce();
+    });
+
+    it('closes dropdown after clicking Sign Out', async () => {
+      mockUseAuth.mockReturnValue(authUser());
+
+      const user = userEvent.setup();
+      render(<Header />);
+
+      await user.click(screen.getByLabelText('User menu'));
+      expect(screen.getByTestId('menu-email')).toBeInTheDocument();
+
+      await user.click(screen.getByText('Sign Out'));
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('menu-email')).not.toBeInTheDocument();
+      });
+    });
+
+    it('closes dropdown when clicking outside', async () => {
+      mockUseAuth.mockReturnValue(authUser());
+
+      const user = userEvent.setup();
+      render(<Header />);
+
+      await user.click(screen.getByLabelText('User menu'));
+      expect(screen.getByTestId('menu-email')).toBeInTheDocument();
+
+      await user.click(document.body);
+
+      await waitFor(() => {
+        expect(screen.queryByTestId('menu-email')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('authenticated - state transitions', () => {
+    it('shows Sign In and Sign Up after sign-out re-render', () => {
+      mockUseAuth.mockReturnValueOnce(authUser());
+
+      const { rerender } = render(<Header />);
+      expect(screen.getByLabelText('User menu')).toBeInTheDocument();
+
+      mockUseAuth.mockReturnValueOnce({
+        session: null,
+        user: null,
+        loading: false,
+        signOut: vi.fn(),
+      });
+
+      rerender(<Header />);
+      expect(screen.getByText('Sign In')).toBeInTheDocument();
+      expect(screen.getByText('Sign Up')).toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/contexts/AuthProvider.test.tsx
+++ b/tests/unit/contexts/AuthProvider.test.tsx
@@ -1,0 +1,239 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, act, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import AuthProvider from '../../../src/contexts/AuthProvider';
+import { useAuth } from '../../../src/contexts/useAuth';
+import { supabase } from '../../../src/lib/supabase';
+
+const mockSupabase = vi.mocked(supabase);
+
+function AuthConsumer() {
+  const { user, loading, signOut } = useAuth();
+
+  if (loading) return <div>Loading...</div>;
+  if (!user) return <div>Not authenticated</div>;
+
+  return (
+    <div>
+      <span data-testid="email">{user.email}</span>
+      <span data-testid="first-name">
+        {(user.user_metadata?.first_name as string) ?? ''}
+      </span>
+      <button onClick={signOut}>Sign Out</button>
+    </div>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <AuthProvider>
+      <AuthConsumer />
+    </AuthProvider>
+  );
+}
+
+describe('AuthProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    } as never);
+    mockSupabase.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe: vi.fn() } },
+    } as never);
+  });
+
+  it('shows not authenticated when no session', async () => {
+    renderWithProvider();
+    await waitFor(() => {
+      expect(screen.getByText('Not authenticated')).toBeInTheDocument();
+    });
+  });
+
+  it('shows user email when session exists', async () => {
+    const mockSession = {
+      access_token: 'test-token',
+      refresh_token: 'test-refresh',
+      user: {
+        id: 'user-1',
+        email: 'test@chillist.dev',
+        user_metadata: {},
+      },
+    };
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    } as never);
+
+    renderWithProvider();
+    await waitFor(() => {
+      expect(screen.getByTestId('email')).toHaveTextContent(
+        'test@chillist.dev'
+      );
+    });
+  });
+
+  it('calls supabase.auth.signOut when signOut is invoked', async () => {
+    const mockSession = {
+      access_token: 'test-token',
+      refresh_token: 'test-refresh',
+      user: {
+        id: 'user-1',
+        email: 'test@chillist.dev',
+        user_metadata: {},
+      },
+    };
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    } as never);
+
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('email')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByText('Sign Out'));
+    expect(mockSupabase.auth.signOut).toHaveBeenCalledOnce();
+  });
+
+  it('subscribes to onAuthStateChange on mount', () => {
+    renderWithProvider();
+    expect(mockSupabase.auth.onAuthStateChange).toHaveBeenCalledOnce();
+  });
+
+  it('unsubscribes on unmount', () => {
+    const unsubscribe = vi.fn();
+    mockSupabase.auth.onAuthStateChange.mockReturnValue({
+      data: { subscription: { unsubscribe } },
+    } as never);
+
+    const { unmount } = renderWithProvider();
+    unmount();
+
+    expect(unsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('updates state when onAuthStateChange fires SIGNED_IN', async () => {
+    let authCallback: (...args: unknown[]) => void = () => {};
+    mockSupabase.auth.onAuthStateChange.mockImplementation(
+      (cb: (...args: unknown[]) => void) => {
+        authCallback = cb;
+        return { data: { subscription: { unsubscribe: vi.fn() } } } as never;
+      }
+    );
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByText('Not authenticated')).toBeInTheDocument();
+    });
+
+    const newSession = {
+      access_token: 'new-token',
+      refresh_token: 'new-refresh',
+      user: {
+        id: 'user-2',
+        email: 'new@chillist.dev',
+        user_metadata: {},
+      },
+    };
+
+    await act(async () => {
+      authCallback('SIGNED_IN', newSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('email')).toHaveTextContent('new@chillist.dev');
+    });
+  });
+
+  it('clears state when onAuthStateChange fires SIGNED_OUT', async () => {
+    const mockSession = {
+      access_token: 'test-token',
+      refresh_token: 'test-refresh',
+      user: {
+        id: 'user-1',
+        email: 'test@chillist.dev',
+        user_metadata: {},
+      },
+    };
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: mockSession },
+      error: null,
+    } as never);
+
+    let authCallback: (...args: unknown[]) => void = () => {};
+    mockSupabase.auth.onAuthStateChange.mockImplementation(
+      (cb: (...args: unknown[]) => void) => {
+        authCallback = cb;
+        return { data: { subscription: { unsubscribe: vi.fn() } } } as never;
+      }
+    );
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('email')).toHaveTextContent(
+        'test@chillist.dev'
+      );
+    });
+
+    await act(async () => {
+      authCallback('SIGNED_OUT', null);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Not authenticated')).toBeInTheDocument();
+    });
+  });
+
+  it('updates user metadata when onAuthStateChange fires USER_UPDATED', async () => {
+    const initialSession = {
+      access_token: 'test-token',
+      refresh_token: 'test-refresh',
+      user: {
+        id: 'user-1',
+        email: 'test@chillist.dev',
+        user_metadata: {},
+      },
+    };
+    mockSupabase.auth.getSession.mockResolvedValue({
+      data: { session: initialSession },
+      error: null,
+    } as never);
+
+    let authCallback: (...args: unknown[]) => void = () => {};
+    mockSupabase.auth.onAuthStateChange.mockImplementation(
+      (cb: (...args: unknown[]) => void) => {
+        authCallback = cb;
+        return { data: { subscription: { unsubscribe: vi.fn() } } } as never;
+      }
+    );
+
+    renderWithProvider();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('first-name')).toHaveTextContent('');
+    });
+
+    const updatedSession = {
+      ...initialSession,
+      user: {
+        ...initialSession.user,
+        user_metadata: { first_name: 'Alex' },
+      },
+    };
+
+    await act(async () => {
+      authCallback('USER_UPDATED', updatedSession);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('first-name')).toHaveTextContent('Alex');
+    });
+  });
+});

--- a/tests/unit/contexts/useAuth.test.tsx
+++ b/tests/unit/contexts/useAuth.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useAuth } from '../../../src/contexts/useAuth';
+import AuthProvider from '../../../src/contexts/AuthProvider';
+import type { ReactNode } from 'react';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <AuthProvider>{children}</AuthProvider>;
+}
+
+describe('useAuth', () => {
+  it('throws when used outside AuthProvider', () => {
+    expect(() => {
+      renderHook(() => useAuth());
+    }).toThrow('useAuth must be used within an AuthProvider');
+  });
+
+  it('returns auth context values when inside AuthProvider', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current).toHaveProperty('session');
+    expect(result.current).toHaveProperty('user');
+    expect(result.current).toHaveProperty('loading');
+    expect(result.current).toHaveProperty('signOut');
+    expect(typeof result.current.signOut).toBe('function');
+  });
+
+  it('starts with null session and user', async () => {
+    const { result } = renderHook(() => useAuth(), { wrapper });
+
+    expect(result.current.session).toBeNull();
+    expect(result.current.user).toBeNull();
+  });
+});

--- a/tests/unit/core/auth-api.test.ts
+++ b/tests/unit/core/auth-api.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { authMeResponseSchema } from '../../../src/core/auth-api';
+
+describe('authMeResponseSchema', () => {
+  it('parses a valid response', () => {
+    const valid = {
+      user: {
+        id: '00000000-0000-0000-0000-000000000001',
+        email: 'test@chillist.dev',
+        role: 'authenticated',
+      },
+    };
+    expect(authMeResponseSchema.parse(valid)).toEqual(valid);
+  });
+
+  it('rejects response missing user', () => {
+    expect(() => authMeResponseSchema.parse({})).toThrow();
+  });
+
+  it('rejects response missing email', () => {
+    expect(() =>
+      authMeResponseSchema.parse({
+        user: { id: '1', role: 'authenticated' },
+      })
+    ).toThrow();
+  });
+
+  it('rejects response with extra fields but still parses core fields', () => {
+    const withExtra = {
+      user: {
+        id: '1',
+        email: 'test@test.com',
+        role: 'admin',
+        extra: 'field',
+      },
+    };
+    const parsed = authMeResponseSchema.parse(withExtra);
+    expect(parsed.user.email).toBe('test@test.com');
+  });
+});

--- a/tests/unit/routes/complete-profile.test.tsx
+++ b/tests/unit/routes/complete-profile.test.tsx
@@ -1,0 +1,235 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { supabase } from '../../../src/lib/supabase';
+
+const mockSupabase = vi.mocked(supabase);
+
+const mockNavigate = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  createLazyFileRoute: () => () => ({ component: undefined }),
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('../../../src/contexts/useAuth');
+
+import toast from 'react-hot-toast';
+import { useAuth } from '../../../src/contexts/useAuth';
+import { CompleteProfile } from '../../../src/routes/complete-profile.lazy';
+
+const mockUseAuth = vi.mocked(useAuth);
+
+function renderPage() {
+  return render(<CompleteProfile />);
+}
+
+describe('Complete Profile Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseAuth.mockReturnValue({
+      session: {} as never,
+      user: {
+        id: 'u1',
+        email: 'test@test.com',
+        user_metadata: {},
+      } as never,
+      loading: false,
+      signOut: vi.fn(),
+    });
+    mockSupabase.auth.updateUser.mockResolvedValue({
+      data: { user: {} },
+      error: null,
+    } as never);
+  });
+
+  it('renders first name, last name, and phone fields', () => {
+    renderPage();
+
+    expect(screen.getByLabelText(/first name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/last name/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/phone/i)).toBeInTheDocument();
+  });
+
+  it('renders Skip link to /plans', () => {
+    renderPage();
+
+    const link = screen.getByText(/skip for now/i);
+    expect(link.closest('a')).toHaveAttribute('href', '/plans');
+  });
+
+  it('renders Save & Continue button', () => {
+    renderPage();
+
+    expect(
+      screen.getByRole('button', { name: /save & continue/i })
+    ).toBeInTheDocument();
+  });
+
+  it('pre-fills fields from Google user_metadata (splits full_name)', () => {
+    mockUseAuth.mockReturnValue({
+      session: {} as never,
+      user: {
+        id: 'u1',
+        email: 'google@test.com',
+        user_metadata: { full_name: 'Alex Guberman' },
+      } as never,
+      loading: false,
+      signOut: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(screen.getByLabelText(/first name/i)).toHaveValue('Alex');
+    expect(screen.getByLabelText(/last name/i)).toHaveValue('Guberman');
+  });
+
+  it('pre-fills from existing first_name/last_name/phone metadata', () => {
+    mockUseAuth.mockReturnValue({
+      session: {} as never,
+      user: {
+        id: 'u1',
+        email: 'test@test.com',
+        user_metadata: {
+          first_name: 'Jamie',
+          last_name: 'Rivera',
+          phone: '+1234567890',
+        },
+      } as never,
+      loading: false,
+      signOut: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(screen.getByLabelText(/first name/i)).toHaveValue('Jamie');
+    expect(screen.getByLabelText(/last name/i)).toHaveValue('Rivera');
+    expect(screen.getByLabelText(/phone/i)).toHaveValue('+1234567890');
+  });
+
+  it('calls updateUser with validated data on submit', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/first name/i), 'Alex');
+    await user.type(screen.getByLabelText(/last name/i), 'Guberman');
+    await user.type(screen.getByLabelText(/phone/i), '+972501234567');
+    await user.click(screen.getByRole('button', { name: /save & continue/i }));
+
+    await waitFor(() => {
+      expect(mockSupabase.auth.updateUser).toHaveBeenCalledWith({
+        data: {
+          first_name: 'Alex',
+          last_name: 'Guberman',
+          phone: '+972501234567',
+        },
+      });
+    });
+  });
+
+  it('shows success toast and navigates to /plans on success', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/first name/i), 'Alex');
+    await user.click(screen.getByRole('button', { name: /save & continue/i }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Profile updated');
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/plans' });
+    });
+  });
+
+  it('shows error toast on updateUser failure', async () => {
+    mockSupabase.auth.updateUser.mockResolvedValue({
+      data: { user: null },
+      error: { message: 'Update failed' },
+    } as never);
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/first name/i), 'Alex');
+    await user.click(screen.getByRole('button', { name: /save & continue/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Update failed');
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('navigates to /plans without calling updateUser when all fields empty', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.click(screen.getByRole('button', { name: /save & continue/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/plans' });
+    });
+
+    expect(mockSupabase.auth.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('submits only filled fields when some are left empty', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/first name/i), 'Alex');
+    await user.click(screen.getByRole('button', { name: /save & continue/i }));
+
+    await waitFor(() => {
+      expect(mockSupabase.auth.updateUser).toHaveBeenCalledWith({
+        data: { first_name: 'Alex' },
+      });
+    });
+  });
+
+  it('shows validation error when first name exceeds 100 characters', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/first name/i), 'A'.repeat(101));
+    await user.click(screen.getByRole('button', { name: /save & continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/100/i)).toBeInTheDocument();
+    });
+
+    expect(mockSupabase.auth.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('shows validation error when phone exceeds 50 characters', async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/phone/i), '1'.repeat(51));
+    await user.click(screen.getByRole('button', { name: /save & continue/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/50/i)).toBeInTheDocument();
+    });
+
+    expect(mockSupabase.auth.updateUser).not.toHaveBeenCalled();
+  });
+
+  it('redirects unauthenticated users to /plans', () => {
+    mockUseAuth.mockReturnValue({
+      session: null,
+      user: null,
+      loading: false,
+      signOut: vi.fn(),
+    });
+
+    renderPage();
+
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/plans' });
+  });
+});

--- a/tests/unit/routes/signin.test.tsx
+++ b/tests/unit/routes/signin.test.tsx
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { supabase } from '../../../src/lib/supabase';
+
+const mockSupabase = vi.mocked(supabase);
+
+const mockNavigate = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  createLazyFileRoute: () => () => ({ component: undefined }),
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+import toast from 'react-hot-toast';
+import { SignIn } from '../../../src/routes/signin.lazy';
+
+function renderSignIn() {
+  return render(<SignIn />);
+}
+
+describe('Sign In Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.auth.signInWithPassword.mockResolvedValue({
+      data: {
+        session: { access_token: 'tok' },
+        user: { id: '1', email: 'a@b.com' },
+      },
+      error: null,
+    } as never);
+  });
+
+  it('renders email and password fields', async () => {
+    await renderSignIn();
+
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+  });
+
+  it('renders Sign in with Google button', async () => {
+    await renderSignIn();
+
+    expect(screen.getByText(/sign in with google/i)).toBeInTheDocument();
+  });
+
+  it('renders link to sign up page', async () => {
+    await renderSignIn();
+
+    const link = screen.getByText(/sign up/i);
+    expect(link.closest('a')).toHaveAttribute('href', '/signup');
+  });
+
+  it('shows validation error for empty email', async () => {
+    const user = userEvent.setup();
+    await renderSignIn();
+
+    await user.click(screen.getByRole('button', { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/valid email/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error for short password', async () => {
+    const user = userEvent.setup();
+    await renderSignIn();
+
+    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
+    await user.type(screen.getByLabelText(/password/i), '123');
+    await user.click(screen.getByRole('button', { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/at least 6/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls signInWithPassword and navigates on success', async () => {
+    const user = userEvent.setup();
+    await renderSignIn();
+
+    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(mockSupabase.auth.signInWithPassword).toHaveBeenCalledWith({
+        email: 'test@test.com',
+        password: 'password123',
+      });
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/plans' });
+    });
+  });
+
+  it('shows toast error on sign-in failure', async () => {
+    mockSupabase.auth.signInWithPassword.mockResolvedValue({
+      data: { session: null, user: null },
+      error: { message: 'Invalid credentials' },
+    } as never);
+
+    const user = userEvent.setup();
+    await renderSignIn();
+
+    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
+    await user.type(screen.getByLabelText(/password/i), 'wrongpass');
+    await user.click(screen.getByRole('button', { name: /^sign in$/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Invalid credentials');
+    });
+  });
+
+  it('calls signInWithOAuth with redirectTo pointing to /plans', async () => {
+    const user = userEvent.setup();
+    renderSignIn();
+
+    await user.click(screen.getByText(/sign in with google/i));
+
+    expect(mockSupabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: expect.objectContaining({
+        redirectTo: expect.stringContaining('/plans'),
+      }),
+    });
+  });
+
+  it('navigates to /plans when OAuth returns no redirect URL (mock mode)', async () => {
+    mockSupabase.auth.signInWithOAuth.mockResolvedValueOnce({
+      data: { provider: 'google', url: '' },
+      error: null,
+    } as never);
+
+    const user = userEvent.setup();
+    renderSignIn();
+
+    await user.click(screen.getByText(/sign in with google/i));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/plans' });
+    });
+  });
+
+  it('does not navigate when OAuth returns a redirect URL (real Supabase)', async () => {
+    mockSupabase.auth.signInWithOAuth.mockResolvedValueOnce({
+      data: { provider: 'google', url: 'https://accounts.google.com/o/oauth2' },
+      error: null,
+    } as never);
+
+    const user = userEvent.setup();
+    renderSignIn();
+
+    await user.click(screen.getByText(/sign in with google/i));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/routes/signup.test.tsx
+++ b/tests/unit/routes/signup.test.tsx
@@ -1,0 +1,194 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { supabase } from '../../../src/lib/supabase';
+
+const mockSupabase = vi.mocked(supabase);
+
+const mockNavigate = vi.fn();
+vi.mock('@tanstack/react-router', () => ({
+  createLazyFileRoute: () => () => ({ component: undefined }),
+  Link: ({ children, to }: { children: React.ReactNode; to: string }) => (
+    <a href={to}>{children}</a>
+  ),
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('react-hot-toast', () => ({
+  default: { error: vi.fn(), success: vi.fn() },
+}));
+
+import toast from 'react-hot-toast';
+import { SignUp } from '../../../src/routes/signup.lazy';
+
+function renderSignUp() {
+  return render(<SignUp />);
+}
+
+describe('Sign Up Page', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSupabase.auth.signUp.mockResolvedValue({
+      data: { session: null, user: null },
+      error: null,
+    } as never);
+  });
+
+  it('renders email and password fields', async () => {
+    await renderSignUp();
+
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/password/i)).toBeInTheDocument();
+  });
+
+  it('renders link to sign in page', async () => {
+    await renderSignUp();
+
+    const link = screen.getByText(/sign in/i);
+    expect(link.closest('a')).toHaveAttribute('href', '/signin');
+  });
+
+  it('shows validation error for empty email', async () => {
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await user.click(screen.getByRole('button', { name: /^sign up$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/valid email/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows validation error for short password', async () => {
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await user.type(screen.getByLabelText(/email/i), 'test@test.com');
+    await user.type(screen.getByLabelText(/password/i), '12');
+    await user.click(screen.getByRole('button', { name: /^sign up$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/at least 6/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows confirmation message when email confirmation is required', async () => {
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await user.type(screen.getByLabelText(/email/i), 'new@test.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /^sign up$/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/check your email/i)).toBeInTheDocument();
+    });
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('redirects to /complete-profile when session is returned (no confirmation)', async () => {
+    mockSupabase.auth.signUp.mockResolvedValue({
+      data: {
+        session: { access_token: 'tok' },
+        user: { id: '1', email: 'new@test.com' },
+      },
+      error: null,
+    } as never);
+
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await user.type(screen.getByLabelText(/email/i), 'new@test.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /^sign up$/i }));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/complete-profile' });
+    });
+  });
+
+  it('shows toast error on sign-up failure', async () => {
+    mockSupabase.auth.signUp.mockResolvedValue({
+      data: { session: null, user: null },
+      error: { message: 'Email already registered' },
+    } as never);
+
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await user.type(screen.getByLabelText(/email/i), 'existing@test.com');
+    await user.type(screen.getByLabelText(/password/i), 'password123');
+    await user.click(screen.getByRole('button', { name: /^sign up$/i }));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Email already registered');
+    });
+  });
+
+  it('renders Sign up with Google button', async () => {
+    await renderSignUp();
+
+    expect(screen.getByText(/sign up with google/i)).toBeInTheDocument();
+  });
+
+  it('calls signInWithOAuth with redirectTo pointing to /complete-profile', async () => {
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await user.click(screen.getByText(/sign up with google/i));
+
+    expect(mockSupabase.auth.signInWithOAuth).toHaveBeenCalledWith({
+      provider: 'google',
+      options: expect.objectContaining({
+        redirectTo: expect.stringContaining('/complete-profile'),
+      }),
+    });
+  });
+
+  it('navigates to /complete-profile when OAuth returns no redirect URL (mock mode)', async () => {
+    mockSupabase.auth.signInWithOAuth.mockResolvedValueOnce({
+      data: { provider: 'google', url: '' },
+      error: null,
+    } as never);
+
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await user.click(screen.getByText(/sign up with google/i));
+
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledWith({ to: '/complete-profile' });
+    });
+  });
+
+  it('does not navigate when OAuth returns a redirect URL (real Supabase)', async () => {
+    mockSupabase.auth.signInWithOAuth.mockResolvedValueOnce({
+      data: { provider: 'google', url: 'https://accounts.google.com/o/oauth2' },
+      error: null,
+    } as never);
+
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await user.click(screen.getByText(/sign up with google/i));
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('shows toast error when Google OAuth fails', async () => {
+    mockSupabase.auth.signInWithOAuth.mockResolvedValueOnce({
+      data: { provider: 'google', url: null },
+      error: { message: 'OAuth provider error' },
+    } as never);
+
+    const user = userEvent.setup();
+    await renderSignUp();
+
+    await user.click(screen.getByText(/sign up with google/i));
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('OAuth provider error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add email/password and Google OAuth sign-up/sign-in pages with Zod validation and React Hook Form
- Add post-signup `/complete-profile` page where users can optionally set first name, last name, and phone (saved to Supabase `user_metadata` via `updateUser`)
- Replace Header's plain email text with avatar initials button + dropdown menu showing user details, Edit Profile link, and Sign Out
- Fix mock server `/auth/me` to decode JWT payload for email consistency instead of hardcoded values
- Fix mock auth `updateUser` to fire `USER_UPDATED` event so AuthProvider state updates reactively
- Move toast position to `bottom-center` with shorter success duration (2s)
- Add 10 cross-boundary integration tests (auth-flow.test.tsx) that wire mock Supabase + real mock server + AuthProvider + Header together
- Add 35+ auth-related unit tests across sign-up, sign-in, complete-profile, Header, and AuthProvider

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] 264 unit + integration tests pass (32 test files)
- [ ] Manual: sign up with email/password → redirected to /complete-profile → fill name → save → Header shows initials + name in dropdown
- [ ] Manual: sign up with Google OAuth → /complete-profile pre-fills name from Google → save or skip
- [ ] Manual: sign in (email or Google) → goes to /plans directly
- [ ] Manual: click avatar → dropdown shows email, name, phone → Edit Profile links to /complete-profile
- [ ] Manual: sign out from dropdown → Header shows Sign In / Sign Up


Made with [Cursor](https://cursor.com)