### PR TITLE
feat: add i18n support with Hebrew and English translations

### DIFF
--- a/api/mock-data.json
+++ b/api/mock-data.json
@@ -98,6 +98,30 @@
       ],
       "createdAt": "2026-02-14T15:24:35.859Z",
       "updatedAt": "2026-02-14T15:24:35.859Z"
+    },
+    {
+      "planId": "fd25aca3-0ce9-4e6a-842c-170808e12eb7",
+      "createdAt": "2026-02-21T12:00:04.108Z",
+      "updatedAt": "2026-02-21T12:00:04.108Z",
+      "description": "חוגגים יום הולדת לדודיניו",
+      "endDate": "2026-02-21T19:05:00Z",
+      "location": {
+        "locationId": "53953405-e1fc-585f-b3eb-2498983cf946",
+        "name": "בית של דודו",
+        "country": "ישראל",
+        "region": "",
+        "city": "אזור"
+      },
+      "ownerParticipantId": "9a69465a-6421-4298-b0b7-2c3d61ef9a2f",
+      "participantIds": [
+        "9a69465a-6421-4298-b0b7-2c3d61ef9a2f",
+        "a581b939-36b4-4f9a-8b3d-9047953398f9",
+        "23e04bdb-8dfe-4b12-8167-737fc83faee3"
+      ],
+      "startDate": "2026-02-21T15:59:00Z",
+      "status": "draft",
+      "title": "חגיגה",
+      "visibility": "public"
     }
   ],
   "participants": [
@@ -230,6 +254,45 @@
       "contactEmail": "dana@example.com",
       "createdAt": "2025-12-15T10:41:13.099Z",
       "updatedAt": "2025-12-15T10:41:13.099Z"
+    },
+    {
+      "participantId": "9a69465a-6421-4298-b0b7-2c3d61ef9a2f",
+      "planId": "fd25aca3-0ce9-4e6a-842c-170808e12eb7",
+      "name": "אלכס",
+      "lastName": "גוברמן",
+      "contactPhone": "0546340926",
+      "displayName": null,
+      "role": "owner",
+      "avatarUrl": null,
+      "contactEmail": null,
+      "createdAt": "2026-02-21T12:00:04.108Z",
+      "updatedAt": "2026-02-21T12:00:04.108Z"
+    },
+    {
+      "participantId": "a581b939-36b4-4f9a-8b3d-9047953398f9",
+      "planId": "fd25aca3-0ce9-4e6a-842c-170808e12eb7",
+      "name": "דודו",
+      "lastName": "אלבז",
+      "contactPhone": "0546468567",
+      "displayName": null,
+      "role": "participant",
+      "avatarUrl": null,
+      "contactEmail": null,
+      "createdAt": "2026-02-21T12:00:04.108Z",
+      "updatedAt": "2026-02-21T12:00:04.108Z"
+    },
+    {
+      "participantId": "23e04bdb-8dfe-4b12-8167-737fc83faee3",
+      "planId": "fd25aca3-0ce9-4e6a-842c-170808e12eb7",
+      "name": "כפיר",
+      "lastName": "פקוס",
+      "contactPhone": "0546786456",
+      "displayName": null,
+      "role": "participant",
+      "avatarUrl": null,
+      "contactEmail": null,
+      "createdAt": "2026-02-21T12:00:04.108Z",
+      "updatedAt": "2026-02-21T12:00:04.108Z"
     }
   ],
   "items": [
@@ -241,10 +304,10 @@
       "unit": "pcs",
       "notes": "Check stakes before departure",
       "status": "packed",
+      "assignedParticipantId": "457393e1-822f-4c1c-a081-8207aa6b9fe1",
       "createdAt": "2025-05-02T10:00:00.000Z",
       "updatedAt": "2026-02-15T07:48:16.012Z",
-      "category": "equipment",
-      "assignedParticipantId": "457393e1-822f-4c1c-a081-8207aa6b9fe1"
+      "category": "equipment"
     },
     {
       "itemId": "404954b1-04f3-4512-abae-42683bffad2b",
@@ -266,10 +329,10 @@
       "unit": "pcs",
       "notes": "Two rated for 20°F",
       "status": "packed",
+      "assignedParticipantId": "1e6f5d21-b8d2-4991-9a23-8803d8aa3428",
       "createdAt": "2025-05-04T11:05:00.000Z",
       "updatedAt": "2026-02-15T07:48:19.630Z",
-      "category": "equipment",
-      "assignedParticipantId": "1e6f5d21-b8d2-4991-9a23-8803d8aa3428"
+      "category": "equipment"
     },
     {
       "itemId": "ccab3332-cc4f-449b-aec6-4130855cb0bf",
@@ -279,10 +342,10 @@
       "unit": "pcs",
       "notes": "Need to borrow from Taylor",
       "status": "pending",
+      "assignedParticipantId": "1e6f5d21-b8d2-4991-9a23-8803d8aa3428",
       "createdAt": "2025-05-06T09:40:00.000Z",
       "updatedAt": "2026-02-15T07:48:17.808Z",
-      "category": "equipment",
-      "assignedParticipantId": "1e6f5d21-b8d2-4991-9a23-8803d8aa3428"
+      "category": "equipment"
     },
     {
       "itemId": "bfd3aa99-197f-4b40-8607-11a7bc59e8f8",
@@ -292,10 +355,10 @@
       "unit": "pcs",
       "notes": "Pick up at REI on Thursday",
       "status": "pending",
+      "assignedParticipantId": "457393e1-822f-4c1c-a081-8207aa6b9fe1",
       "createdAt": "2025-05-06T09:45:00.000Z",
       "updatedAt": "2026-02-15T07:48:21.196Z",
-      "category": "equipment",
-      "assignedParticipantId": "457393e1-822f-4c1c-a081-8207aa6b9fe1"
+      "category": "equipment"
     },
     {
       "itemId": "10ad45f4-4afb-40c3-b0e7-676e293fada1",
@@ -823,6 +886,19 @@
       "createdAt": "2026-02-14T16:35:00.000Z",
       "updatedAt": "2026-02-14T17:00:00.000Z",
       "category": "food"
+    },
+    {
+      "itemId": "1a2842b5-a06e-42cf-af12-b12b46023e86",
+      "planId": "fd25aca3-0ce9-4e6a-842c-170808e12eb7",
+      "name": "טופו",
+      "category": "food",
+      "quantity": 1,
+      "unit": "kg",
+      "status": "pending",
+      "notes": null,
+      "assignedParticipantId": "9a69465a-6421-4298-b0b7-2c3d61ef9a2f",
+      "createdAt": "2026-02-21T12:01:02.836Z",
+      "updatedAt": "2026-02-21T12:01:02.836Z"
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "chillist-fe",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chillist-fe",
-      "version": "1.3.1",
+      "version": "1.3.2",
       "dependencies": {
         "@headlessui/react": "2.2.9",
         "@hookform/resolvers": "^5.2.2",
@@ -14,11 +14,13 @@
         "@tanstack/react-query": "^5.90.7",
         "@tanstack/react-router": "^1.134.15",
         "clsx": "2.1.1",
+        "i18next": "23.16.8",
         "openapi-fetch": "^0.15.0",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
         "react-hook-form": "^7.68.0",
         "react-hot-toast": "2.6.0",
+        "react-i18next": "15.4.1",
         "uuid": "^13.0.0"
       },
       "devDependencies": {
@@ -362,7 +364,6 @@
       "version": "7.28.4",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
       "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4655,6 +4656,15 @@
         "node": ">=18"
       }
     },
+    "node_modules/html-parse-stringify": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz",
+      "integrity": "sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==",
+      "license": "MIT",
+      "dependencies": {
+        "void-elements": "3.1.0"
+      }
+    },
     "node_modules/http-proxy-agent": {
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
@@ -4697,6 +4707,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/typicode"
+      }
+    },
+    "node_modules/i18next": {
+      "version": "23.16.8",
+      "resolved": "https://registry.npmjs.org/i18next/-/i18next-23.16.8.tgz",
+      "integrity": "sha512-06r/TitrM88Mg5FdUXAKL96dJMzgqLE5dv3ryBAra4KCwD9mJ4ndOTS95ZuymIGoE+2hzfdaMak2X11/es7ZWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://locize.com"
+        },
+        {
+          "type": "individual",
+          "url": "https://locize.com/i18next.html"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.i18next.com/how-to/faq#i18next-is-awesome.-how-can-i-support-the-project"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.2"
       }
     },
     "node_modules/iceberg-js": {
@@ -6104,6 +6137,28 @@
         "react-dom": ">=16"
       }
     },
+    "node_modules/react-i18next": {
+      "version": "15.4.1",
+      "resolved": "https://registry.npmjs.org/react-i18next/-/react-i18next-15.4.1.tgz",
+      "integrity": "sha512-ahGab+IaSgZmNPYXdV1n+OYky95TGpFwnKRflX/16dY04DsYYKHtVLjeny7sBSCREEcoMbAgSkFiGLF5g5Oofw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.25.0",
+        "html-parse-stringify": "^3.0.1"
+      },
+      "peerDependencies": {
+        "i18next": ">= 23.2.3",
+        "react": ">= 16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -7190,6 +7245,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/void-elements": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/void-elements/-/void-elements-3.1.0.tgz",
+      "integrity": "sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/w3c-xmlserializer": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.3.2",
+  "version": "1.4.0",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",
@@ -31,11 +31,13 @@
     "@tanstack/react-query": "^5.90.7",
     "@tanstack/react-router": "^1.134.15",
     "clsx": "2.1.1",
+    "i18next": "23.16.8",
     "openapi-fetch": "^0.15.0",
     "react": "^19.1.1",
     "react-dom": "^19.1.1",
     "react-hook-form": "^7.68.0",
     "react-hot-toast": "2.6.0",
+    "react-i18next": "15.4.1",
     "uuid": "^13.0.0"
   },
   "devDependencies": {

--- a/src/components/CategorySection.tsx
+++ b/src/components/CategorySection.tsx
@@ -3,15 +3,11 @@ import {
   DisclosureButton,
   DisclosurePanel,
 } from '@headlessui/react';
+import { useTranslation } from 'react-i18next';
 import type { Item, ItemCategory, ItemPatch } from '../core/schemas/item';
 import type { Participant } from '../core/schemas/participant';
 import type { ListFilter } from '../core/schemas/plan-search';
 import ItemCard from './ItemCard';
-
-const CATEGORY_LABELS: Record<ItemCategory, string> = {
-  equipment: 'Equipment',
-  food: 'Food',
-};
 
 interface CategorySectionProps {
   category: ItemCategory;
@@ -30,7 +26,8 @@ export default function CategorySection({
   onEditItem,
   onUpdateItem,
 }: CategorySectionProps) {
-  const label = CATEGORY_LABELS[category];
+  const { t } = useTranslation();
+  const categoryLabel = t(`categories.${category}`);
 
   return (
     <Disclosure
@@ -40,9 +37,9 @@ export default function CategorySection({
     >
       <DisclosureButton className="group w-full px-4 sm:px-5 py-3 sm:py-4 flex items-center justify-between cursor-pointer hover:bg-gray-50 active:bg-gray-100 transition-colors">
         <h3 className="text-base sm:text-lg font-semibold text-gray-800">
-          {label}
+          {categoryLabel}
           {items.length > 0 && (
-            <span className="ml-2 text-sm font-normal text-gray-500">
+            <span className="ms-2 text-sm font-normal text-gray-500">
               ({items.length})
             </span>
           )}
@@ -86,7 +83,9 @@ export default function CategorySection({
         ) : (
           <div className="border-t border-gray-200 px-4 sm:px-5 py-3 sm:py-4 text-center">
             <p className="text-sm sm:text-base text-gray-500">
-              No {label.toLowerCase()} items
+              {t('categories.noItems', {
+                category: categoryLabel.toLowerCase(),
+              })}
             </p>
           </div>
         )}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,8 @@
 import { Link } from '@tanstack/react-router';
 import { useEffect, useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { useAuth } from '../contexts/useAuth';
+import { useLanguage } from '../contexts/useLanguage';
 
 function getUserDisplayName(user: {
   email?: string;
@@ -36,6 +38,12 @@ export default function Header() {
   const [isUserMenuOpen, setIsUserMenuOpen] = useState(false);
   const userMenuRef = useRef<HTMLDivElement>(null);
   const { user, loading, signOut } = useAuth();
+  const { t } = useTranslation();
+  const { language, setLanguage } = useLanguage();
+
+  function toggleLanguage() {
+    setLanguage(language === 'en' ? 'he' : 'en');
+  }
 
   useEffect(() => {
     function handleClickOutside(e: MouseEvent) {
@@ -112,7 +120,7 @@ export default function Header() {
                   to="/plans"
                   className="block px-3 py-2 text-base sm:text-lg font-medium text-gray-700 hover:text-blue-600 transition-colors"
                 >
-                  Plans
+                  {t('nav.plans')}
                 </Link>
               </li>
               <li>
@@ -120,10 +128,19 @@ export default function Header() {
                   to="/about"
                   className="block px-3 py-2 text-base sm:text-lg font-medium text-gray-700 hover:text-blue-600 transition-colors"
                 >
-                  About
+                  {t('nav.about')}
                 </Link>
               </li>
             </ul>
+
+            <button
+              type="button"
+              onClick={toggleLanguage}
+              data-testid="lang-toggle"
+              className="rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-semibold text-gray-700 shadow-sm hover:bg-gray-50 transition-colors cursor-pointer"
+            >
+              {t('language.toggle')}
+            </button>
 
             {!loading && (
               <>
@@ -144,13 +161,13 @@ export default function Header() {
                     </button>
 
                     {isUserMenuOpen && (
-                      <div className="absolute right-0 mt-2 w-64 rounded-lg bg-white shadow-lg ring-1 ring-black/5 z-50">
+                      <div className="absolute end-0 mt-2 w-64 rounded-lg bg-white shadow-lg ring-1 ring-black/5 z-50">
                         <div className="px-4 py-3 border-b border-gray-100">
                           <p
                             className="text-sm font-medium text-gray-900"
                             data-testid="menu-display-name"
                           >
-                            {getUserDisplayName(user) || 'User'}
+                            {getUserDisplayName(user) || t('auth.userFallback')}
                           </p>
                           <p
                             className="text-xs text-gray-500 truncate mt-0.5"
@@ -173,16 +190,16 @@ export default function Header() {
                             onClick={() => setIsUserMenuOpen(false)}
                             className="block px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                           >
-                            Edit Profile
+                            {t('auth.editProfile')}
                           </Link>
                           <button
                             onClick={() => {
                               setIsUserMenuOpen(false);
                               signOut();
                             }}
-                            className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
+                            className="block w-full text-start px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 transition-colors"
                           >
-                            Sign Out
+                            {t('auth.signOut')}
                           </button>
                         </div>
                       </div>
@@ -194,13 +211,13 @@ export default function Header() {
                       to="/signin"
                       className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors"
                     >
-                      Sign In
+                      {t('auth.signIn')}
                     </Link>
                     <Link
                       to="/signup"
                       className="rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 transition-colors"
                     >
-                      Sign Up
+                      {t('auth.signUp')}
                     </Link>
                   </div>
                 )}
@@ -210,7 +227,7 @@ export default function Header() {
         </div>
 
         {isMenuOpen && (
-          <div className="absolute top-full left-0 right-0 bg-white shadow-lg z-50 sm:hidden border-t border-gray-200 transition-opacity duration-200">
+          <div className="absolute top-full start-0 end-0 bg-white shadow-lg z-50 sm:hidden border-t border-gray-200 transition-opacity duration-200">
             <ul className="list-none m-0 p-0">
               <li className="border-b border-gray-100">
                 <Link
@@ -218,7 +235,7 @@ export default function Header() {
                   onClick={() => setIsMenuOpen(false)}
                   className="block px-4 py-3 text-base font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 transition-colors"
                 >
-                  Plans
+                  {t('nav.plans')}
                 </Link>
               </li>
               <li className="border-b border-gray-100">
@@ -227,8 +244,21 @@ export default function Header() {
                   onClick={() => setIsMenuOpen(false)}
                   className="block px-4 py-3 text-base font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 transition-colors"
                 >
-                  About
+                  {t('nav.about')}
                 </Link>
+              </li>
+              <li className="border-b border-gray-100">
+                <button
+                  type="button"
+                  onClick={() => {
+                    toggleLanguage();
+                    setIsMenuOpen(false);
+                  }}
+                  data-testid="lang-toggle-mobile"
+                  className="block w-full text-start px-4 py-3 text-base font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 transition-colors"
+                >
+                  {t('language.toggle')}
+                </button>
               </li>
               {!loading && (
                 <li className="border-b border-gray-100 last:border-b-0">
@@ -240,7 +270,7 @@ export default function Header() {
                         </span>
                         <div className="min-w-0">
                           <p className="text-sm font-medium text-gray-900 truncate">
-                            {getUserDisplayName(user) || 'User'}
+                            {getUserDisplayName(user) || t('auth.userFallback')}
                           </p>
                           <p className="text-xs text-gray-500 truncate">
                             {user.email}
@@ -257,7 +287,7 @@ export default function Header() {
                         onClick={() => setIsMenuOpen(false)}
                         className="block w-full text-center rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors"
                       >
-                        Edit Profile
+                        {t('auth.editProfile')}
                       </Link>
                       <button
                         onClick={() => {
@@ -266,7 +296,7 @@ export default function Header() {
                         }}
                         className="mt-2 w-full rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 transition-colors"
                       >
-                        Sign Out
+                        {t('auth.signOut')}
                       </button>
                     </div>
                   ) : (
@@ -276,14 +306,14 @@ export default function Header() {
                         onClick={() => setIsMenuOpen(false)}
                         className="block px-4 py-3 text-base font-medium text-gray-700 hover:text-blue-600 hover:bg-gray-50 transition-colors"
                       >
-                        Sign In
+                        {t('auth.signIn')}
                       </Link>
                       <Link
                         to="/signup"
                         onClick={() => setIsMenuOpen(false)}
                         className="block px-4 py-3 text-base font-medium text-blue-600 hover:bg-gray-50 transition-colors border-t border-gray-100"
                       >
-                        Sign Up
+                        {t('auth.signUp')}
                       </Link>
                     </div>
                   )}

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from 'react';
 import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
 import type { Item, ItemPatch } from '../core/schemas/item';
 import type { Participant } from '../core/schemas/participant';
 import type { ListFilter } from '../core/schemas/plan-search';
@@ -45,7 +46,20 @@ export default function ItemCard({
   onEdit,
   onUpdate,
 }: ItemCardProps) {
-  const statusOption = STATUS_OPTIONS.find((s) => s.value === item.status);
+  const { t } = useTranslation();
+
+  const resolvedStatusOptions = useMemo(
+    () => STATUS_OPTIONS.map((s) => ({ ...s, label: t(s.labelKey) })),
+    [t]
+  );
+  const resolvedUnitOptions = useMemo(
+    () => UNIT_OPTIONS.map((u) => ({ ...u, label: t(u.labelKey) })),
+    [t]
+  );
+
+  const statusOption = resolvedStatusOptions.find(
+    (s) => s.value === item.status
+  );
   const isCanceled = item.status === 'canceled';
   const isEquipment = item.category === 'equipment';
   const quickAction =
@@ -61,7 +75,7 @@ export default function ItemCard({
   );
 
   const assignmentOptions = useMemo(() => {
-    const opts = [{ value: '', label: 'Unassigned' }];
+    const opts = [{ value: '', label: t('items.unassigned') }];
     for (const p of participants) {
       opts.push({
         value: p.participantId,
@@ -69,7 +83,7 @@ export default function ItemCard({
       });
     }
     return opts;
-  }, [participants]);
+  }, [participants, t]);
 
   function handleCheck() {
     if (!onUpdate || !quickAction || isChecking) return;
@@ -111,7 +125,7 @@ export default function ItemCard({
 
           <div className="flex flex-wrap items-center gap-2 mt-1">
             <span className="inline-flex items-center rounded-md px-2 py-0.5 text-xs sm:text-sm font-medium bg-gray-100 text-gray-600">
-              {item.quantity} {item.unit}
+              {item.quantity} {t(`units.${item.unit}`)}
             </span>
 
             {item.notes && (
@@ -168,7 +182,7 @@ export default function ItemCard({
             <InlineSelect
               value={item.status}
               onChange={(status) => onUpdate({ status })}
-              options={STATUS_OPTIONS}
+              options={resolvedStatusOptions}
               buttonClassName={clsx(
                 'inline-flex items-center px-2.5 py-1 rounded-full text-xs font-medium hover:opacity-80 transition-opacity',
                 statusOption?.bg,
@@ -184,7 +198,7 @@ export default function ItemCard({
                 statusOption?.text
               )}
             >
-              {statusOption?.label ?? item.status}
+              {statusOption?.label ?? t(`itemStatus.${item.status}`)}
             </span>
           )}
 
@@ -232,7 +246,7 @@ export default function ItemCard({
             <InlineSelect
               value={item.unit}
               onChange={(unit) => onUpdate({ unit })}
-              options={UNIT_OPTIONS}
+              options={resolvedUnitOptions}
               disabled={isEquipment}
               buttonClassName={clsx(
                 'text-xs sm:text-sm font-medium',
@@ -250,7 +264,7 @@ export default function ItemCard({
                 : 'bg-gray-100 text-gray-700'
             )}
           >
-            {item.quantity} {item.unit}
+            {item.quantity} {t(`units.${item.unit}`)}
           </span>
         )}
 
@@ -304,7 +318,7 @@ export default function ItemCard({
                 </svg>
                 {assignedParticipant
                   ? `${assignedParticipant.name} ${assignedParticipant.lastName}`
-                  : 'Unassigned'}
+                  : t('items.unassigned')}
               </span>
             )}
           </>

--- a/src/components/ParticipantFilter.tsx
+++ b/src/components/ParticipantFilter.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
 import type { Participant } from '../core/schemas/participant';
 
 interface ParticipantFilterProps {
@@ -16,6 +17,7 @@ export default function ParticipantFilter({
   counts,
   total,
 }: ParticipantFilterProps) {
+  const { t } = useTranslation();
   return (
     <div
       className="flex flex-wrap gap-2"
@@ -33,7 +35,7 @@ export default function ParticipantFilter({
         )}
         aria-pressed={selected === null}
       >
-        All
+        {t('filters.all')}
         <span
           className={clsx(
             'text-xs tabular-nums',
@@ -55,7 +57,7 @@ export default function ParticipantFilter({
         )}
         aria-pressed={selected === 'unassigned'}
       >
-        Unassigned
+        {t('items.unassigned')}
         <span
           className={clsx(
             'text-xs tabular-nums',

--- a/src/components/Plan.tsx
+++ b/src/components/Plan.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
 import type { PlanWithDetails } from '../core/schemas/plan';
 import type {
   Participant,
@@ -66,6 +67,7 @@ function AddParticipantForm({
   onCancel: () => void;
   isSubmitting: boolean;
 }) {
+  const { t } = useTranslation();
   const {
     register,
     handleSubmit,
@@ -96,17 +98,21 @@ function AddParticipantForm({
     >
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
-          <FormLabel>First Name *</FormLabel>
-          <FormInput {...register('name')} placeholder="First name" compact />
+          <FormLabel>{t('addParticipant.firstName')}</FormLabel>
+          <FormInput
+            {...register('name')}
+            placeholder={t('addParticipant.firstNamePlaceholder')}
+            compact
+          />
           {errors.name && (
             <p className="text-sm text-red-600 mt-1">{errors.name.message}</p>
           )}
         </div>
         <div>
-          <FormLabel>Last Name *</FormLabel>
+          <FormLabel>{t('addParticipant.lastName')}</FormLabel>
           <FormInput
             {...register('lastName')}
-            placeholder="Last name"
+            placeholder={t('addParticipant.lastNamePlaceholder')}
             compact
           />
           {errors.lastName && (
@@ -118,10 +124,10 @@ function AddParticipantForm({
       </div>
       <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
         <div>
-          <FormLabel>Phone *</FormLabel>
+          <FormLabel>{t('addParticipant.phone')}</FormLabel>
           <FormInput
             {...register('contactPhone')}
-            placeholder="Phone number"
+            placeholder={t('addParticipant.phonePlaceholder')}
             compact
           />
           {errors.contactPhone && (
@@ -131,10 +137,10 @@ function AddParticipantForm({
           )}
         </div>
         <div>
-          <FormLabel>Email</FormLabel>
+          <FormLabel>{t('addParticipant.email')}</FormLabel>
           <FormInput
             {...register('contactEmail')}
-            placeholder="Email (optional)"
+            placeholder={t('addParticipant.emailPlaceholder')}
             compact
           />
         </div>
@@ -145,14 +151,16 @@ function AddParticipantForm({
           disabled={isSubmitting}
           className="flex-1 px-4 py-2 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 active:bg-blue-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors text-sm"
         >
-          {isSubmitting ? 'Adding…' : 'Add Participant'}
+          {isSubmitting
+            ? t('addParticipant.submitting')
+            : t('addParticipant.submit')}
         </button>
         <button
           type="button"
           onClick={onCancel}
           className="px-4 py-2 border border-gray-300 text-gray-700 font-semibold rounded-lg hover:bg-gray-50 active:bg-gray-100 transition-colors text-sm"
         >
-          Cancel
+          {t('addParticipant.cancel')}
         </button>
       </div>
     </form>
@@ -170,6 +178,7 @@ export function Plan({
   onAddParticipant,
   isAddingParticipant = false,
 }: PlanProps) {
+  const { t } = useTranslation();
   const [showForm, setShowForm] = useState(false);
 
   const {
@@ -183,7 +192,6 @@ export function Plan({
     participants,
   } = plan;
 
-  const NA = 'N/A';
   const start = startDate ? formatDateTime(startDate) : null;
   const end = endDate ? formatDateTime(endDate) : null;
 
@@ -211,51 +219,53 @@ export function Plan({
 
         <div className="px-3 sm:px-6 lg:px-8 py-3 sm:py-6">
           <h2 className="text-base sm:text-lg lg:text-xl font-semibold text-gray-700 mb-4">
-            Details
+            {t('plan.details')}
           </h2>
           <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 sm:gap-4 lg:gap-6">
-            <DetailRow label="Status">
-              <span className="font-medium capitalize">{status}</span>
+            <DetailRow label={t('plan.status')}>
+              <span className="font-medium">{t(`planStatus.${status}`)}</span>
             </DetailRow>
 
-            <DetailRow label="Visibility">
-              <span className="font-medium capitalize">{visibility || NA}</span>
+            <DetailRow label={t('plan.visibility')}>
+              <span className="font-medium">
+                {visibility ? t(`planVisibility.${visibility}`) : t('plan.na')}
+              </span>
             </DetailRow>
 
             {owner && (
-              <DetailRow label="Owner">
+              <DetailRow label={t('plan.owner')}>
                 <span className="font-medium">
                   {owner.name} {owner.lastName}
                 </span>
               </DetailRow>
             )}
 
-            <DetailRow label="Start">
+            <DetailRow label={t('plan.start')}>
               {start ? (
                 <span>
                   {start.date}{' '}
                   <span className="text-gray-500">{start.time}</span>
                 </span>
               ) : (
-                NA
+                t('plan.na')
               )}
             </DetailRow>
 
-            <DetailRow label="End">
+            <DetailRow label={t('plan.end')}>
               {end ? (
                 <span>
                   {end.date} <span className="text-gray-500">{end.time}</span>
                 </span>
               ) : (
-                NA
+                t('plan.na')
               )}
             </DetailRow>
 
             {location && (
-              <DetailRow label="Location">
+              <DetailRow label={t('plan.location')}>
                 <span className="font-medium">{location.name}</span>
                 {(location.city || location.country) && (
-                  <span className="text-gray-500 ml-1">
+                  <span className="text-gray-500 ms-1">
                     —{' '}
                     {[location.city, location.region, location.country]
                       .filter(Boolean)
@@ -270,8 +280,8 @@ export function Plan({
         <div className="px-3 sm:px-6 lg:px-8 py-3 sm:py-6 border-t border-gray-200">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-base sm:text-lg lg:text-xl font-semibold text-gray-700">
-              Participants
-              <span className="ml-2 text-sm font-normal text-gray-500">
+              {t('plan.participants')}
+              <span className="ms-2 text-sm font-normal text-gray-500">
                 ({participants.length})
               </span>
             </h2>
@@ -302,11 +312,11 @@ export function Plan({
                   </div>
                   <span
                     className={clsx(
-                      'text-xs font-medium px-2 py-0.5 rounded-full capitalize shrink-0',
+                      'text-xs font-medium px-2 py-0.5 rounded-full shrink-0',
                       roleBadgeColor(p.role)
                     )}
                   >
-                    {p.role}
+                    {t(`roles.${p.role}`)}
                   </span>
                 </div>
               ))}
@@ -315,7 +325,7 @@ export function Plan({
 
           {participants.length === 0 && !showForm && (
             <p className="text-gray-500 text-sm mb-4">
-              No participants yet. Add one to get started!
+              {t('plan.noParticipants')}
             </p>
           )}
 
@@ -332,7 +342,7 @@ export function Plan({
                 onClick={() => setShowForm(true)}
                 className="w-full px-4 py-2 border-2 border-dashed border-gray-300 text-gray-600 rounded-lg hover:border-blue-400 hover:text-blue-600 transition-colors text-sm font-medium"
               >
-                + Add Participant
+                {t('plan.addParticipant')}
               </button>
             ))}
         </div>

--- a/src/components/PlanForm.tsx
+++ b/src/components/PlanForm.tsx
@@ -2,6 +2,7 @@ import { useForm, useFieldArray } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { v5 as uuidv5 } from 'uuid';
+import { useTranslation } from 'react-i18next';
 
 import {
   planStatusSchema,
@@ -83,6 +84,7 @@ export default function PlanForm({
   onSubmit,
   isSubmitting = false,
 }: PlanFormProps) {
+  const { t } = useTranslation();
   const {
     register,
     handleSubmit,
@@ -188,29 +190,32 @@ export default function PlanForm({
         className="bg-white rounded-lg shadow-sm p-4 sm:p-6 lg:p-8 space-y-6"
       >
         <div>
-          <FormLabel>Title *</FormLabel>
-          <FormInput {...register('title')} placeholder="Enter plan title" />
+          <FormLabel>{t('planForm.title')}</FormLabel>
+          <FormInput
+            {...register('title')}
+            placeholder={t('planForm.titlePlaceholder')}
+          />
           {errors.title && (
             <p className="text-sm text-red-600 mt-1">{errors.title.message}</p>
           )}
         </div>
 
         <div>
-          <FormLabel>Description</FormLabel>
+          <FormLabel>{t('planForm.description')}</FormLabel>
           <FormTextarea
             {...register('description')}
-            placeholder="Add details about your plan"
+            placeholder={t('planForm.descriptionPlaceholder')}
             rows={4}
           />
         </div>
 
         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 sm:gap-6">
           <div>
-            <FormLabel>Status</FormLabel>
+            <FormLabel>{t('planForm.status')}</FormLabel>
             <FormSelect {...register('status')}>
-              <option value="draft">Draft</option>
-              <option value="active">Active</option>
-              <option value="archived">Archived</option>
+              <option value="draft">{t('planStatus.draft')}</option>
+              <option value="active">{t('planStatus.active')}</option>
+              <option value="archived">{t('planStatus.archived')}</option>
             </FormSelect>
             {errors.status && (
               <p className="text-sm text-red-600 mt-1">
@@ -220,26 +225,26 @@ export default function PlanForm({
           </div>
 
           <div>
-            <FormLabel>Visibility</FormLabel>
+            <FormLabel>{t('planForm.visibility')}</FormLabel>
             <FormSelect {...register('visibility')}>
-              <option value="public">Public</option>
-              <option value="unlisted">Unlisted</option>
-              <option value="private">Private</option>
+              <option value="public">{t('planVisibility.public')}</option>
+              <option value="unlisted">{t('planVisibility.unlisted')}</option>
+              <option value="private">{t('planVisibility.private')}</option>
             </FormSelect>
           </div>
         </div>
 
         <fieldset className="border border-gray-200 rounded-lg p-4 sm:p-5">
           <legend className="text-sm font-semibold text-gray-700 px-2 mb-3">
-            Owner (you) *
+            {t('planForm.ownerLegend')}
           </legend>
           <div className="space-y-4">
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <FormLabel>First Name *</FormLabel>
+                <FormLabel>{t('planForm.firstName')}</FormLabel>
                 <FormInput
                   {...register('ownerName')}
-                  placeholder="First name"
+                  placeholder={t('planForm.firstNamePlaceholder')}
                   compact
                 />
                 {errors.ownerName && (
@@ -249,10 +254,10 @@ export default function PlanForm({
                 )}
               </div>
               <div>
-                <FormLabel>Last Name *</FormLabel>
+                <FormLabel>{t('planForm.lastName')}</FormLabel>
                 <FormInput
                   {...register('ownerLastName')}
-                  placeholder="Last name"
+                  placeholder={t('planForm.lastNamePlaceholder')}
                   compact
                 />
                 {errors.ownerLastName && (
@@ -264,10 +269,10 @@ export default function PlanForm({
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <FormLabel>Phone *</FormLabel>
+                <FormLabel>{t('planForm.phone')}</FormLabel>
                 <FormInput
                   {...register('ownerPhone')}
-                  placeholder="Phone number"
+                  placeholder={t('planForm.phonePlaceholder')}
                   compact
                 />
                 {errors.ownerPhone && (
@@ -277,10 +282,10 @@ export default function PlanForm({
                 )}
               </div>
               <div>
-                <FormLabel>Email</FormLabel>
+                <FormLabel>{t('planForm.email')}</FormLabel>
                 <FormInput
                   {...register('ownerEmail')}
-                  placeholder="Email (optional)"
+                  placeholder={t('planForm.emailPlaceholder')}
                   compact
                 />
               </div>
@@ -290,7 +295,7 @@ export default function PlanForm({
 
         <fieldset className="border border-gray-200 rounded-lg p-4 sm:p-5">
           <legend className="text-sm font-semibold text-gray-700 px-2 mb-3">
-            Participants (optional)
+            {t('planForm.participantsLegend')}
           </legend>
           <div className="space-y-4">
             {fields.map((field, index) => (
@@ -300,21 +305,21 @@ export default function PlanForm({
               >
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium text-gray-600">
-                    Participant {index + 1}
+                    {t('planForm.participantIndex', { index: index + 1 })}
                   </span>
                   <button
                     type="button"
                     onClick={() => remove(index)}
                     className="text-sm text-red-500 hover:text-red-700 transition-colors"
                   >
-                    Remove
+                    {t('planForm.remove')}
                   </button>
                 </div>
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
                   <div>
                     <FormInput
                       {...register(`participants.${index}.name`)}
-                      placeholder="First name *"
+                      placeholder={t('planForm.firstNamePlaceholder')}
                       compact
                     />
                     {errors.participants?.[index]?.name && (
@@ -326,7 +331,7 @@ export default function PlanForm({
                   <div>
                     <FormInput
                       {...register(`participants.${index}.lastName`)}
-                      placeholder="Last name *"
+                      placeholder={t('planForm.lastNamePlaceholder')}
                       compact
                     />
                     {errors.participants?.[index]?.lastName && (
@@ -340,7 +345,7 @@ export default function PlanForm({
                   <div>
                     <FormInput
                       {...register(`participants.${index}.contactPhone`)}
-                      placeholder="Phone *"
+                      placeholder={t('planForm.phonePlaceholder')}
                       compact
                     />
                     {errors.participants?.[index]?.contactPhone && (
@@ -352,7 +357,7 @@ export default function PlanForm({
                   <div>
                     <FormInput
                       {...register(`participants.${index}.contactEmail`)}
-                      placeholder="Email (optional)"
+                      placeholder={t('planForm.emailPlaceholder')}
                       compact
                     />
                   </div>
@@ -371,47 +376,47 @@ export default function PlanForm({
               }
               className="w-full px-4 py-2 border-2 border-dashed border-gray-300 text-gray-600 rounded-lg hover:border-blue-400 hover:text-blue-600 transition-colors text-sm font-medium"
             >
-              + Add Participant
+              {t('planForm.addParticipant')}
             </button>
           </div>
         </fieldset>
 
         <fieldset className="border border-gray-200 rounded-lg p-4 sm:p-5">
           <legend className="text-sm font-semibold text-gray-700 px-2 mb-3">
-            Location (optional)
+            {t('planForm.locationLegend')}
           </legend>
           <div className="space-y-4">
             <div>
-              <FormLabel>Name</FormLabel>
+              <FormLabel>{t('planForm.locationName')}</FormLabel>
               <FormInput
                 {...register('location.name' as const)}
-                placeholder="Location name"
+                placeholder={t('planForm.locationNamePlaceholder')}
                 compact
               />
             </div>
             <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
               <div>
-                <FormLabel>City</FormLabel>
+                <FormLabel>{t('planForm.city')}</FormLabel>
                 <FormInput
                   {...register('location.city' as const)}
-                  placeholder="City"
+                  placeholder={t('planForm.cityPlaceholder')}
                   compact
                 />
               </div>
               <div>
-                <FormLabel>Country</FormLabel>
+                <FormLabel>{t('planForm.country')}</FormLabel>
                 <FormInput
                   {...register('location.country' as const)}
-                  placeholder="Country"
+                  placeholder={t('planForm.countryPlaceholder')}
                   compact
                 />
               </div>
             </div>
             <div>
-              <FormLabel>Region</FormLabel>
+              <FormLabel>{t('planForm.region')}</FormLabel>
               <FormInput
                 {...register('location.region' as const)}
-                placeholder="Region/Province"
+                placeholder={t('planForm.regionPlaceholder')}
                 compact
               />
             </div>
@@ -430,14 +435,14 @@ export default function PlanForm({
               htmlFor="oneDay"
               className="text-sm font-medium text-gray-700 cursor-pointer"
             >
-              One-day plan
+              {t('planForm.oneDay')}
             </label>
           </div>
 
           {oneDay ? (
             <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 bg-blue-50 p-4 rounded-lg">
               <div>
-                <FormLabel>Date *</FormLabel>
+                <FormLabel>{t('planForm.date')}</FormLabel>
                 <FormInput type="date" {...register('singleDate')} compact />
                 {errors.singleDate && (
                   <p className="text-sm text-red-600 mt-1">
@@ -446,7 +451,7 @@ export default function PlanForm({
                 )}
               </div>
               <div>
-                <FormLabel>Start time</FormLabel>
+                <FormLabel>{t('planForm.startTime')}</FormLabel>
                 <FormInput
                   type="time"
                   {...register('singleStartTime')}
@@ -454,14 +459,14 @@ export default function PlanForm({
                 />
               </div>
               <div>
-                <FormLabel>End time</FormLabel>
+                <FormLabel>{t('planForm.endTime')}</FormLabel>
                 <FormInput type="time" {...register('singleEndTime')} compact />
               </div>
             </div>
           ) : (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4 bg-blue-50 p-4 rounded-lg">
               <div>
-                <FormLabel>Start date *</FormLabel>
+                <FormLabel>{t('planForm.startDate')}</FormLabel>
                 <FormInput type="date" {...register('startDateDate')} compact />
                 {errors.startDateDate && (
                   <p className="text-sm text-red-600 mt-1">
@@ -470,11 +475,11 @@ export default function PlanForm({
                 )}
               </div>
               <div>
-                <FormLabel>Start time</FormLabel>
+                <FormLabel>{t('planForm.startTime')}</FormLabel>
                 <FormInput type="time" {...register('startDateTime')} compact />
               </div>
               <div>
-                <FormLabel>End date *</FormLabel>
+                <FormLabel>{t('planForm.endDate')}</FormLabel>
                 <FormInput type="date" {...register('endDateDate')} compact />
                 {errors.endDateDate && (
                   <p className="text-sm text-red-600 mt-1">
@@ -483,7 +488,7 @@ export default function PlanForm({
                 )}
               </div>
               <div>
-                <FormLabel>End time</FormLabel>
+                <FormLabel>{t('planForm.endTime')}</FormLabel>
                 <FormInput type="time" {...register('endDateTime')} compact />
               </div>
             </div>
@@ -491,10 +496,10 @@ export default function PlanForm({
         </div>
 
         <div>
-          <FormLabel>Tags (comma separated)</FormLabel>
+          <FormLabel>{t('planForm.tags')}</FormLabel>
           <FormInput
             {...register('tagsCsv')}
-            placeholder="e.g. picnic, friends, summer"
+            placeholder={t('planForm.tagsPlaceholder')}
           />
         </div>
 
@@ -504,7 +509,7 @@ export default function PlanForm({
             disabled={isSubmitting}
             className="w-full px-4 py-3 bg-blue-600 text-white text-base sm:text-lg font-semibold rounded-lg hover:bg-blue-700 active:bg-blue-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm hover:shadow-md"
           >
-            {isSubmitting ? 'Creating…' : 'Create Plan'}
+            {isSubmitting ? t('planForm.submitting') : t('planForm.submit')}
           </button>
         </div>
       </form>

--- a/src/components/PlansList.tsx
+++ b/src/components/PlansList.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { Link } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 import type { Plan, PlanStatus } from '../core/types/plan';
 
 interface PlansListProps {
@@ -16,49 +17,42 @@ interface PlansListProps {
   >;
 }
 
-const statusConfig: Record<PlanStatus, { label: string; className: string }> = {
-  active: {
-    label: 'Active',
-    className: 'bg-green-100 text-green-700',
-  },
-  draft: {
-    label: 'Draft',
-    className: 'bg-yellow-100 text-yellow-700',
-  },
-  archived: {
-    label: 'Archived',
-    className: 'bg-gray-100 text-gray-500',
-  },
+const statusClassName: Record<PlanStatus, string> = {
+  active: 'bg-green-100 text-green-700',
+  draft: 'bg-yellow-100 text-yellow-700',
+  archived: 'bg-gray-100 text-gray-500',
 };
 
-function formatDate(dateStr: string): string {
-  return new Date(dateStr).toLocaleDateString('en-US', {
-    month: 'short',
-    day: 'numeric',
-    year: 'numeric',
-  });
-}
-
 export function PlansList({ plans }: PlansListProps) {
+  const { t } = useTranslation();
+
+  function formatDate(dateStr: string): string {
+    return new Date(dateStr).toLocaleDateString(undefined, {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+    });
+  }
+
   return (
     <div className="w-full">
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-6">
         <h1 className="text-2xl sm:text-3xl lg:text-4xl font-bold text-gray-800">
-          My Plans
+          {t('plans.title')}
         </h1>
         <button
           type="button"
           className="w-full sm:w-auto px-4 py-2 bg-blue-600 text-white text-base sm:text-lg font-medium rounded-lg hover:bg-blue-700 active:bg-blue-800 transition-colors cursor-pointer shadow-sm hover:shadow-md"
         >
           <Link to="/create-plan" className="block">
-            Create New Plan
+            {t('plans.createNew')}
           </Link>
         </button>
       </div>
       {plans.length === 0 ? (
         <div className="bg-white rounded-lg shadow-sm p-6 sm:p-8 text-center">
           <p className="text-gray-500 text-base sm:text-lg">
-            No plans yet. Create one to get started!
+            {t('plans.empty')}
           </p>
         </div>
       ) : (
@@ -67,7 +61,6 @@ export function PlansList({ plans }: PlansListProps) {
           className="bg-white rounded-lg shadow-sm divide-y divide-gray-200 overflow-hidden"
         >
           {plans.map((plan) => {
-            const { label, className } = statusConfig[plan.status];
             const meta: string[] = [];
             if (plan.startDate) {
               meta.push(formatDate(plan.startDate));
@@ -76,8 +69,9 @@ export function PlansList({ plans }: PlansListProps) {
               meta.push(plan.location.name);
             }
             if (plan.participantIds && plan.participantIds.length > 0) {
-              const count = plan.participantIds.length;
-              meta.push(`${count} participant${count === 1 ? '' : 's'}`);
+              meta.push(
+                t('plans.participant', { count: plan.participantIds.length })
+              );
             }
 
             return (
@@ -97,10 +91,10 @@ export function PlansList({ plans }: PlansListProps) {
                     <span
                       className={clsx(
                         'inline-flex self-start sm:self-auto items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
-                        className
+                        statusClassName[plan.status]
                       )}
                     >
-                      {label}
+                      {t(`planStatus.${plan.status}`)}
                     </span>
                   </div>
                   {meta.length > 0 && (

--- a/src/components/StatusFilter.tsx
+++ b/src/components/StatusFilter.tsx
@@ -1,9 +1,10 @@
 import clsx from 'clsx';
+import { useTranslation } from 'react-i18next';
 import type { ListFilter } from '../core/schemas/plan-search';
 
 interface ListTabOption {
   value: ListFilter | null;
-  label: string;
+  labelKey: string;
   icon: React.ReactNode;
   activeBg: string;
   activeText: string;
@@ -81,7 +82,7 @@ const ListIcon = () => (
 const LIST_TABS: ListTabOption[] = [
   {
     value: null,
-    label: 'All',
+    labelKey: 'filters.all',
     icon: <ListIcon />,
     activeBg: 'bg-gray-800',
     activeText: 'text-white',
@@ -89,7 +90,7 @@ const LIST_TABS: ListTabOption[] = [
   },
   {
     value: 'buying',
-    label: 'Buying List',
+    labelKey: 'filters.buyingList',
     icon: <ShoppingCartIcon />,
     activeBg: 'bg-amber-50',
     activeText: 'text-amber-700',
@@ -97,7 +98,7 @@ const LIST_TABS: ListTabOption[] = [
   },
   {
     value: 'packing',
-    label: 'Packing List',
+    labelKey: 'filters.packingList',
     icon: <BoxIcon />,
     activeBg: 'bg-blue-50',
     activeText: 'text-blue-700',
@@ -105,7 +106,7 @@ const LIST_TABS: ListTabOption[] = [
   },
   {
     value: 'assigning',
-    label: 'Assigning List',
+    labelKey: 'filters.assigningList',
     icon: <UserPlusIcon />,
     activeBg: 'bg-violet-50',
     activeText: 'text-violet-700',
@@ -126,6 +127,7 @@ export default function ListTabs({
   counts,
   total,
 }: ListTabsProps) {
+  const { t } = useTranslation();
   return (
     <div
       className="inline-flex rounded-xl border border-gray-200 bg-gray-50 p-1 gap-1"
@@ -156,7 +158,7 @@ export default function ListTabs({
             aria-selected={isActive}
           >
             {tab.icon}
-            <span className="hidden sm:inline">{tab.label}</span>
+            <span className="hidden sm:inline">{t(tab.labelKey)}</span>
             <span
               className={clsx(
                 'inline-flex items-center justify-center min-w-5 h-5 px-1.5 rounded-full text-xs font-semibold tabular-nums',

--- a/src/components/shared/Autocomplete.tsx
+++ b/src/components/shared/Autocomplete.tsx
@@ -16,6 +16,7 @@ interface AutocompleteProps {
   onSelect: (value: string) => void;
   placeholder?: string;
   compact?: boolean;
+  filterFn?: (item: string, query: string) => boolean;
 }
 
 export default function Autocomplete({
@@ -25,14 +26,18 @@ export default function Autocomplete({
   onSelect,
   placeholder,
   compact = false,
+  filterFn,
 }: AutocompleteProps) {
   const [query, setQuery] = useState('');
 
+  const defaultFilter = (item: string, q: string) =>
+    item.toLowerCase().includes(q.toLowerCase());
+
+  const matchFn = filterFn ?? defaultFilter;
+
   const filtered =
     query.length > 0
-      ? items
-          .filter((item) => item.toLowerCase().includes(query.toLowerCase()))
-          .slice(0, MAX_RESULTS)
+      ? items.filter((item) => matchFn(item, query)).slice(0, MAX_RESULTS)
       : [];
 
   const inputStyles = clsx(

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback, type ReactNode } from 'react';
 import type { Session, User } from '@supabase/supabase-js';
 import toast from 'react-hot-toast';
+import i18n from '../i18n';
 import { supabase } from '../lib/supabase';
 import { fetchAuthMe } from '../core/api';
 import { AuthContext } from './auth-context';
@@ -26,10 +27,10 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       if (event === 'SIGNED_IN') {
         fetchAuthMe()
           .then((res) => {
-            toast.success(`Signed in as ${res.user.email}`);
+            toast.success(i18n.t('auth.signedInAs', { email: res.user.email }));
           })
           .catch(() => {
-            toast.success('Signed in');
+            toast.success(i18n.t('auth.signedIn'));
           });
       }
 
@@ -47,7 +48,7 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   const signOut = useCallback(async () => {
     const { error } = await supabase.auth.signOut();
     if (error) {
-      toast.error(`Sign out failed: ${error.message}`);
+      toast.error(i18n.t('auth.signOutFailed', { message: error.message }));
     }
   }, []);
 

--- a/src/contexts/LanguageProvider.tsx
+++ b/src/contexts/LanguageProvider.tsx
@@ -1,0 +1,44 @@
+import { useCallback, useEffect, type ReactNode } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+import { LanguageContext, type AppLanguage } from './language-context';
+
+function applyDirection(lang: AppLanguage) {
+  const html = document.documentElement;
+  html.dir = lang === 'he' ? 'rtl' : 'ltr';
+  html.lang = lang;
+}
+
+export default function LanguageProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const { i18n } = useTranslation();
+  const [language, setStoredLanguage] = useLocalStorage<AppLanguage>(
+    'chillist-lang',
+    (i18n.language as AppLanguage) || 'en'
+  );
+
+  useEffect(() => {
+    applyDirection(language);
+    if (i18n.language !== language) {
+      i18n.changeLanguage(language);
+    }
+  }, [language, i18n]);
+
+  const setLanguage = useCallback(
+    (lang: AppLanguage) => {
+      setStoredLanguage(lang);
+      i18n.changeLanguage(lang);
+      applyDirection(lang);
+    },
+    [i18n, setStoredLanguage]
+  );
+
+  return (
+    <LanguageContext.Provider value={{ language, setLanguage }}>
+      {children}
+    </LanguageContext.Provider>
+  );
+}

--- a/src/contexts/language-context.ts
+++ b/src/contexts/language-context.ts
@@ -1,0 +1,12 @@
+import { createContext } from 'react';
+
+export type AppLanguage = 'en' | 'he';
+
+export interface LanguageContextValue {
+  language: AppLanguage;
+  setLanguage: (lang: AppLanguage) => void;
+}
+
+export const LanguageContext = createContext<LanguageContextValue | undefined>(
+  undefined
+);

--- a/src/contexts/useLanguage.ts
+++ b/src/contexts/useLanguage.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { LanguageContext, type LanguageContextValue } from './language-context';
+
+export function useLanguage(): LanguageContextValue {
+  const context = useContext(LanguageContext);
+  if (!context) {
+    throw new Error('useLanguage must be used within a LanguageProvider');
+  }
+  return context;
+}

--- a/src/core/constants/item.ts
+++ b/src/core/constants/item.ts
@@ -1,50 +1,53 @@
 import type { ItemCategory, ItemStatus, Unit } from '../schemas/item';
 
-export const CATEGORY_OPTIONS: { value: ItemCategory; label: string }[] = [
-  { value: 'food', label: 'Food' },
-  { value: 'equipment', label: 'Equipment' },
+export const CATEGORY_OPTIONS: {
+  value: ItemCategory;
+  labelKey: string;
+}[] = [
+  { value: 'food', labelKey: 'categories.food' },
+  { value: 'equipment', labelKey: 'categories.equipment' },
 ];
 
 export const STATUS_OPTIONS: {
   value: ItemStatus;
-  label: string;
+  labelKey: string;
   bg: string;
   text: string;
 }[] = [
   {
     value: 'pending',
-    label: 'Pending',
+    labelKey: 'itemStatus.pending',
     bg: 'bg-yellow-100',
     text: 'text-yellow-800',
   },
   {
     value: 'purchased',
-    label: 'Purchased',
+    labelKey: 'itemStatus.purchased',
     bg: 'bg-blue-100',
     text: 'text-blue-800',
   },
   {
     value: 'packed',
-    label: 'Packed',
+    labelKey: 'itemStatus.packed',
     bg: 'bg-green-100',
     text: 'text-green-800',
   },
   {
     value: 'canceled',
-    label: 'Canceled',
+    labelKey: 'itemStatus.canceled',
     bg: 'bg-gray-100',
     text: 'text-gray-500',
   },
 ];
 
-export const UNIT_OPTIONS: { value: Unit; label: string }[] = [
-  { value: 'kg', label: 'kg' },
-  { value: 'g', label: 'g' },
-  { value: 'lb', label: 'lb' },
-  { value: 'oz', label: 'oz' },
-  { value: 'l', label: 'l' },
-  { value: 'ml', label: 'ml' },
-  { value: 'pcs', label: 'pcs' },
-  { value: 'pack', label: 'pack' },
-  { value: 'set', label: 'set' },
+export const UNIT_OPTIONS: { value: Unit; labelKey: string }[] = [
+  { value: 'kg', labelKey: 'units.kg' },
+  { value: 'g', labelKey: 'units.g' },
+  { value: 'lb', labelKey: 'units.lb' },
+  { value: 'oz', labelKey: 'units.oz' },
+  { value: 'l', labelKey: 'units.l' },
+  { value: 'ml', labelKey: 'units.ml' },
+  { value: 'pcs', labelKey: 'units.pcs' },
+  { value: 'pack', labelKey: 'units.pack' },
+  { value: 'set', labelKey: 'units.set' },
 ];

--- a/src/data/common-items.json
+++ b/src/data/common-items.json
@@ -1,752 +1,5784 @@
 [
-  { "name": "Tent", "category": "equipment", "unit": "pcs" },
-  { "name": "Sleeping Bag", "category": "equipment", "unit": "pcs" },
-  { "name": "Sleeping Pad", "category": "equipment", "unit": "pcs" },
-  { "name": "Camping Stove", "category": "equipment", "unit": "pcs" },
-  { "name": "Flashlight", "category": "equipment", "unit": "pcs" },
-  { "name": "Lantern", "category": "equipment", "unit": "pcs" },
-  { "name": "Headlamp", "category": "equipment", "unit": "pcs" },
-  { "name": "Cooler", "category": "equipment", "unit": "pcs" },
-  { "name": "Grill", "category": "equipment", "unit": "pcs" },
-  { "name": "Folding Chair", "category": "equipment", "unit": "pcs" },
-  { "name": "Folding Table", "category": "equipment", "unit": "pcs" },
-  { "name": "Picnic Blanket", "category": "equipment", "unit": "pcs" },
-  { "name": "Beach Umbrella", "category": "equipment", "unit": "pcs" },
-  { "name": "Tarp", "category": "equipment", "unit": "pcs" },
-  { "name": "Backpack", "category": "equipment", "unit": "pcs" },
-  { "name": "First Aid Kit", "category": "equipment", "unit": "pcs" },
-  { "name": "Sunscreen", "category": "equipment", "unit": "pcs" },
-  { "name": "Insect Repellent", "category": "equipment", "unit": "pcs" },
-  { "name": "Water Bottle", "category": "equipment", "unit": "pcs" },
-  { "name": "Thermos", "category": "equipment", "unit": "pcs" },
-  { "name": "Plates", "category": "equipment", "unit": "set" },
-  { "name": "Cups", "category": "equipment", "unit": "set" },
-  { "name": "Cutlery Set", "category": "equipment", "unit": "set" },
-  { "name": "Napkins", "category": "equipment", "unit": "pack" },
-  { "name": "Trash Bags", "category": "equipment", "unit": "pack" },
-  { "name": "Paper Towels", "category": "equipment", "unit": "pack" },
-  { "name": "Lighter", "category": "equipment", "unit": "pcs" },
-  { "name": "Matches", "category": "equipment", "unit": "pack" },
-  { "name": "Cutting Board", "category": "equipment", "unit": "pcs" },
-  { "name": "Kitchen Knife", "category": "equipment", "unit": "pcs" },
-  { "name": "Tongs", "category": "equipment", "unit": "pcs" },
-  { "name": "Bottle Opener", "category": "equipment", "unit": "pcs" },
-  { "name": "Can Opener", "category": "equipment", "unit": "pcs" },
-  { "name": "Towels", "category": "equipment", "unit": "pcs" },
-  { "name": "Rope", "category": "equipment", "unit": "pcs" },
-  { "name": "Portable Speaker", "category": "equipment", "unit": "pcs" },
-  { "name": "Power Bank", "category": "equipment", "unit": "pcs" },
-  { "name": "Fishing Rod", "category": "equipment", "unit": "pcs" },
-  { "name": "Volleyball", "category": "equipment", "unit": "pcs" },
-  { "name": "Frisbee", "category": "equipment", "unit": "pcs" },
-  { "name": "Playing Cards", "category": "equipment", "unit": "pack" },
-  { "name": "Board Game", "category": "equipment", "unit": "pcs" },
-  { "name": "Hammock", "category": "equipment", "unit": "pcs" },
-  { "name": "Camping Pillow", "category": "equipment", "unit": "pcs" },
-  { "name": "Camp Blanket", "category": "equipment", "unit": "pcs" },
-  { "name": "Tent Stakes", "category": "equipment", "unit": "set" },
-  { "name": "Tent Footprint", "category": "equipment", "unit": "pcs" },
-  { "name": "Rain Fly", "category": "equipment", "unit": "pcs" },
-  { "name": "Camping Cot", "category": "equipment", "unit": "pcs" },
-  { "name": "Air Mattress", "category": "equipment", "unit": "pcs" },
-  { "name": "Air Pump", "category": "equipment", "unit": "pcs" },
-  { "name": "Dutch Oven", "category": "equipment", "unit": "pcs" },
-  { "name": "Cast Iron Skillet", "category": "equipment", "unit": "pcs" },
-  { "name": "Cooking Pot", "category": "equipment", "unit": "pcs" },
-  { "name": "Kettle", "category": "equipment", "unit": "pcs" },
-  { "name": "Spatula", "category": "equipment", "unit": "pcs" },
-  { "name": "Ladle", "category": "equipment", "unit": "pcs" },
-  { "name": "Serving Spoons", "category": "equipment", "unit": "set" },
-  { "name": "Skewers", "category": "equipment", "unit": "set" },
-  { "name": "Grill Grate", "category": "equipment", "unit": "pcs" },
-  { "name": "Charcoal", "category": "equipment", "unit": "kg" },
-  { "name": "Fire Starter", "category": "equipment", "unit": "pack" },
-  { "name": "Firewood", "category": "equipment", "unit": "pack" },
-  { "name": "Axe", "category": "equipment", "unit": "pcs" },
-  { "name": "Multi-Tool", "category": "equipment", "unit": "pcs" },
-  { "name": "Pocket Knife", "category": "equipment", "unit": "pcs" },
-  { "name": "Duct Tape", "category": "equipment", "unit": "pcs" },
-  { "name": "Bungee Cords", "category": "equipment", "unit": "set" },
-  { "name": "Carabiners", "category": "equipment", "unit": "set" },
-  { "name": "Compass", "category": "equipment", "unit": "pcs" },
-  { "name": "Map", "category": "equipment", "unit": "pcs" },
-  { "name": "Binoculars", "category": "equipment", "unit": "pcs" },
-  { "name": "Whistle", "category": "equipment", "unit": "pcs" },
-  { "name": "Emergency Blanket", "category": "equipment", "unit": "pcs" },
-  { "name": "Hand Warmers", "category": "equipment", "unit": "pack" },
-  { "name": "Rain Poncho", "category": "equipment", "unit": "pcs" },
-  { "name": "Waterproof Bag", "category": "equipment", "unit": "pcs" },
-  { "name": "Dry Bag", "category": "equipment", "unit": "pcs" },
-  { "name": "Water Filter", "category": "equipment", "unit": "pcs" },
   {
-    "name": "Water Purification Tablets",
-    "category": "equipment",
-    "unit": "pack"
+    "id": "acai-packets",
+    "name": "Acai Packets",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit"]
   },
-  { "name": "Hydration Pack", "category": "equipment", "unit": "pcs" },
-  { "name": "Cooler Bag", "category": "equipment", "unit": "pcs" },
-  { "name": "Ice Packs", "category": "equipment", "unit": "pcs" },
-  { "name": "Camping Shower", "category": "equipment", "unit": "pcs" },
-  { "name": "Biodegradable Soap", "category": "equipment", "unit": "pcs" },
-  { "name": "Toilet Paper", "category": "equipment", "unit": "pack" },
-  { "name": "Wet Wipes", "category": "equipment", "unit": "pack" },
-  { "name": "Hand Sanitizer", "category": "equipment", "unit": "pcs" },
-  { "name": "Toothbrush", "category": "equipment", "unit": "pcs" },
-  { "name": "Toothpaste", "category": "equipment", "unit": "pcs" },
-  { "name": "Lip Balm", "category": "equipment", "unit": "pcs" },
-  { "name": "Aloe Vera Gel", "category": "equipment", "unit": "pcs" },
-  { "name": "Sunglasses", "category": "equipment", "unit": "pcs" },
-  { "name": "Hat", "category": "equipment", "unit": "pcs" },
-  { "name": "Hiking Boots", "category": "equipment", "unit": "pcs" },
-  { "name": "Sandals", "category": "equipment", "unit": "pcs" },
-  { "name": "Rain Jacket", "category": "equipment", "unit": "pcs" },
-  { "name": "Warm Layers", "category": "equipment", "unit": "pcs" },
-  { "name": "Swimsuit", "category": "equipment", "unit": "pcs" },
-  { "name": "Canoe Paddle", "category": "equipment", "unit": "pcs" },
-  { "name": "Life Jacket", "category": "equipment", "unit": "pcs" },
-  { "name": "Kayak", "category": "equipment", "unit": "pcs" },
-  { "name": "Paddleboard", "category": "equipment", "unit": "pcs" },
-  { "name": "Snorkel Set", "category": "equipment", "unit": "set" },
-  { "name": "Fishing Tackle Box", "category": "equipment", "unit": "pcs" },
-  { "name": "Fishing Bait", "category": "equipment", "unit": "pack" },
-  { "name": "Bike", "category": "equipment", "unit": "pcs" },
-  { "name": "Bike Helmet", "category": "equipment", "unit": "pcs" },
-  { "name": "Badminton Set", "category": "equipment", "unit": "set" },
-  { "name": "Soccer Ball", "category": "equipment", "unit": "pcs" },
-  { "name": "Football", "category": "equipment", "unit": "pcs" },
-  { "name": "Kite", "category": "equipment", "unit": "pcs" },
-  { "name": "Bocce Ball Set", "category": "equipment", "unit": "set" },
-  { "name": "Cornhole Set", "category": "equipment", "unit": "set" },
-  { "name": "Horseshoe Set", "category": "equipment", "unit": "set" },
-  { "name": "Walkie-Talkies", "category": "equipment", "unit": "set" },
-  { "name": "Camera", "category": "equipment", "unit": "pcs" },
-  { "name": "Tripod", "category": "equipment", "unit": "pcs" },
-  { "name": "Extension Cord", "category": "equipment", "unit": "pcs" },
-  { "name": "Portable Generator", "category": "equipment", "unit": "pcs" },
-  { "name": "Solar Charger", "category": "equipment", "unit": "pcs" },
-  { "name": "Battery Pack", "category": "equipment", "unit": "pack" },
-  { "name": "Spare Batteries", "category": "equipment", "unit": "pack" },
-  { "name": "USB Charging Cable", "category": "equipment", "unit": "pcs" },
-  { "name": "Portable Fan", "category": "equipment", "unit": "pcs" },
-  { "name": "Camping Heater", "category": "equipment", "unit": "pcs" },
-  { "name": "Propane Tank", "category": "equipment", "unit": "pcs" },
-  { "name": "Fuel Canister", "category": "equipment", "unit": "pcs" },
-  { "name": "Collapsible Bucket", "category": "equipment", "unit": "pcs" },
-  { "name": "Clothesline", "category": "equipment", "unit": "pcs" },
-  { "name": "Clothespins", "category": "equipment", "unit": "pack" },
-  { "name": "Dish Soap", "category": "equipment", "unit": "pcs" },
-  { "name": "Sponge", "category": "equipment", "unit": "pcs" },
-  { "name": "Wash Basin", "category": "equipment", "unit": "pcs" },
-  { "name": "Zip Ties", "category": "equipment", "unit": "pack" },
-  { "name": "Paracord", "category": "equipment", "unit": "pcs" },
-  { "name": "Flag Markers", "category": "equipment", "unit": "pack" },
-  { "name": "Bear Canister", "category": "equipment", "unit": "pcs" },
-  { "name": "Bear Spray", "category": "equipment", "unit": "pcs" },
-  { "name": "Mosquito Net", "category": "equipment", "unit": "pcs" },
-  { "name": "Citronella Candles", "category": "equipment", "unit": "pack" },
-  { "name": "String Lights", "category": "equipment", "unit": "set" },
-  { "name": "Glow Sticks", "category": "equipment", "unit": "pack" },
-  { "name": "Star Chart", "category": "equipment", "unit": "pcs" },
-  { "name": "Field Guide", "category": "equipment", "unit": "pcs" },
-  { "name": "Journal", "category": "equipment", "unit": "pcs" },
-  { "name": "Pen", "category": "equipment", "unit": "pcs" },
-  { "name": "Book", "category": "equipment", "unit": "pcs" },
-  { "name": "Chicken Breast", "category": "food", "unit": "kg" },
-  { "name": "Ground Beef", "category": "food", "unit": "kg" },
-  { "name": "Steak", "category": "food", "unit": "kg" },
-  { "name": "Sausages", "category": "food", "unit": "pack" },
-  { "name": "Hot Dogs", "category": "food", "unit": "pack" },
-  { "name": "Burger Patties", "category": "food", "unit": "pack" },
-  { "name": "Bacon", "category": "food", "unit": "pack" },
-  { "name": "Eggs", "category": "food", "unit": "pcs" },
-  { "name": "Bread", "category": "food", "unit": "pcs" },
-  { "name": "Burger Buns", "category": "food", "unit": "pack" },
-  { "name": "Hot Dog Buns", "category": "food", "unit": "pack" },
-  { "name": "Tortillas", "category": "food", "unit": "pack" },
-  { "name": "Rice", "category": "food", "unit": "kg" },
-  { "name": "Pasta", "category": "food", "unit": "pack" },
-  { "name": "Cheese", "category": "food", "unit": "kg" },
-  { "name": "Butter", "category": "food", "unit": "pack" },
-  { "name": "Milk", "category": "food", "unit": "l" },
-  { "name": "Yogurt", "category": "food", "unit": "pcs" },
-  { "name": "Apples", "category": "food", "unit": "kg" },
-  { "name": "Bananas", "category": "food", "unit": "kg" },
-  { "name": "Oranges", "category": "food", "unit": "kg" },
-  { "name": "Grapes", "category": "food", "unit": "kg" },
-  { "name": "Strawberries", "category": "food", "unit": "pack" },
-  { "name": "Watermelon", "category": "food", "unit": "pcs" },
-  { "name": "Tomatoes", "category": "food", "unit": "kg" },
-  { "name": "Lettuce", "category": "food", "unit": "pcs" },
-  { "name": "Onions", "category": "food", "unit": "kg" },
-  { "name": "Potatoes", "category": "food", "unit": "kg" },
-  { "name": "Corn on the Cob", "category": "food", "unit": "pcs" },
-  { "name": "Carrots", "category": "food", "unit": "kg" },
-  { "name": "Cucumber", "category": "food", "unit": "pcs" },
-  { "name": "Bell Peppers", "category": "food", "unit": "pcs" },
-  { "name": "Mushrooms", "category": "food", "unit": "pack" },
-  { "name": "Hummus", "category": "food", "unit": "pcs" },
-  { "name": "Peanut Butter", "category": "food", "unit": "pcs" },
-  { "name": "Chips", "category": "food", "unit": "pack" },
-  { "name": "Crackers", "category": "food", "unit": "pack" },
-  { "name": "Trail Mix", "category": "food", "unit": "pack" },
-  { "name": "Energy Bars", "category": "food", "unit": "pack" },
-  { "name": "Granola", "category": "food", "unit": "pack" },
-  { "name": "Marshmallows", "category": "food", "unit": "pack" },
-  { "name": "Chocolate", "category": "food", "unit": "pack" },
-  { "name": "Cookies", "category": "food", "unit": "pack" },
-  { "name": "Ice", "category": "food", "unit": "kg" },
-  { "name": "Water", "category": "food", "unit": "l" },
-  { "name": "Juice", "category": "food", "unit": "l" },
-  { "name": "Soda", "category": "food", "unit": "l" },
-  { "name": "Beer", "category": "food", "unit": "pack" },
-  { "name": "Wine", "category": "food", "unit": "pcs" },
-  { "name": "Coffee", "category": "food", "unit": "pack" },
-  { "name": "Tea Bags", "category": "food", "unit": "pack" },
-  { "name": "Ketchup", "category": "food", "unit": "pcs" },
-  { "name": "Mustard", "category": "food", "unit": "pcs" },
-  { "name": "BBQ Sauce", "category": "food", "unit": "pcs" },
-  { "name": "Olive Oil", "category": "food", "unit": "pcs" },
-  { "name": "Salt", "category": "food", "unit": "pcs" },
-  { "name": "Pepper", "category": "food", "unit": "pcs" },
-  { "name": "Salad Dressing", "category": "food", "unit": "pcs" },
-  { "name": "Aluminum Foil", "category": "food", "unit": "pcs" },
-  { "name": "Sandwich Bags", "category": "food", "unit": "pack" },
-  { "name": "Chicken Thighs", "category": "food", "unit": "kg" },
-  { "name": "Chicken Wings", "category": "food", "unit": "kg" },
-  { "name": "Pork Chops", "category": "food", "unit": "kg" },
-  { "name": "Pulled Pork", "category": "food", "unit": "kg" },
-  { "name": "Ribs", "category": "food", "unit": "kg" },
-  { "name": "Lamb Chops", "category": "food", "unit": "kg" },
-  { "name": "Salmon Fillet", "category": "food", "unit": "kg" },
-  { "name": "Shrimp", "category": "food", "unit": "kg" },
-  { "name": "Tuna Steaks", "category": "food", "unit": "kg" },
-  { "name": "Canned Tuna", "category": "food", "unit": "pcs" },
-  { "name": "Canned Beans", "category": "food", "unit": "pcs" },
-  { "name": "Canned Soup", "category": "food", "unit": "pcs" },
-  { "name": "Canned Corn", "category": "food", "unit": "pcs" },
-  { "name": "Canned Tomatoes", "category": "food", "unit": "pcs" },
-  { "name": "Baked Beans", "category": "food", "unit": "pcs" },
-  { "name": "Chili", "category": "food", "unit": "pcs" },
-  { "name": "Instant Noodles", "category": "food", "unit": "pack" },
-  { "name": "Instant Oatmeal", "category": "food", "unit": "pack" },
-  { "name": "Pancake Mix", "category": "food", "unit": "pack" },
-  { "name": "Maple Syrup", "category": "food", "unit": "pcs" },
-  { "name": "Honey", "category": "food", "unit": "pcs" },
-  { "name": "Jam", "category": "food", "unit": "pcs" },
-  { "name": "Nutella", "category": "food", "unit": "pcs" },
-  { "name": "Cream Cheese", "category": "food", "unit": "pcs" },
-  { "name": "Sliced Cheese", "category": "food", "unit": "pack" },
-  { "name": "Ham", "category": "food", "unit": "pack" },
-  { "name": "Turkey Slices", "category": "food", "unit": "pack" },
-  { "name": "Salami", "category": "food", "unit": "pack" },
-  { "name": "Pepperoni", "category": "food", "unit": "pack" },
-  { "name": "Smoked Salmon", "category": "food", "unit": "pack" },
-  { "name": "Jerky", "category": "food", "unit": "pack" },
-  { "name": "Dried Fruit", "category": "food", "unit": "pack" },
-  { "name": "Raisins", "category": "food", "unit": "pack" },
-  { "name": "Almonds", "category": "food", "unit": "pack" },
-  { "name": "Cashews", "category": "food", "unit": "pack" },
-  { "name": "Peanuts", "category": "food", "unit": "pack" },
-  { "name": "Sunflower Seeds", "category": "food", "unit": "pack" },
-  { "name": "Popcorn", "category": "food", "unit": "pack" },
-  { "name": "Pretzels", "category": "food", "unit": "pack" },
-  { "name": "Salsa", "category": "food", "unit": "pcs" },
-  { "name": "Guacamole", "category": "food", "unit": "pcs" },
-  { "name": "Tortilla Chips", "category": "food", "unit": "pack" },
-  { "name": "Pita Bread", "category": "food", "unit": "pack" },
-  { "name": "Bagels", "category": "food", "unit": "pack" },
-  { "name": "English Muffins", "category": "food", "unit": "pack" },
-  { "name": "Croissants", "category": "food", "unit": "pack" },
-  { "name": "Muffins", "category": "food", "unit": "pack" },
-  { "name": "Cereal", "category": "food", "unit": "pack" },
-  { "name": "Granola Bars", "category": "food", "unit": "pack" },
-  { "name": "Protein Bars", "category": "food", "unit": "pack" },
-  { "name": "Blueberries", "category": "food", "unit": "pack" },
-  { "name": "Raspberries", "category": "food", "unit": "pack" },
-  { "name": "Cherries", "category": "food", "unit": "pack" },
-  { "name": "Peaches", "category": "food", "unit": "kg" },
-  { "name": "Pears", "category": "food", "unit": "kg" },
-  { "name": "Pineapple", "category": "food", "unit": "pcs" },
-  { "name": "Mango", "category": "food", "unit": "pcs" },
-  { "name": "Avocado", "category": "food", "unit": "pcs" },
-  { "name": "Lemons", "category": "food", "unit": "pcs" },
-  { "name": "Limes", "category": "food", "unit": "pcs" },
-  { "name": "Celery", "category": "food", "unit": "pcs" },
-  { "name": "Broccoli", "category": "food", "unit": "pcs" },
-  { "name": "Zucchini", "category": "food", "unit": "pcs" },
-  { "name": "Asparagus", "category": "food", "unit": "pack" },
-  { "name": "Green Beans", "category": "food", "unit": "pack" },
-  { "name": "Sweet Potatoes", "category": "food", "unit": "kg" },
-  { "name": "Garlic", "category": "food", "unit": "pcs" },
-  { "name": "Ginger", "category": "food", "unit": "pcs" },
-  { "name": "Jalapenos", "category": "food", "unit": "pcs" },
-  { "name": "Fresh Herbs", "category": "food", "unit": "pack" },
-  { "name": "Coleslaw Mix", "category": "food", "unit": "pack" },
-  { "name": "Salad Mix", "category": "food", "unit": "pack" },
-  { "name": "Couscous", "category": "food", "unit": "pack" },
-  { "name": "Quinoa", "category": "food", "unit": "pack" },
-  { "name": "Flour", "category": "food", "unit": "kg" },
-  { "name": "Sugar", "category": "food", "unit": "kg" },
-  { "name": "Brown Sugar", "category": "food", "unit": "pack" },
-  { "name": "Cooking Spray", "category": "food", "unit": "pcs" },
-  { "name": "Vegetable Oil", "category": "food", "unit": "pcs" },
-  { "name": "Soy Sauce", "category": "food", "unit": "pcs" },
-  { "name": "Hot Sauce", "category": "food", "unit": "pcs" },
-  { "name": "Worcestershire Sauce", "category": "food", "unit": "pcs" },
-  { "name": "Vinegar", "category": "food", "unit": "pcs" },
-  { "name": "Mayonnaise", "category": "food", "unit": "pcs" },
-  { "name": "Relish", "category": "food", "unit": "pcs" },
-  { "name": "Pickles", "category": "food", "unit": "pcs" },
-  { "name": "Olives", "category": "food", "unit": "pcs" },
-  { "name": "Garlic Powder", "category": "food", "unit": "pcs" },
-  { "name": "Onion Powder", "category": "food", "unit": "pcs" },
-  { "name": "Paprika", "category": "food", "unit": "pcs" },
-  { "name": "Cumin", "category": "food", "unit": "pcs" },
-  { "name": "Chili Powder", "category": "food", "unit": "pcs" },
-  { "name": "Italian Seasoning", "category": "food", "unit": "pcs" },
-  { "name": "Cinnamon", "category": "food", "unit": "pcs" },
-  { "name": "S'mores Kit", "category": "food", "unit": "pack" },
-  { "name": "Graham Crackers", "category": "food", "unit": "pack" },
-  { "name": "Chocolate Bars", "category": "food", "unit": "pack" },
-  { "name": "Brownies", "category": "food", "unit": "pack" },
-  { "name": "Cake Mix", "category": "food", "unit": "pack" },
-  { "name": "Pie", "category": "food", "unit": "pcs" },
-  { "name": "Ice Cream", "category": "food", "unit": "l" },
-  { "name": "Frozen Pizza", "category": "food", "unit": "pcs" },
-  { "name": "Frozen Vegetables", "category": "food", "unit": "pack" },
-  { "name": "Frozen Fruit", "category": "food", "unit": "pack" },
-  { "name": "Frozen Burgers", "category": "food", "unit": "pack" },
-  { "name": "Sparkling Water", "category": "food", "unit": "l" },
-  { "name": "Lemonade", "category": "food", "unit": "l" },
-  { "name": "Iced Tea", "category": "food", "unit": "l" },
-  { "name": "Sports Drink", "category": "food", "unit": "l" },
-  { "name": "Coconut Water", "category": "food", "unit": "l" },
-  { "name": "Hot Chocolate Mix", "category": "food", "unit": "pack" },
-  { "name": "Instant Coffee", "category": "food", "unit": "pack" },
-  { "name": "Coffee Filters", "category": "food", "unit": "pack" },
-  { "name": "Creamer", "category": "food", "unit": "pcs" },
-  { "name": "Cider", "category": "food", "unit": "l" },
-  { "name": "Cocktail Mixer", "category": "food", "unit": "l" },
-  { "name": "Spirits", "category": "food", "unit": "pcs" },
-  { "name": "Hard Seltzer", "category": "food", "unit": "pack" },
-  { "name": "Plastic Wrap", "category": "food", "unit": "pcs" },
-  { "name": "Parchment Paper", "category": "food", "unit": "pcs" },
-  { "name": "Food Storage Containers", "category": "food", "unit": "set" },
-  { "name": "Disposable Gloves", "category": "food", "unit": "pack" },
-  { "name": "Toothpicks", "category": "food", "unit": "pack" },
-  { "name": "Straws", "category": "food", "unit": "pack" },
-  { "name": "Paper Plates", "category": "food", "unit": "pack" },
-  { "name": "Plastic Cups", "category": "food", "unit": "pack" },
-  { "name": "Disposable Cutlery", "category": "food", "unit": "pack" },
-  { "name": "Tofu", "category": "food", "unit": "kg" },
-  { "name": "Tempeh", "category": "food", "unit": "pack" },
-  { "name": "Seitan", "category": "food", "unit": "pack" },
-  { "name": "Veggie Burgers", "category": "food", "unit": "pack" },
-  { "name": "Veggie Sausages", "category": "food", "unit": "pack" },
-  { "name": "Veggie Hot Dogs", "category": "food", "unit": "pack" },
-  { "name": "Beyond Meat", "category": "food", "unit": "pack" },
-  { "name": "Falafel", "category": "food", "unit": "pack" },
-  { "name": "Edamame", "category": "food", "unit": "pack" },
-  { "name": "Chickpeas", "category": "food", "unit": "pack" },
-  { "name": "Lentils", "category": "food", "unit": "pack" },
-  { "name": "Black Beans", "category": "food", "unit": "pack" },
-  { "name": "Kidney Beans", "category": "food", "unit": "pack" },
-  { "name": "Oat Milk", "category": "food", "unit": "l" },
-  { "name": "Almond Milk", "category": "food", "unit": "l" },
-  { "name": "Soy Milk", "category": "food", "unit": "l" },
-  { "name": "Coconut Milk", "category": "food", "unit": "l" },
-  { "name": "Vegan Cheese", "category": "food", "unit": "pack" },
-  { "name": "Vegan Butter", "category": "food", "unit": "pack" },
-  { "name": "Vegan Mayo", "category": "food", "unit": "pcs" },
-  { "name": "Vegan Yogurt", "category": "food", "unit": "pcs" },
-  { "name": "Nutritional Yeast", "category": "food", "unit": "pcs" },
-  { "name": "Tahini", "category": "food", "unit": "pcs" },
-  { "name": "Almond Butter", "category": "food", "unit": "pcs" },
-  { "name": "Cashew Butter", "category": "food", "unit": "pcs" },
-  { "name": "Chia Seeds", "category": "food", "unit": "pack" },
-  { "name": "Flax Seeds", "category": "food", "unit": "pack" },
-  { "name": "Hemp Seeds", "category": "food", "unit": "pack" },
-  { "name": "Pumpkin Seeds", "category": "food", "unit": "pack" },
-  { "name": "Walnuts", "category": "food", "unit": "pack" },
-  { "name": "Pistachios", "category": "food", "unit": "pack" },
-  { "name": "Mixed Nuts", "category": "food", "unit": "pack" },
-  { "name": "Kale", "category": "food", "unit": "pack" },
-  { "name": "Spinach", "category": "food", "unit": "pack" },
-  { "name": "Arugula", "category": "food", "unit": "pack" },
-  { "name": "Swiss Chard", "category": "food", "unit": "pack" },
-  { "name": "Cabbage", "category": "food", "unit": "pcs" },
-  { "name": "Brussels Sprouts", "category": "food", "unit": "pack" },
-  { "name": "Cauliflower", "category": "food", "unit": "pcs" },
-  { "name": "Beets", "category": "food", "unit": "kg" },
-  { "name": "Radishes", "category": "food", "unit": "pack" },
-  { "name": "Snap Peas", "category": "food", "unit": "pack" },
-  { "name": "Eggplant", "category": "food", "unit": "pcs" },
-  { "name": "Artichokes", "category": "food", "unit": "pcs" },
-  { "name": "Fennel", "category": "food", "unit": "pcs" },
-  { "name": "Butternut Squash", "category": "food", "unit": "pcs" },
-  { "name": "Acorn Squash", "category": "food", "unit": "pcs" },
-  { "name": "Portobello Mushrooms", "category": "food", "unit": "pack" },
-  { "name": "Sun-Dried Tomatoes", "category": "food", "unit": "pack" },
-  { "name": "Roasted Red Peppers", "category": "food", "unit": "pcs" },
-  { "name": "Kimchi", "category": "food", "unit": "pcs" },
-  { "name": "Sauerkraut", "category": "food", "unit": "pcs" },
-  { "name": "Miso Paste", "category": "food", "unit": "pcs" },
-  { "name": "Coconut Cream", "category": "food", "unit": "pcs" },
-  { "name": "Coconut Oil", "category": "food", "unit": "pcs" },
-  { "name": "Avocado Oil", "category": "food", "unit": "pcs" },
-  { "name": "Flaxseed Oil", "category": "food", "unit": "pcs" },
-  { "name": "Apple Cider Vinegar", "category": "food", "unit": "pcs" },
-  { "name": "Balsamic Vinegar", "category": "food", "unit": "pcs" },
-  { "name": "Tamari", "category": "food", "unit": "pcs" },
-  { "name": "Sriracha", "category": "food", "unit": "pcs" },
-  { "name": "Agave Syrup", "category": "food", "unit": "pcs" },
-  { "name": "Date Syrup", "category": "food", "unit": "pcs" },
-  { "name": "Brown Rice", "category": "food", "unit": "kg" },
-  { "name": "Wild Rice", "category": "food", "unit": "pack" },
-  { "name": "Bulgur", "category": "food", "unit": "pack" },
-  { "name": "Buckwheat", "category": "food", "unit": "pack" },
-  { "name": "Whole Wheat Pasta", "category": "food", "unit": "pack" },
-  { "name": "Rice Noodles", "category": "food", "unit": "pack" },
-  { "name": "Whole Wheat Bread", "category": "food", "unit": "pcs" },
-  { "name": "Whole Wheat Tortillas", "category": "food", "unit": "pack" },
-  { "name": "Rice Cakes", "category": "food", "unit": "pack" },
-  { "name": "Veggie Chips", "category": "food", "unit": "pack" },
-  { "name": "Kale Chips", "category": "food", "unit": "pack" },
-  { "name": "Seaweed Snacks", "category": "food", "unit": "pack" },
-  { "name": "Dried Mango", "category": "food", "unit": "pack" },
-  { "name": "Dried Cranberries", "category": "food", "unit": "pack" },
-  { "name": "Dates", "category": "food", "unit": "pack" },
-  { "name": "Goji Berries", "category": "food", "unit": "pack" },
-  { "name": "Acai Packets", "category": "food", "unit": "pack" },
-  { "name": "Smoothie Mix", "category": "food", "unit": "pack" },
-  { "name": "Protein Powder", "category": "food", "unit": "pcs" },
-  { "name": "Spirulina", "category": "food", "unit": "pack" },
-  { "name": "Turmeric", "category": "food", "unit": "pcs" },
-  { "name": "Matcha", "category": "food", "unit": "pack" },
-  { "name": "Herbal Tea", "category": "food", "unit": "pack" },
-  { "name": "Green Tea", "category": "food", "unit": "pack" },
-  { "name": "Kombucha", "category": "food", "unit": "l" },
-  { "name": "Fresh Squeezed Juice", "category": "food", "unit": "l" },
-  { "name": "Aloe Vera Juice", "category": "food", "unit": "l" },
-  { "name": "Dark Chocolate", "category": "food", "unit": "pack" },
-  { "name": "Vegan Cookies", "category": "food", "unit": "pack" },
-  { "name": "Fruit Leather", "category": "food", "unit": "pack" },
-  { "name": "Coconut Yogurt", "category": "food", "unit": "pcs" },
-  { "name": "Overnight Oats Mix", "category": "food", "unit": "pack" },
-  { "name": "Stroller", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Carrier", "category": "equipment", "unit": "pcs" },
-  { "name": "Portable Crib", "category": "equipment", "unit": "pcs" },
-  { "name": "Pack and Play", "category": "equipment", "unit": "pcs" },
-  { "name": "Travel High Chair", "category": "equipment", "unit": "pcs" },
-  { "name": "Booster Seat", "category": "equipment", "unit": "pcs" },
-  { "name": "Car Seat", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Monitor", "category": "equipment", "unit": "pcs" },
-  { "name": "Diaper Bag", "category": "equipment", "unit": "pcs" },
-  { "name": "Diapers", "category": "equipment", "unit": "pack" },
-  { "name": "Baby Wipes", "category": "equipment", "unit": "pack" },
-  { "name": "Diaper Cream", "category": "equipment", "unit": "pcs" },
-  { "name": "Changing Pad", "category": "equipment", "unit": "pcs" },
-  { "name": "Diaper Disposal Bags", "category": "equipment", "unit": "pack" },
-  { "name": "Baby Blanket", "category": "equipment", "unit": "pcs" },
-  { "name": "Swaddle", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Sleeping Bag", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Sunscreen", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Insect Repellent", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Sun Hat", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Sunglasses", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Swim Diapers", "category": "equipment", "unit": "pack" },
-  { "name": "Baby Swimsuit", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Life Jacket", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Bathtub", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Shampoo", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Body Wash", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Lotion", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Towel", "category": "equipment", "unit": "pcs" },
-  { "name": "Pacifier", "category": "equipment", "unit": "pcs" },
-  { "name": "Teething Toy", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Bottles", "category": "equipment", "unit": "pcs" },
-  { "name": "Bottle Brush", "category": "equipment", "unit": "pcs" },
-  { "name": "Bottle Warmer", "category": "equipment", "unit": "pcs" },
-  { "name": "Sippy Cups", "category": "equipment", "unit": "pcs" },
-  { "name": "Toddler Plates", "category": "equipment", "unit": "set" },
-  { "name": "Toddler Bowls", "category": "equipment", "unit": "set" },
-  { "name": "Toddler Cutlery", "category": "equipment", "unit": "set" },
-  { "name": "Bibs", "category": "equipment", "unit": "pack" },
-  { "name": "Splat Mat", "category": "equipment", "unit": "pcs" },
-  { "name": "Snack Containers", "category": "equipment", "unit": "set" },
-  { "name": "Baby First Aid Kit", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Thermometer", "category": "equipment", "unit": "pcs" },
-  { "name": "Infant Tylenol", "category": "equipment", "unit": "pcs" },
-  { "name": "Saline Drops", "category": "equipment", "unit": "pcs" },
-  { "name": "Nose Aspirator", "category": "equipment", "unit": "pcs" },
-  { "name": "Band-Aids (kids)", "category": "equipment", "unit": "pack" },
-  { "name": "Baby Gate", "category": "equipment", "unit": "pcs" },
-  { "name": "Outlet Covers", "category": "equipment", "unit": "pack" },
-  { "name": "Corner Protectors", "category": "equipment", "unit": "pack" },
-  { "name": "Cabinet Locks", "category": "equipment", "unit": "pack" },
-  { "name": "Night Light", "category": "equipment", "unit": "pcs" },
-  { "name": "White Noise Machine", "category": "equipment", "unit": "pcs" },
-  { "name": "Stuffed Animal", "category": "equipment", "unit": "pcs" },
-  { "name": "Comfort Blanket", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Backpack", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Water Bottle", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Sunscreen", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Hat", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Rain Boots", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Rain Jacket", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Sleeping Bag", "category": "equipment", "unit": "pcs" },
-  { "name": "Sand Toys", "category": "equipment", "unit": "set" },
-  { "name": "Beach Ball", "category": "equipment", "unit": "pcs" },
-  { "name": "Bubbles", "category": "equipment", "unit": "pcs" },
-  { "name": "Coloring Books", "category": "equipment", "unit": "pcs" },
-  { "name": "Crayons", "category": "equipment", "unit": "pack" },
-  { "name": "Colored Pencils", "category": "equipment", "unit": "pack" },
-  { "name": "Stickers", "category": "equipment", "unit": "pack" },
-  { "name": "Kids Books", "category": "equipment", "unit": "pcs" },
-  { "name": "Puzzle", "category": "equipment", "unit": "pcs" },
-  { "name": "Action Figures", "category": "equipment", "unit": "pcs" },
-  { "name": "Dolls", "category": "equipment", "unit": "pcs" },
-  { "name": "Toy Cars", "category": "equipment", "unit": "set" },
-  { "name": "Building Blocks", "category": "equipment", "unit": "set" },
-  { "name": "Playdough", "category": "equipment", "unit": "pack" },
-  { "name": "Water Guns", "category": "equipment", "unit": "pcs" },
-  { "name": "Jump Rope", "category": "equipment", "unit": "pcs" },
-  { "name": "Hula Hoop", "category": "equipment", "unit": "pcs" },
-  { "name": "Scooter", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Bike Helmet", "category": "equipment", "unit": "pcs" },
-  { "name": "Floaties", "category": "equipment", "unit": "set" },
-  { "name": "Inflatable Pool", "category": "equipment", "unit": "pcs" },
-  { "name": "Pool Noodles", "category": "equipment", "unit": "pcs" },
-  { "name": "Bug Catcher Kit", "category": "equipment", "unit": "set" },
-  { "name": "Magnifying Glass", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Binoculars", "category": "equipment", "unit": "pcs" },
   {
-    "name": "Nature Scavenger Hunt Cards",
+    "id": "ace-wrap",
+    "name": "ACE Wrap",
     "category": "equipment",
-    "unit": "pack"
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
   },
-  { "name": "Tablet", "category": "equipment", "unit": "pcs" },
-  { "name": "Kids Headphones", "category": "equipment", "unit": "pcs" },
-  { "name": "Portable DVD Player", "category": "equipment", "unit": "pcs" },
-  { "name": "Baby Formula", "category": "food", "unit": "pack" },
-  { "name": "Baby Cereal", "category": "food", "unit": "pack" },
-  { "name": "Baby Food Pouches", "category": "food", "unit": "pack" },
-  { "name": "Baby Food Jars", "category": "food", "unit": "pack" },
-  { "name": "Puffs (baby snack)", "category": "food", "unit": "pack" },
-  { "name": "Teething Biscuits", "category": "food", "unit": "pack" },
-  { "name": "Rice Rusks", "category": "food", "unit": "pack" },
-  { "name": "Toddler Snack Bars", "category": "food", "unit": "pack" },
-  { "name": "Goldfish Crackers", "category": "food", "unit": "pack" },
-  { "name": "Animal Crackers", "category": "food", "unit": "pack" },
-  { "name": "Cheese Sticks", "category": "food", "unit": "pack" },
-  { "name": "Yogurt Tubes", "category": "food", "unit": "pack" },
-  { "name": "Applesauce Pouches", "category": "food", "unit": "pack" },
-  { "name": "Fruit Cups", "category": "food", "unit": "pack" },
-  { "name": "Raisin Boxes", "category": "food", "unit": "pack" },
-  { "name": "Mini Muffins", "category": "food", "unit": "pack" },
-  { "name": "Mini Pancakes", "category": "food", "unit": "pack" },
-  { "name": "Chicken Nuggets", "category": "food", "unit": "pack" },
-  { "name": "Fish Sticks", "category": "food", "unit": "pack" },
-  { "name": "Mac and Cheese", "category": "food", "unit": "pack" },
-  { "name": "PB&J Supplies", "category": "food", "unit": "set" },
-  { "name": "Fruit Snacks", "category": "food", "unit": "pack" },
-  { "name": "Pudding Cups", "category": "food", "unit": "pack" },
-  { "name": "Jello Cups", "category": "food", "unit": "pack" },
-  { "name": "Juice Boxes", "category": "food", "unit": "pack" },
-  { "name": "Kids Water Pouches", "category": "food", "unit": "pack" },
-  { "name": "Pedialyte", "category": "food", "unit": "pack" },
-  { "name": "Whole Milk", "category": "food", "unit": "l" },
-  { "name": "Chocolate Milk", "category": "food", "unit": "l" },
-  { "name": "String Cheese", "category": "food", "unit": "pack" },
-  { "name": "Mini Bagels", "category": "food", "unit": "pack" },
-  { "name": "Teddy Grahams", "category": "food", "unit": "pack" },
-  { "name": "Veggie Straws", "category": "food", "unit": "pack" },
-  { "name": "Freeze-Dried Fruit", "category": "food", "unit": "pack" },
-  { "name": "Squeezable Yogurt", "category": "food", "unit": "pack" },
-  { "name": "Mini Sandwiches", "category": "food", "unit": "pack" },
-  { "name": "Popsicles", "category": "food", "unit": "pack" },
-  { "name": "Bandages (assorted)", "category": "equipment", "unit": "pack" },
-  { "name": "Gauze Pads", "category": "equipment", "unit": "pack" },
-  { "name": "Gauze Roll", "category": "equipment", "unit": "pcs" },
-  { "name": "Medical Tape", "category": "equipment", "unit": "pcs" },
-  { "name": "Antiseptic Wipes", "category": "equipment", "unit": "pack" },
-  { "name": "Hydrogen Peroxide", "category": "equipment", "unit": "pcs" },
-  { "name": "Antibiotic Ointment", "category": "equipment", "unit": "pcs" },
-  { "name": "Hydrocortisone Cream", "category": "equipment", "unit": "pcs" },
-  { "name": "Anti-Itch Cream", "category": "equipment", "unit": "pcs" },
-  { "name": "Burn Gel", "category": "equipment", "unit": "pcs" },
-  { "name": "Ibuprofen", "category": "equipment", "unit": "pcs" },
-  { "name": "Acetaminophen", "category": "equipment", "unit": "pcs" },
-  { "name": "Aspirin", "category": "equipment", "unit": "pcs" },
-  { "name": "Antihistamine", "category": "equipment", "unit": "pcs" },
-  { "name": "Allergy Medication", "category": "equipment", "unit": "pcs" },
-  { "name": "EpiPen", "category": "equipment", "unit": "pcs" },
-  { "name": "Motion Sickness Pills", "category": "equipment", "unit": "pcs" },
   {
+    "id": "acetaminophen",
+    "name": "Acetaminophen",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "acorn-squash",
+    "name": "Acorn Squash",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "action-figures",
+    "name": "Action Figures",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "after-bite",
+    "name": "After Bite",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "agave-syrup",
+    "name": "Agave Syrup",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "air-mattress",
+    "name": "Air Mattress",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Inflatable Mattress", "Air Bed", "מזרן מתנפח"],
+    "tags": ["sleep"]
+  },
+  {
+    "id": "air-pump",
+    "name": "Air Pump",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "allergy-medication",
+    "name": "Allergy Medication",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "almond-butter",
+    "name": "Almond Butter",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "almond-milk",
+    "name": "Almond Milk",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["Almond Mylk"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "almonds",
+    "name": "Almonds",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["שקדים"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "aloe-vera-gel",
+    "name": "Aloe Vera Gel",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "aloe-vera-juice",
+    "name": "Aloe Vera Juice",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "aluminum-foil",
+    "name": "Aluminum Foil",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Tin Foil", "Aluminium Foil", "Foil", "נייר אלומיניום", "רדיד"],
+    "tags": []
+  },
+  {
+    "id": "animal-crackers",
+    "name": "Animal Crackers",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["ביסקוויטים"],
+    "tags": ["kids", "snack"]
+  },
+  {
+    "id": "antacid-tablets",
+    "name": "Antacid Tablets",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "anti-diarrhea-medication",
     "name": "Anti-Diarrhea Medication",
     "category": "equipment",
-    "unit": "pcs"
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
   },
-  { "name": "Antacid Tablets", "category": "equipment", "unit": "pcs" },
-  { "name": "Electrolyte Packets", "category": "equipment", "unit": "pack" },
-  { "name": "Oral Rehydration Salts", "category": "equipment", "unit": "pack" },
-  { "name": "Thermometer", "category": "equipment", "unit": "pcs" },
-  { "name": "Tweezers", "category": "equipment", "unit": "pcs" },
-  { "name": "Scissors (medical)", "category": "equipment", "unit": "pcs" },
-  { "name": "Safety Pins", "category": "equipment", "unit": "pack" },
-  { "name": "Splint", "category": "equipment", "unit": "pcs" },
-  { "name": "Elastic Bandage", "category": "equipment", "unit": "pcs" },
-  { "name": "ACE Wrap", "category": "equipment", "unit": "pcs" },
-  { "name": "Triangle Bandage", "category": "equipment", "unit": "pcs" },
-  { "name": "Cold Pack (instant)", "category": "equipment", "unit": "pack" },
-  { "name": "Hot Pack (instant)", "category": "equipment", "unit": "pack" },
-  { "name": "Moleskin", "category": "equipment", "unit": "pack" },
-  { "name": "Blister Pads", "category": "equipment", "unit": "pack" },
-  { "name": "Eye Drops", "category": "equipment", "unit": "pcs" },
-  { "name": "Saline Wound Wash", "category": "equipment", "unit": "pcs" },
-  { "name": "Butterfly Bandages", "category": "equipment", "unit": "pack" },
-  { "name": "Sterile Gloves", "category": "equipment", "unit": "pack" },
-  { "name": "CPR Mask", "category": "equipment", "unit": "pcs" },
-  { "name": "Tourniquet", "category": "equipment", "unit": "pcs" },
-  { "name": "Snakebite Kit", "category": "equipment", "unit": "pcs" },
-  { "name": "Tick Remover", "category": "equipment", "unit": "pcs" },
-  { "name": "Sting Relief Pads", "category": "equipment", "unit": "pack" },
-  { "name": "Calamine Lotion", "category": "equipment", "unit": "pcs" },
   {
-    "name": "Prescription Medications",
+    "id": "anti-itch-cream",
+    "name": "Anti-Itch Cream",
     "category": "equipment",
-    "unit": "pcs"
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
   },
-  { "name": "Inhaler", "category": "equipment", "unit": "pcs" },
-  { "name": "Contact Lens Solution", "category": "equipment", "unit": "pcs" },
-  { "name": "Spare Glasses", "category": "equipment", "unit": "pcs" },
-  { "name": "Sunburn Relief Spray", "category": "equipment", "unit": "pcs" },
-  { "name": "After Bite", "category": "equipment", "unit": "pcs" },
-  { "name": "Petroleum Jelly", "category": "equipment", "unit": "pcs" },
-  { "name": "Cotton Balls", "category": "equipment", "unit": "pack" },
-  { "name": "Cotton Swabs", "category": "equipment", "unit": "pack" },
-  { "name": "Tongue Depressors", "category": "equipment", "unit": "pack" },
-  { "name": "First Aid Manual", "category": "equipment", "unit": "pcs" },
-  { "name": "Dog Leash", "category": "equipment", "unit": "pcs" },
-  { "name": "Dog Harness", "category": "equipment", "unit": "pcs" },
-  { "name": "Dog Collar", "category": "equipment", "unit": "pcs" },
-  { "name": "Pet Carrier", "category": "equipment", "unit": "pcs" },
-  { "name": "Dog Bed", "category": "equipment", "unit": "pcs" },
-  { "name": "Pet Bowls", "category": "equipment", "unit": "set" },
-  { "name": "Dog Food", "category": "food", "unit": "kg" },
-  { "name": "Dog Treats", "category": "food", "unit": "pack" },
-  { "name": "Cat Food", "category": "food", "unit": "kg" },
-  { "name": "Pet Waste Bags", "category": "equipment", "unit": "pack" },
-  { "name": "Pet Tick Collar", "category": "equipment", "unit": "pcs" },
-  { "name": "Pet First Aid Kit", "category": "equipment", "unit": "pcs" },
   {
-    "name": "Portable Dog Water Bottle",
+    "id": "antibiotic-ointment",
+    "name": "Antibiotic Ointment",
     "category": "equipment",
-    "unit": "pcs"
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
   },
-  { "name": "Dog Life Jacket", "category": "equipment", "unit": "pcs" },
-  { "name": "Pet Towel", "category": "equipment", "unit": "pcs" },
-  { "name": "Deodorant", "category": "equipment", "unit": "pcs" },
-  { "name": "Shampoo", "category": "equipment", "unit": "pcs" },
-  { "name": "Conditioner", "category": "equipment", "unit": "pcs" },
-  { "name": "Body Wash", "category": "equipment", "unit": "pcs" },
-  { "name": "Razor", "category": "equipment", "unit": "pcs" },
-  { "name": "Shaving Cream", "category": "equipment", "unit": "pcs" },
-  { "name": "Hair Ties", "category": "equipment", "unit": "pack" },
-  { "name": "Hairbrush", "category": "equipment", "unit": "pcs" },
-  { "name": "Menstrual Pads", "category": "equipment", "unit": "pack" },
-  { "name": "Tampons", "category": "equipment", "unit": "pack" },
-  { "name": "Mirror (small)", "category": "equipment", "unit": "pcs" },
-  { "name": "Nail Clippers", "category": "equipment", "unit": "pcs" },
-  { "name": "Tissues", "category": "equipment", "unit": "pack" },
-  { "name": "Ear Plugs", "category": "equipment", "unit": "pack" },
-  { "name": "Sleep Mask", "category": "equipment", "unit": "pcs" },
-  { "name": "Travel Pillow", "category": "equipment", "unit": "pcs" },
-  { "name": "Passport", "category": "equipment", "unit": "pcs" },
-  { "name": "ID / Driver License", "category": "equipment", "unit": "pcs" },
-  { "name": "Insurance Cards", "category": "equipment", "unit": "pcs" },
-  { "name": "Cash", "category": "equipment", "unit": "pcs" },
-  { "name": "Credit Cards", "category": "equipment", "unit": "pcs" },
-  { "name": "Reservation Printouts", "category": "equipment", "unit": "pcs" },
-  { "name": "Campsite Permit", "category": "equipment", "unit": "pcs" },
-  { "name": "Fishing License", "category": "equipment", "unit": "pcs" },
-  { "name": "Car Charger", "category": "equipment", "unit": "pcs" },
-  { "name": "Jumper Cables", "category": "equipment", "unit": "pcs" },
-  { "name": "Tire Repair Kit", "category": "equipment", "unit": "pcs" },
-  { "name": "Tow Strap", "category": "equipment", "unit": "pcs" },
-  { "name": "Roof Rack Straps", "category": "equipment", "unit": "set" },
-  { "name": "Cargo Net", "category": "equipment", "unit": "pcs" },
-  { "name": "Reflective Vest", "category": "equipment", "unit": "pcs" },
-  { "name": "Road Flares", "category": "equipment", "unit": "pack" },
-  { "name": "Snow Chains", "category": "equipment", "unit": "set" },
-  { "name": "Windshield Scraper", "category": "equipment", "unit": "pcs" },
-  { "name": "Fire Extinguisher", "category": "equipment", "unit": "pcs" },
   {
-    "name": "Smoke Detector (portable)",
+    "id": "antihistamine",
+    "name": "Antihistamine",
     "category": "equipment",
-    "unit": "pcs"
+    "unit": "pcs",
+    "aliases": ["אנטיהיסטמין"],
+    "tags": ["first-aid"]
   },
   {
+    "id": "antiseptic-wipes",
+    "name": "Antiseptic Wipes",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "apple-cider-vinegar",
+    "name": "Apple Cider Vinegar",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "apples",
+    "name": "Apples",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Apple", "תפוחים"],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "applesauce-pouches",
+    "name": "Applesauce Pouches",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit", "kids", "snack"]
+  },
+  {
+    "id": "artichokes",
+    "name": "Artichokes",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "arugula",
+    "name": "Arugula",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "asparagus",
+    "name": "Asparagus",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "aspirin",
+    "name": "Aspirin",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "avocado",
+    "name": "Avocado",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Avocados", "Avo", "אבוקדו"],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "avocado-oil",
+    "name": "Avocado Oil",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "axe",
+    "name": "Axe",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["גרזן"],
+    "tags": ["cooking", "tools"]
+  },
+  {
+    "id": "baby-bathtub",
+    "name": "Baby Bathtub",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "baby-blanket",
+    "name": "Baby Blanket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-body-wash",
+    "name": "Baby Body Wash",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "baby-bottles",
+    "name": "Baby Bottles",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["בקבוקי תינוק", "בקבוקים"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-carrier",
+    "name": "Baby Carrier",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מנשא תינוק", "מנשא"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-cereal",
+    "name": "Baby Cereal",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby", "breakfast"]
+  },
+  {
+    "id": "baby-first-aid-kit",
+    "name": "Baby First Aid Kit",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "first-aid"]
+  },
+  {
+    "id": "baby-food-jars",
+    "name": "Baby Food Jars",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-food-pouches",
+    "name": "Baby Food Pouches",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["מחיות לתינוק"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-formula",
+    "name": "Baby Formula",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["תרכובת מזון לתינוק", "תמ\"ל"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-gate",
+    "name": "Baby Gate",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-insect-repellent",
+    "name": "Baby Insect Repellent",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-life-jacket",
+    "name": "Baby Life Jacket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "beach"]
+  },
+  {
+    "id": "baby-lotion",
+    "name": "Baby Lotion",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "baby-monitor",
+    "name": "Baby Monitor",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מוניטור לתינוק", "מעקב תינוק"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-shampoo",
+    "name": "Baby Shampoo",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "baby-sleeping-bag",
+    "name": "Baby Sleeping Bag",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "sleep"]
+  },
+  {
+    "id": "baby-sun-hat",
+    "name": "Baby Sun Hat",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "clothing"]
+  },
+  {
+    "id": "baby-sunglasses",
+    "name": "Baby Sunglasses",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "clothing"]
+  },
+  {
+    "id": "baby-sunscreen",
+    "name": "Baby Sunscreen",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["קרם הגנה לתינוק"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "baby-swim-diapers",
+    "name": "Baby Swim Diapers",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby", "beach"]
+  },
+  {
+    "id": "baby-swimsuit",
+    "name": "Baby Swimsuit",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "clothing"]
+  },
+  {
+    "id": "baby-thermometer",
+    "name": "Baby Thermometer",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "first-aid"]
+  },
+  {
+    "id": "baby-towel",
+    "name": "Baby Towel",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "baby-wipes",
+    "name": "Baby Wipes",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["מגבונים"],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "backpack",
+    "name": "Backpack",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Backpacks", "Rucksack", "תרמיל", "תיק גב"],
+    "tags": ["storage"]
+  },
+  {
+    "id": "bacon",
+    "name": "Bacon",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Rashers", "בייקון"],
+    "tags": ["breakfast", "protein"]
+  },
+  {
+    "id": "badminton-set",
+    "name": "Badminton Set",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["סט בדמינטון"],
+    "tags": ["games"]
+  },
+  {
+    "id": "bagels",
+    "name": "Bagels",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "baked-beans",
+    "name": "Baked Beans",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "balsamic-vinegar",
+    "name": "Balsamic Vinegar",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "bananas",
+    "name": "Bananas",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Banana", "בננות"],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "band-aids-kids",
+    "name": "Band-Aids (kids)",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby", "first-aid"]
+  },
+  {
+    "id": "bandages-assorted",
+    "name": "Bandages (assorted)",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["תחבושות", "פלסטרים"],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "base-layer-bottom",
+    "name": "Base Layer Bottom",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "base-layer-top",
+    "name": "Base Layer Top",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "bbq-sauce",
+    "name": "BBQ Sauce",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Barbecue Sauce", "רוטב ברביקיו"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "beach-ball",
+    "name": "Beach Ball",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כדור ים"],
+    "tags": ["beach", "kids"]
+  },
+  {
+    "id": "beach-umbrella",
+    "name": "Beach Umbrella",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Beach Umbrellas", "Sun Umbrella", "שמשייה", "שמשיית חוף"],
+    "tags": ["beach"]
+  },
+  {
+    "id": "beanie",
+    "name": "Beanie",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כובע צמר", "כיפה"],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "bear-canister",
+    "name": "Bear Canister",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["storage"]
+  },
+  {
+    "id": "bear-spray",
+    "name": "Bear Spray",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Pepper Spray", "ספריי דובים"],
+    "tags": []
+  },
+  {
+    "id": "beer",
+    "name": "Beer",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Beers", "Brews", "Lager", "Ale", "בירה"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "beets",
+    "name": "Beets",
+    "category": "food",
+    "unit": "kg",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "bell-peppers",
+    "name": "Bell Peppers",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Capsicum", "Bell Pepper", "פלפל", "גמבה"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "beyond-meat",
+    "name": "Beyond Meat",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "bibs",
+    "name": "Bibs",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["סינרים"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "bike",
+    "name": "Bike",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "bike-helmet",
+    "name": "Bike Helmet",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "bike-rack",
+    "name": "Bike Rack",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "binoculars",
+    "name": "Binoculars",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Binos", "משקפת"],
+    "tags": ["navigation"]
+  },
+  {
+    "id": "biodegradable-soap",
+    "name": "Biodegradable Soap",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["סבון מתכלה"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "black-beans",
+    "name": "Black Beans",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "blister-pads",
+    "name": "Blister Pads",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "blueberries",
+    "name": "Blueberries",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "board-game",
+    "name": "Board Game",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["משחק קופסה"],
+    "tags": ["games"]
+  },
+  {
+    "id": "bocce-ball-set",
+    "name": "Bocce Ball Set",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["games"]
+  },
+  {
+    "id": "body-wash",
+    "name": "Body Wash",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "book",
+    "name": "Book",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "booster-seat",
+    "name": "Booster Seat",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "bottle-brush",
+    "name": "Bottle Brush",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "bottle-opener",
+    "name": "Bottle Opener",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Bottle Openers", "פותחן בקבוקים"],
+    "tags": []
+  },
+  {
+    "id": "bottle-warmer",
+    "name": "Bottle Warmer",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "bread",
+    "name": "Bread",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Loaf", "לחם"],
+    "tags": ["breakfast", "pantry"]
+  },
+  {
+    "id": "broccoli",
+    "name": "Broccoli",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["ברוקולי"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "brown-rice",
+    "name": "Brown Rice",
+    "category": "food",
+    "unit": "kg",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "brown-sugar",
+    "name": "Brown Sugar",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "brownies",
+    "name": "Brownies",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "brussels-sprouts",
+    "name": "Brussels Sprouts",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "bubbles",
+    "name": "Bubbles",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["בועות סבון"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "buckwheat",
+    "name": "Buckwheat",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "bug-catcher-kit",
+    "name": "Bug Catcher Kit",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "building-blocks",
+    "name": "Building Blocks",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["קוביות", "לגו"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "bulgur",
+    "name": "Bulgur",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "bungee-cords",
+    "name": "Bungee Cords",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["tools"]
+  },
+  {
+    "id": "burger-buns",
+    "name": "Burger Buns",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "burger-patties",
+    "name": "Burger Patties",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Hamburger Patties", "Beef Patties", "קציצות המבורגר"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "burn-gel",
+    "name": "Burn Gel",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "butter",
+    "name": "Butter",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Margarine", "חמאה"],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "butterfly-bandages",
+    "name": "Butterfly Bandages",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "butternut-squash",
+    "name": "Butternut Squash",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "cabbage",
+    "name": "Cabbage",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["כרוב"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "cabinet-locks",
+    "name": "Cabinet Locks",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "cake-mix",
+    "name": "Cake Mix",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "calamine-lotion",
+    "name": "Calamine Lotion",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "camera",
+    "name": "Camera",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Cameras", "מצלמה"],
+    "tags": []
+  },
+  {
+    "id": "camp-blanket",
+    "name": "Camp Blanket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["sleep"]
+  },
+  {
+    "id": "camping-cot",
+    "name": "Camping Cot",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מיטת שדה"],
+    "tags": ["sleep"]
+  },
+  {
+    "id": "camping-heater",
+    "name": "Camping Heater",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["power", "winter"]
+  },
+  {
+    "id": "camping-mat",
+    "name": "Camping Mat",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מזרן קמפינג"],
+    "tags": ["sleep"]
+  },
+  {
+    "id": "camping-pillow",
+    "name": "Camping Pillow",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Camp Pillow", "כרית קמפינג"],
+    "tags": ["sleep"]
+  },
+  {
+    "id": "camping-shower",
+    "name": "Camping Shower",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מקלחת שדה"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "camping-sink",
+    "name": "Camping Sink",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "camping-stove",
+    "name": "Camping Stove",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [
+      "Camp Stove",
+      "Portable Stove",
+      "כיריים",
+      "גז שדה",
+      "בַּבּוּשׁקָה"
+    ],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "campsite-permit",
+    "name": "Campsite Permit",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "can-opener",
+    "name": "Can Opener",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Tin Opener", "פותחן קופסאות"],
+    "tags": []
+  },
+  {
+    "id": "canned-beans",
+    "name": "Canned Beans",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["שעועית בקופסה"],
+    "tags": ["pantry", "protein"]
+  },
+  {
+    "id": "canned-corn",
+    "name": "Canned Corn",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "canned-soup",
+    "name": "Canned Soup",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "canned-tomatoes",
+    "name": "Canned Tomatoes",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "canned-tuna",
+    "name": "Canned Tuna",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["טונה בקופסה", "טונה"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "canoe-paddle",
+    "name": "Canoe Paddle",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["beach"]
+  },
+  {
+    "id": "canopy",
+    "name": "Canopy",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["גזיבו", "סוכך"],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "car-charger",
+    "name": "Car Charger",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car", "power"]
+  },
+  {
+    "id": "car-seat",
+    "name": "Car Seat",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כיסא בטיחות", "מושב בטיחות"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "carabiners",
+    "name": "Carabiners",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["tools"]
+  },
+  {
+    "id": "carbon-monoxide-detector",
     "name": "Carbon Monoxide Detector",
     "category": "equipment",
-    "unit": "pcs"
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
   },
-  { "name": "Shovel (camping)", "category": "equipment", "unit": "pcs" },
-  { "name": "Saw (folding)", "category": "equipment", "unit": "pcs" },
-  { "name": "Hammer", "category": "equipment", "unit": "pcs" },
-  { "name": "Sewing Kit", "category": "equipment", "unit": "pcs" },
-  { "name": "Repair Patches", "category": "equipment", "unit": "pack" },
-  { "name": "Gear Repair Tape", "category": "equipment", "unit": "pcs" },
-  { "name": "Cable Ties", "category": "equipment", "unit": "pack" },
-  { "name": "WD-40", "category": "equipment", "unit": "pcs" },
-  { "name": "Super Glue", "category": "equipment", "unit": "pcs" },
-  { "name": "Waterproof Matches", "category": "equipment", "unit": "pack" },
-  { "name": "Trekking Poles", "category": "equipment", "unit": "set" },
-  { "name": "Gaiters", "category": "equipment", "unit": "pcs" },
-  { "name": "Crampons", "category": "equipment", "unit": "set" },
-  { "name": "Snowshoes", "category": "equipment", "unit": "set" },
-  { "name": "Ski Goggles", "category": "equipment", "unit": "pcs" },
-  { "name": "Thermal Underwear", "category": "equipment", "unit": "set" },
-  { "name": "Wool Socks", "category": "equipment", "unit": "pcs" },
-  { "name": "Gloves", "category": "equipment", "unit": "pcs" },
-  { "name": "Beanie", "category": "equipment", "unit": "pcs" },
-  { "name": "Scarf", "category": "equipment", "unit": "pcs" },
-  { "name": "Neck Gaiter", "category": "equipment", "unit": "pcs" },
-  { "name": "Base Layer Top", "category": "equipment", "unit": "pcs" },
-  { "name": "Base Layer Bottom", "category": "equipment", "unit": "pcs" },
-  { "name": "Fleece Jacket", "category": "equipment", "unit": "pcs" },
-  { "name": "Down Jacket", "category": "equipment", "unit": "pcs" },
-  { "name": "Quick-Dry Shirt", "category": "equipment", "unit": "pcs" },
-  { "name": "Hiking Pants", "category": "equipment", "unit": "pcs" },
-  { "name": "Shorts", "category": "equipment", "unit": "pcs" },
-  { "name": "Flip Flops", "category": "equipment", "unit": "pcs" },
-  { "name": "Water Shoes", "category": "equipment", "unit": "pcs" },
-  { "name": "Dry Sack", "category": "equipment", "unit": "pcs" },
-  { "name": "Stuff Sack", "category": "equipment", "unit": "pcs" },
-  { "name": "Packing Cubes", "category": "equipment", "unit": "set" },
-  { "name": "Laundry Bag", "category": "equipment", "unit": "pcs" },
-  { "name": "Camelback", "category": "equipment", "unit": "pcs" },
-  { "name": "Daypack", "category": "equipment", "unit": "pcs" },
-  { "name": "Duffel Bag", "category": "equipment", "unit": "pcs" },
-  { "name": "Roof Box", "category": "equipment", "unit": "pcs" },
-  { "name": "Bike Rack", "category": "equipment", "unit": "pcs" },
-  { "name": "Kayak Rack", "category": "equipment", "unit": "pcs" },
-  { "name": "Canopy", "category": "equipment", "unit": "pcs" },
-  { "name": "Pop-Up Shelter", "category": "equipment", "unit": "pcs" },
-  { "name": "Windbreak", "category": "equipment", "unit": "pcs" },
-  { "name": "Groundsheet", "category": "equipment", "unit": "pcs" },
-  { "name": "Camping Mat", "category": "equipment", "unit": "pcs" },
-  { "name": "Portable Toilet", "category": "equipment", "unit": "pcs" },
-  { "name": "Shower Tent", "category": "equipment", "unit": "pcs" },
-  { "name": "Privacy Screen", "category": "equipment", "unit": "pcs" },
-  { "name": "Camping Sink", "category": "equipment", "unit": "pcs" },
-  { "name": "Water Jug", "category": "equipment", "unit": "pcs" },
-  { "name": "Water Bladder", "category": "equipment", "unit": "pcs" },
-  { "name": "Spigot", "category": "equipment", "unit": "pcs" },
-  { "name": "Leveling Blocks (RV)", "category": "equipment", "unit": "set" },
-  { "name": "Wheel Chocks", "category": "equipment", "unit": "set" },
-  { "name": "RV Sewer Hose", "category": "equipment", "unit": "pcs" },
-  { "name": "Electrical Adapter (RV)", "category": "equipment", "unit": "pcs" },
-  { "name": "Water Hose", "category": "equipment", "unit": "pcs" },
-  { "name": "Water Pressure Regulator", "category": "equipment", "unit": "pcs" }
+  {
+    "id": "cargo-net",
+    "name": "Cargo Net",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "carrots",
+    "name": "Carrots",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Carrot", "גזר"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "cash",
+    "name": "Cash",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מזומן", "כסף מזומן"],
+    "tags": []
+  },
+  {
+    "id": "cashew-butter",
+    "name": "Cashew Butter",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "cashews",
+    "name": "Cashews",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "cast-iron-skillet",
+    "name": "Cast Iron Skillet",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מחבת יצוקה", "מחבת ברזל"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "cat-food",
+    "name": "Cat Food",
+    "category": "food",
+    "unit": "kg",
+    "aliases": [],
+    "tags": ["pets"]
+  },
+  {
+    "id": "cauliflower",
+    "name": "Cauliflower",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["כרובית"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "celery",
+    "name": "Celery",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["סלרי"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "cereal",
+    "name": "Cereal",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["דגני בוקר"],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "changing-pad",
+    "name": "Changing Pad",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "charcoal",
+    "name": "Charcoal",
+    "category": "equipment",
+    "unit": "kg",
+    "aliases": ["Briquettes", "פחם"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "cheese",
+    "name": "Cheese",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Cheddar", "גבינה"],
+    "tags": []
+  },
+  {
+    "id": "cheese-sticks",
+    "name": "Cheese Sticks",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids", "snack"]
+  },
+  {
+    "id": "cherries",
+    "name": "Cherries",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "chia-seeds",
+    "name": "Chia Seeds",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "chicken-breast",
+    "name": "Chicken Breast",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Chicken Breasts", "חזה עוף"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "chicken-nuggets",
+    "name": "Chicken Nuggets",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["נאגטס", "שניצלונים"],
+    "tags": ["kids", "protein"]
+  },
+  {
+    "id": "chicken-thighs",
+    "name": "Chicken Thighs",
+    "category": "food",
+    "unit": "kg",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "chicken-wings",
+    "name": "Chicken Wings",
+    "category": "food",
+    "unit": "kg",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "chickpeas",
+    "name": "Chickpeas",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Garbanzo Beans", "חומוס (גרגירים)"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "chili",
+    "name": "Chili",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "chili-powder",
+    "name": "Chili Powder",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "chips",
+    "name": "Chips",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Crisps", "Potato Chips", "צ'יפס", "חטיפים"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "chocolate",
+    "name": "Chocolate",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["שוקולד"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "chocolate-bars",
+    "name": "Chocolate Bars",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "chocolate-milk",
+    "name": "Chocolate Milk",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink", "kids"]
+  },
+  {
+    "id": "cider",
+    "name": "Cider",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "cinnamon",
+    "name": "Cinnamon",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["קינמון"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "citronella-candles",
+    "name": "Citronella Candles",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["lighting"]
+  },
+  {
+    "id": "clothesline",
+    "name": "Clothesline",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "clothespins",
+    "name": "Clothespins",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "cocktail-mixer",
+    "name": "Cocktail Mixer",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "coconut-cream",
+    "name": "Coconut Cream",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "coconut-milk",
+    "name": "Coconut Milk",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "coconut-oil",
+    "name": "Coconut Oil",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "coconut-water",
+    "name": "Coconut Water",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "coconut-yogurt",
+    "name": "Coconut Yogurt",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "coffee",
+    "name": "Coffee",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Ground Coffee", "Coffee Beans", "קפה"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "coffee-filters",
+    "name": "Coffee Filters",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "cold-pack-instant",
+    "name": "Cold Pack (instant)",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "coleslaw-mix",
+    "name": "Coleslaw Mix",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "collapsible-bucket",
+    "name": "Collapsible Bucket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["water"]
+  },
+  {
+    "id": "colored-pencils",
+    "name": "Colored Pencils",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "coloring-books",
+    "name": "Coloring Books",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["חוברות צביעה"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "comfort-blanket",
+    "name": "Comfort Blanket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "compass",
+    "name": "Compass",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Compasses", "מצפן"],
+    "tags": ["navigation"]
+  },
+  {
+    "id": "conditioner",
+    "name": "Conditioner",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "contact-lens-solution",
+    "name": "Contact Lens Solution",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "cookies",
+    "name": "Cookies",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["עוגיות"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "cooking-pot",
+    "name": "Cooking Pot",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["סיר בישול"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "cooking-spray",
+    "name": "Cooking Spray",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["תרסיס שמן"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "cooler",
+    "name": "Cooler",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Coolers", "Ice Chest", "Esky", "צידנית"],
+    "tags": ["storage"]
+  },
+  {
+    "id": "cooler-bag",
+    "name": "Cooler Bag",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["storage"]
+  },
+  {
+    "id": "corn-on-the-cob",
+    "name": "Corn on the Cob",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["תירס", "קלחי תירס"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "corner-protectors",
+    "name": "Corner Protectors",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "cornhole-set",
+    "name": "Cornhole Set",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["games"]
+  },
+  {
+    "id": "cotton-balls",
+    "name": "Cotton Balls",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "cotton-swabs",
+    "name": "Cotton Swabs",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "couscous",
+    "name": "Couscous",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "cpr-mask",
+    "name": "CPR Mask",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "crackers",
+    "name": "Crackers",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Cracker", "Biscuits", "קרקרים"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "crampons",
+    "name": "Crampons",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "crayons",
+    "name": "Crayons",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["צבעי שעווה"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "cream-cheese",
+    "name": "Cream Cheese",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "creamer",
+    "name": "Creamer",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "credit-cards",
+    "name": "Credit Cards",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כרטיסי אשראי"],
+    "tags": []
+  },
+  {
+    "id": "croissants",
+    "name": "Croissants",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "cucumber",
+    "name": "Cucumber",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Cucumbers", "מלפפון", "מלפפונים"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "cumin",
+    "name": "Cumin",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["כמון"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "cups",
+    "name": "Cups",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["Cup", "כוסות"],
+    "tags": []
+  },
+  {
+    "id": "cutlery-set",
+    "name": "Cutlery Set",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["Utensils", "Silverware", "סט סכום", "סכום"],
+    "tags": []
+  },
+  {
+    "id": "cutting-board",
+    "name": "Cutting Board",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Chopping Board", "קרש חיתוך"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "dark-chocolate",
+    "name": "Dark Chocolate",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "date-syrup",
+    "name": "Date Syrup",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "dates",
+    "name": "Dates",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["תמרים"],
+    "tags": ["fruit", "snack"]
+  },
+  {
+    "id": "daypack",
+    "name": "Daypack",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["storage"]
+  },
+  {
+    "id": "deodorant",
+    "name": "Deodorant",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Antiperspirant", "דאודורנט"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "diaper-bag",
+    "name": "Diaper Bag",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "storage"]
+  },
+  {
+    "id": "diaper-cream",
+    "name": "Diaper Cream",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "diaper-disposal-bags",
+    "name": "Diaper Disposal Bags",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "diapers",
+    "name": "Diapers",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Nappies", "חיתולים"],
+    "tags": ["baby", "hygiene"]
+  },
+  {
+    "id": "dish-soap",
+    "name": "Dish Soap",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "disposable-cutlery",
+    "name": "Disposable Cutlery",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Plastic Cutlery", "Plastic Utensils", "סכום חד פעמי"],
+    "tags": []
+  },
+  {
+    "id": "disposable-gloves",
+    "name": "Disposable Gloves",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "dog-bed",
+    "name": "Dog Bed",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מיטת כלב"],
+    "tags": ["pets"]
+  },
+  {
+    "id": "dog-collar",
+    "name": "Dog Collar",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pets"]
+  },
+  {
+    "id": "dog-food",
+    "name": "Dog Food",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Kibble", "אוכל לכלבים", "מזון לכלבים"],
+    "tags": ["pets"]
+  },
+  {
+    "id": "dog-harness",
+    "name": "Dog Harness",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pets"]
+  },
+  {
+    "id": "dog-leash",
+    "name": "Dog Leash",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Dog Lead", "רצועת כלב", "רצועה"],
+    "tags": ["pets"]
+  },
+  {
+    "id": "dog-life-jacket",
+    "name": "Dog Life Jacket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["beach", "pets"]
+  },
+  {
+    "id": "dog-treats",
+    "name": "Dog Treats",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["חטיפים לכלב"],
+    "tags": ["pets"]
+  },
+  {
+    "id": "dolls",
+    "name": "Dolls",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "down-jacket",
+    "name": "Down Jacket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מעיל פוך"],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "dried-cranberries",
+    "name": "Dried Cranberries",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit", "snack"]
+  },
+  {
+    "id": "dried-fruit",
+    "name": "Dried Fruit",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit", "snack"]
+  },
+  {
+    "id": "dried-mango",
+    "name": "Dried Mango",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit", "snack"]
+  },
+  {
+    "id": "dry-bag",
+    "name": "Dry Bag",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Waterproof Bag", "Dry Sack", "Drybag", "תיק יבש", "שק יבש"],
+    "tags": ["storage"]
+  },
+  {
+    "id": "duct-tape",
+    "name": "Duct Tape",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Gaffer Tape", "טייפ חבלה", "דאקט טייפ"],
+    "tags": ["tools"]
+  },
+  {
+    "id": "duffel-bag",
+    "name": "Duffel Bag",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["storage"]
+  },
+  {
+    "id": "dutch-oven",
+    "name": "Dutch Oven",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["סיר הולנדי"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "ear-plugs",
+    "name": "Ear Plugs",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["אטמי אוזניים"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "edamame",
+    "name": "Edamame",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein", "snack"]
+  },
+  {
+    "id": "eggplant",
+    "name": "Eggplant",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["חציל"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "eggs",
+    "name": "Eggs",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Egg", "ביצים"],
+    "tags": ["breakfast", "protein"]
+  },
+  {
+    "id": "elastic-bandage",
+    "name": "Elastic Bandage",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "electrical-adapter-rv",
+    "name": "Electrical Adapter (RV)",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "electrolyte-packets",
+    "name": "Electrolyte Packets",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "emergency-blanket",
+    "name": "Emergency Blanket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [
+      "Space Blanket",
+      "Mylar Blanket",
+      "Survival Blanket",
+      "שמיכת חירום",
+      "שמיכת הצלה"
+    ],
+    "tags": ["sleep"]
+  },
+  {
+    "id": "energy-bars",
+    "name": "Energy Bars",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "english-muffins",
+    "name": "English Muffins",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "epipen",
+    "name": "EpiPen",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "extension-cord",
+    "name": "Extension Cord",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כבל מאריך"],
+    "tags": ["power"]
+  },
+  {
+    "id": "eye-drops",
+    "name": "Eye Drops",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "falafel",
+    "name": "Falafel",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "fennel",
+    "name": "Fennel",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "field-guide",
+    "name": "Field Guide",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["navigation"]
+  },
+  {
+    "id": "fire-extinguisher",
+    "name": "Fire Extinguisher",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "fire-starter",
+    "name": "Fire Starter",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["מצת אש"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "firewood",
+    "name": "Firewood",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Fire Wood", "Logs", "עצי הסקה", "עצים"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "first-aid-kit",
+    "name": "First Aid Kit",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [
+      "First-Aid Kit",
+      "Medical Kit",
+      "ערכת עזרה ראשונה",
+      "תיק עזרה ראשונה"
+    ],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "first-aid-manual",
+    "name": "First Aid Manual",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "fish-sticks",
+    "name": "Fish Sticks",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids", "protein"]
+  },
+  {
+    "id": "fishing-bait",
+    "name": "Fishing Bait",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["פיתיון דיג"],
+    "tags": ["games"]
+  },
+  {
+    "id": "fishing-license",
+    "name": "Fishing License",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "fishing-rod",
+    "name": "Fishing Rod",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Fishing Pole", "חכה", "חכת דיג"],
+    "tags": ["games"]
+  },
+  {
+    "id": "fishing-tackle-box",
+    "name": "Fishing Tackle Box",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["games"]
+  },
+  {
+    "id": "flag-markers",
+    "name": "Flag Markers",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "flashlight",
+    "name": "Flashlight",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Torch", "Flashlights", "פנס", "פנס יד"],
+    "tags": ["lighting"]
+  },
+  {
+    "id": "flax-seeds",
+    "name": "Flax Seeds",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "flaxseed-oil",
+    "name": "Flaxseed Oil",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "fleece-jacket",
+    "name": "Fleece Jacket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["פליז", "מעיל פליז"],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "flip-flops",
+    "name": "Flip Flops",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כפכפים"],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "floaties",
+    "name": "Floaties",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["beach", "kids"]
+  },
+  {
+    "id": "flour",
+    "name": "Flour",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["קמח"],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "folding-chair",
+    "name": "Folding Chair",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Camp Chair", "Folding Chairs", "כיסא מתקפל", "כיסא קמפינג"],
+    "tags": []
+  },
+  {
+    "id": "folding-table",
+    "name": "Folding Table",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Camp Table", "Folding Tables", "שולחן מתקפל", "שולחן קמפינג"],
+    "tags": []
+  },
+  {
+    "id": "food-storage-containers",
+    "name": "Food Storage Containers",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["storage"]
+  },
+  {
+    "id": "football",
+    "name": "Football",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["games"]
+  },
+  {
+    "id": "freeze-dried-fruit",
+    "name": "Freeze-Dried Fruit",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids", "snack"]
+  },
+  {
+    "id": "fresh-herbs",
+    "name": "Fresh Herbs",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["עשבי תיבול"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "fresh-squeezed-juice",
+    "name": "Fresh Squeezed Juice",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "frisbee",
+    "name": "Frisbee",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["פריזבי"],
+    "tags": ["games"]
+  },
+  {
+    "id": "frozen-burgers",
+    "name": "Frozen Burgers",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["frozen", "protein"]
+  },
+  {
+    "id": "frozen-fruit",
+    "name": "Frozen Fruit",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["frozen", "fruit"]
+  },
+  {
+    "id": "frozen-pizza",
+    "name": "Frozen Pizza",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["פיצה קפואה"],
+    "tags": ["frozen"]
+  },
+  {
+    "id": "frozen-vegetables",
+    "name": "Frozen Vegetables",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["frozen", "vegetables"]
+  },
+  {
+    "id": "fruit-cups",
+    "name": "Fruit Cups",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit", "kids", "snack"]
+  },
+  {
+    "id": "fruit-leather",
+    "name": "Fruit Leather",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "fruit-snacks",
+    "name": "Fruit Snacks",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["חטיפי פירות"],
+    "tags": ["kids", "snack"]
+  },
+  {
+    "id": "fuel-canister",
+    "name": "Fuel Canister",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "gaiters",
+    "name": "Gaiters",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "garlic",
+    "name": "Garlic",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["שום"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "garlic-powder",
+    "name": "Garlic Powder",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "gauze-pads",
+    "name": "Gauze Pads",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "gauze-roll",
+    "name": "Gauze Roll",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "gear-repair-tape",
+    "name": "Gear Repair Tape",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["tools"]
+  },
+  {
+    "id": "ginger",
+    "name": "Ginger",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["ג'ינג'ר", "זנגביל"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "gloves",
+    "name": "Gloves",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כפפות"],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "glow-sticks",
+    "name": "Glow Sticks",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["lighting"]
+  },
+  {
+    "id": "goji-berries",
+    "name": "Goji Berries",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit", "snack"]
+  },
+  {
+    "id": "goldfish-crackers",
+    "name": "Goldfish Crackers",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids", "snack"]
+  },
+  {
+    "id": "graham-crackers",
+    "name": "Graham Crackers",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "granola",
+    "name": "Granola",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["גרנולה"],
+    "tags": ["breakfast", "snack"]
+  },
+  {
+    "id": "granola-bars",
+    "name": "Granola Bars",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "grapes",
+    "name": "Grapes",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["ענבים"],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "green-beans",
+    "name": "Green Beans",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "green-tea",
+    "name": "Green Tea",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "grill",
+    "name": "Grill",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["BBQ", "Barbecue", "מנגל", "גריל"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "grill-grate",
+    "name": "Grill Grate",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "ground-beef",
+    "name": "Ground Beef",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Mince", "Ground Meat", "Minced Beef", "בשר טחון"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "groundsheet",
+    "name": "Groundsheet",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["יריעת קרקע"],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "guacamole",
+    "name": "Guacamole",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "hair-ties",
+    "name": "Hair Ties",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["גומיות לשיער"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "hairbrush",
+    "name": "Hairbrush",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "ham",
+    "name": "Ham",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["חזיר מעושן"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "hammer",
+    "name": "Hammer",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["פטיש"],
+    "tags": ["tools"]
+  },
+  {
+    "id": "hammock",
+    "name": "Hammock",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Hammocks", "ערסל"],
+    "tags": ["sleep"]
+  },
+  {
+    "id": "hand-sanitizer",
+    "name": "Hand Sanitizer",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Hand Sanitiser", "Hand Gel", "ג'ל חיטוי", "אלכוג'ל"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "hand-warmers",
+    "name": "Hand Warmers",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["winter"]
+  },
+  {
+    "id": "hard-seltzer",
+    "name": "Hard Seltzer",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "hat",
+    "name": "Hat",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כובע"],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "headlamp",
+    "name": "Headlamp",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Headlamps", "Head Torch", "פנס ראש"],
+    "tags": ["lighting"]
+  },
+  {
+    "id": "hemp-seeds",
+    "name": "Hemp Seeds",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "herbal-tea",
+    "name": "Herbal Tea",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "hiking-boots",
+    "name": "Hiking Boots",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Hiking Shoes", "Trail Boots", "נעלי הליכה", "נעלי טיול"],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "hiking-pants",
+    "name": "Hiking Pants",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "honey",
+    "name": "Honey",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["דבש"],
+    "tags": ["breakfast", "condiments"]
+  },
+  {
+    "id": "horseshoe-set",
+    "name": "Horseshoe Set",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["games"]
+  },
+  {
+    "id": "hot-chocolate-mix",
+    "name": "Hot Chocolate Mix",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["שוקו חם", "קקאו"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "hot-dog-buns",
+    "name": "Hot Dog Buns",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "hot-dogs",
+    "name": "Hot Dogs",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [
+      "Hotdogs",
+      "Franks",
+      "Frankfurters",
+      "נקניקיות חמות",
+      "הוט דוג"
+    ],
+    "tags": ["protein"]
+  },
+  {
+    "id": "hot-pack-instant",
+    "name": "Hot Pack (instant)",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "hot-sauce",
+    "name": "Hot Sauce",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["רוטב חריף"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "hula-hoop",
+    "name": "Hula Hoop",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "hummus",
+    "name": "Hummus",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Houmous", "Humous", "חומוס"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "hydration-pack",
+    "name": "Hydration Pack",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Camelback", "Water Bladder Pack", "שלוקר", "תיק שתייה"],
+    "tags": ["water"]
+  },
+  {
+    "id": "hydrocortisone-cream",
+    "name": "Hydrocortisone Cream",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "hydrogen-peroxide",
+    "name": "Hydrogen Peroxide",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "ibuprofen",
+    "name": "Ibuprofen",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["איבופרופן", "נורופן"],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "ice",
+    "name": "Ice",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Ice Cubes", "Bag of Ice", "קרח"],
+    "tags": ["frozen"]
+  },
+  {
+    "id": "ice-cream",
+    "name": "Ice Cream",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["גלידה"],
+    "tags": ["frozen"]
+  },
+  {
+    "id": "ice-packs",
+    "name": "Ice Packs",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["storage"]
+  },
+  {
+    "id": "iced-tea",
+    "name": "Iced Tea",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "id-driver-license",
+    "name": "ID / Driver License",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "infant-tylenol",
+    "name": "Infant Tylenol",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "first-aid"]
+  },
+  {
+    "id": "inflatable-pool",
+    "name": "Inflatable Pool",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["בריכה מתנפחת"],
+    "tags": ["beach", "kids"]
+  },
+  {
+    "id": "inhaler",
+    "name": "Inhaler",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "insect-repellent",
+    "name": "Insect Repellent",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [
+      "Bug Spray",
+      "Mosquito Repellent",
+      "דוחה חרקים",
+      "ספריי יתושים"
+    ],
+    "tags": []
+  },
+  {
+    "id": "instant-coffee",
+    "name": "Instant Coffee",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["קפה נמס"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "instant-noodles",
+    "name": "Instant Noodles",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["נודלס מהיר", "אטריות מהירות"],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "instant-oatmeal",
+    "name": "Instant Oatmeal",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "insurance-cards",
+    "name": "Insurance Cards",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "italian-seasoning",
+    "name": "Italian Seasoning",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["תבלין איטלקי"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "jalapenos",
+    "name": "Jalapenos",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "jam",
+    "name": "Jam",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["ריבה"],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "jello-cups",
+    "name": "Jello Cups",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "jerky",
+    "name": "Jerky",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Beef Jerky", "Biltong", "בשר מיובש"],
+    "tags": ["protein", "snack"]
+  },
+  {
+    "id": "journal",
+    "name": "Journal",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "juice",
+    "name": "Juice",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["Fruit Juice", "מיץ"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "juice-boxes",
+    "name": "Juice Boxes",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["קרטוני מיץ"],
+    "tags": ["drink", "kids"]
+  },
+  {
+    "id": "jump-rope",
+    "name": "Jump Rope",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["חבל קפיצה"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "jumper-cables",
+    "name": "Jumper Cables",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Jump Leads", "Booster Cables", "כבלי הנעה", "כבלים"],
+    "tags": ["car"]
+  },
+  {
+    "id": "kale",
+    "name": "Kale",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "kale-chips",
+    "name": "Kale Chips",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "kayak",
+    "name": "Kayak",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Kayaks", "קיאק"],
+    "tags": ["beach"]
+  },
+  {
+    "id": "kayak-rack",
+    "name": "Kayak Rack",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "ketchup",
+    "name": "Ketchup",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Tomato Sauce", "Catsup", "קטשופ"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "kettle",
+    "name": "Kettle",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["קומקום"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "kidney-beans",
+    "name": "Kidney Beans",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "kids-backpack",
+    "name": "Kids Backpack",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids", "storage"]
+  },
+  {
+    "id": "kids-bike-helmet",
+    "name": "Kids Bike Helmet",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "kids-binoculars",
+    "name": "Kids Binoculars",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "kids-books",
+    "name": "Kids Books",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "kids-hat",
+    "name": "Kids Hat",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "kids"]
+  },
+  {
+    "id": "kids-headphones",
+    "name": "Kids Headphones",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "kids-rain-boots",
+    "name": "Kids Rain Boots",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "kids"]
+  },
+  {
+    "id": "kids-rain-jacket",
+    "name": "Kids Rain Jacket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "kids"]
+  },
+  {
+    "id": "kids-sleeping-bag",
+    "name": "Kids Sleeping Bag",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "kids", "sleep"]
+  },
+  {
+    "id": "kids-sunscreen",
+    "name": "Kids Sunscreen",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["קרם הגנה לילדים"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "kids-water-bottle",
+    "name": "Kids Water Bottle",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "kids-water-pouches",
+    "name": "Kids Water Pouches",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["drink", "kids"]
+  },
+  {
+    "id": "kimchi",
+    "name": "Kimchi",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "kitchen-knife",
+    "name": "Kitchen Knife",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Chef Knife", "Camp Knife", "סכין מטבח", "סכין"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "kite",
+    "name": "Kite",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["עפיפון"],
+    "tags": ["games"]
+  },
+  {
+    "id": "kombucha",
+    "name": "Kombucha",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "ladle",
+    "name": "Ladle",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מצקת"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "lamb-chops",
+    "name": "Lamb Chops",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["צלעות כבש"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "lantern",
+    "name": "Lantern",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Lanterns", "Camp Lantern", "פנס קמפינג", "עששית"],
+    "tags": ["lighting"]
+  },
+  {
+    "id": "laundry-bag",
+    "name": "Laundry Bag",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["storage"]
+  },
+  {
+    "id": "lemonade",
+    "name": "Lemonade",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["לימונדה"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "lemons",
+    "name": "Lemons",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["לימונים"],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "lentils",
+    "name": "Lentils",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["עדשים"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "lettuce",
+    "name": "Lettuce",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Salad Greens", "חסה"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "leveling-blocks-rv",
+    "name": "Leveling Blocks (RV)",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "life-jacket",
+    "name": "Life Jacket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Life Vest", "PFD", "אפוד הצלה"],
+    "tags": ["beach"]
+  },
+  {
+    "id": "lighter",
+    "name": "Lighter",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Lighters", "מצית"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "limes",
+    "name": "Limes",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "lip-balm",
+    "name": "Lip Balm",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["שפתון לחות"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "mac-and-cheese",
+    "name": "Mac and Cheese",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["מק אנד צ'יז", "פסטה עם גבינה"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "magnifying-glass",
+    "name": "Magnifying Glass",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "mango",
+    "name": "Mango",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "map",
+    "name": "Map",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["navigation"]
+  },
+  {
+    "id": "maple-syrup",
+    "name": "Maple Syrup",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["breakfast", "condiments"]
+  },
+  {
+    "id": "marshmallows",
+    "name": "Marshmallows",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Marshmallow", "מרשמלו"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "matcha",
+    "name": "Matcha",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "matches",
+    "name": "Matches",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Match", "גפרורים"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "mayonnaise",
+    "name": "Mayonnaise",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["מיונז"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "medical-tape",
+    "name": "Medical Tape",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "menstrual-pads",
+    "name": "Menstrual Pads",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "milk",
+    "name": "Milk",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["Whole Milk", "חלב"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "mini-bagels",
+    "name": "Mini Bagels",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "mini-muffins",
+    "name": "Mini Muffins",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["breakfast", "kids"]
+  },
+  {
+    "id": "mini-pancakes",
+    "name": "Mini Pancakes",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["breakfast", "kids"]
+  },
+  {
+    "id": "mini-sandwiches",
+    "name": "Mini Sandwiches",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "mirror-small",
+    "name": "Mirror (small)",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מראה קטנה"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "miso-paste",
+    "name": "Miso Paste",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "mixed-nuts",
+    "name": "Mixed Nuts",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "moleskin",
+    "name": "Moleskin",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "mosquito-net",
+    "name": "Mosquito Net",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Mosquito Nets", "Bug Net", "רשת יתושים", "כילה"],
+    "tags": []
+  },
+  {
+    "id": "motion-sickness-pills",
+    "name": "Motion Sickness Pills",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "muffins",
+    "name": "Muffins",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "multi-tool",
+    "name": "Multi-Tool",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Multitool", "Leatherman", "אולר רב שימושי"],
+    "tags": ["tools"]
+  },
+  {
+    "id": "mushrooms",
+    "name": "Mushrooms",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Mushroom", "פטריות"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "mustard",
+    "name": "Mustard",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["חרדל"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "nail-clippers",
+    "name": "Nail Clippers",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["גוזז ציפורניים"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "napkins",
+    "name": "Napkins",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Napkin", "Serviettes", "מפיות"],
+    "tags": []
+  },
+  {
+    "id": "nature-scavenger-hunt-cards",
+    "name": "Nature Scavenger Hunt Cards",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "neck-gaiter",
+    "name": "Neck Gaiter",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "night-light",
+    "name": "Night Light",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מנורת לילה"],
+    "tags": ["baby", "lighting"]
+  },
+  {
+    "id": "nose-aspirator",
+    "name": "Nose Aspirator",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "first-aid"]
+  },
+  {
+    "id": "nutella",
+    "name": "Nutella",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "nutritional-yeast",
+    "name": "Nutritional Yeast",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "oat-milk",
+    "name": "Oat Milk",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["Oatmilk", "חלב שיבולת שועל"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "olive-oil",
+    "name": "Olive Oil",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["EVOO", "Extra Virgin Olive Oil", "שמן זית"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "olives",
+    "name": "Olives",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["זיתים"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "onion-powder",
+    "name": "Onion Powder",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "onions",
+    "name": "Onions",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Onion", "בצל"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "oral-rehydration-salts",
+    "name": "Oral Rehydration Salts",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "oranges",
+    "name": "Oranges",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Orange", "תפוזים"],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "outlet-covers",
+    "name": "Outlet Covers",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "overnight-oats-mix",
+    "name": "Overnight Oats Mix",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "pacifier",
+    "name": "Pacifier",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Dummy", "Soother", "מוצץ"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "pack-and-play",
+    "name": "Pack and Play",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "packing-cubes",
+    "name": "Packing Cubes",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["storage"]
+  },
+  {
+    "id": "paddleboard",
+    "name": "Paddleboard",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["SUP", "Stand Up Paddleboard"],
+    "tags": ["beach"]
+  },
+  {
+    "id": "pancake-mix",
+    "name": "Pancake Mix",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["תערובת פנקייקים"],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "paper-plates",
+    "name": "Paper Plates",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Disposable Plates", "צלחות חד פעמיות", "צלחות נייר"],
+    "tags": []
+  },
+  {
+    "id": "paper-towels",
+    "name": "Paper Towels",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Kitchen Roll", "מגבות נייר", "נייר סופג"],
+    "tags": []
+  },
+  {
+    "id": "paprika",
+    "name": "Paprika",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["פפריקה"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "paracord",
+    "name": "Paracord",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Para Cord", "550 Cord"],
+    "tags": ["tools"]
+  },
+  {
+    "id": "parchment-paper",
+    "name": "Parchment Paper",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "passport",
+    "name": "Passport",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Passports", "דרכון"],
+    "tags": []
+  },
+  {
+    "id": "pasta",
+    "name": "Pasta",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Noodles", "Spaghetti", "פסטה", "אטריות"],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "pbandj-supplies",
+    "name": "PB&J Supplies",
+    "category": "food",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "peaches",
+    "name": "Peaches",
+    "category": "food",
+    "unit": "kg",
+    "aliases": [],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "peanut-butter",
+    "name": "Peanut Butter",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["PB", "חמאת בוטנים"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "peanuts",
+    "name": "Peanuts",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["בוטנים"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "pears",
+    "name": "Pears",
+    "category": "food",
+    "unit": "kg",
+    "aliases": [],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "pedialyte",
+    "name": "Pedialyte",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["משקה אלקטרוליטים לילדים"],
+    "tags": ["drink", "kids"]
+  },
+  {
+    "id": "pen",
+    "name": "Pen",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "pepper",
+    "name": "Pepper",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Black Pepper", "פלפל שחור"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "pepperoni",
+    "name": "Pepperoni",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "pet-bowls",
+    "name": "Pet Bowls",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["קערות לחיות"],
+    "tags": ["pets"]
+  },
+  {
+    "id": "pet-carrier",
+    "name": "Pet Carrier",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כלוב נשיאה"],
+    "tags": ["pets"]
+  },
+  {
+    "id": "pet-first-aid-kit",
+    "name": "Pet First Aid Kit",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid", "pets"]
+  },
+  {
+    "id": "pet-tick-collar",
+    "name": "Pet Tick Collar",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pets"]
+  },
+  {
+    "id": "pet-towel",
+    "name": "Pet Towel",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pets"]
+  },
+  {
+    "id": "pet-waste-bags",
+    "name": "Pet Waste Bags",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["שקיות לכלב"],
+    "tags": ["pets"]
+  },
+  {
+    "id": "petroleum-jelly",
+    "name": "Petroleum Jelly",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "pickles",
+    "name": "Pickles",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["מלפפון חמוץ", "חמוצים"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "picnic-blanket",
+    "name": "Picnic Blanket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Picnic Rug", "Picnic Blankets", "שמיכת פיקניק"],
+    "tags": ["beach"]
+  },
+  {
+    "id": "pie",
+    "name": "Pie",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "pineapple",
+    "name": "Pineapple",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "pistachios",
+    "name": "Pistachios",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "pita-bread",
+    "name": "Pita Bread",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["פיתות", "לחם פיתה"],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "plastic-cups",
+    "name": "Plastic Cups",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Disposable Cups", "כוסות חד פעמיות", "כוסות פלסטיק"],
+    "tags": []
+  },
+  {
+    "id": "plastic-wrap",
+    "name": "Plastic Wrap",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [
+      "Cling Wrap",
+      "Cling Film",
+      "Saran Wrap",
+      "ניילון נצמד",
+      "ניילון למזון"
+    ],
+    "tags": []
+  },
+  {
+    "id": "plates",
+    "name": "Plates",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["Plate", "צלחות"],
+    "tags": []
+  },
+  {
+    "id": "playdough",
+    "name": "Playdough",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "playing-cards",
+    "name": "Playing Cards",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["קלפים"],
+    "tags": ["games"]
+  },
+  {
+    "id": "pocket-knife",
+    "name": "Pocket Knife",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["אולר"],
+    "tags": ["cooking", "tools"]
+  },
+  {
+    "id": "pool-noodles",
+    "name": "Pool Noodles",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["נודלס בריכה"],
+    "tags": ["beach", "kids"]
+  },
+  {
+    "id": "pop-up-shelter",
+    "name": "Pop-Up Shelter",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "popcorn",
+    "name": "Popcorn",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["פופקורן"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "popsicles",
+    "name": "Popsicles",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Ice Pops", "Icy Poles", "Ice Lollies", "ארטיק", "שלגון"],
+    "tags": ["frozen", "kids"]
+  },
+  {
+    "id": "pork-chops",
+    "name": "Pork Chops",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["צלעות חזיר"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "portable-crib",
+    "name": "Portable Crib",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מיטת תינוק מתקפלת", "לול"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "portable-dog-water-bottle",
+    "name": "Portable Dog Water Bottle",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pets"]
+  },
+  {
+    "id": "portable-dvd-player",
+    "name": "Portable DVD Player",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "portable-fan",
+    "name": "Portable Fan",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["power"]
+  },
+  {
+    "id": "portable-generator",
+    "name": "Portable Generator",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["גנרטור נייד"],
+    "tags": ["power"]
+  },
+  {
+    "id": "portable-speaker",
+    "name": "Portable Speaker",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "portable-toilet",
+    "name": "Portable Toilet",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "portobello-mushrooms",
+    "name": "Portobello Mushrooms",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "potatoes",
+    "name": "Potatoes",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Potato", "Spuds", "תפוחי אדמה"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "power-bank",
+    "name": "Power Bank",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Battery Pack", "Portable Charger", "מטען נייד", "סוללת גיבוי"],
+    "tags": ["power"]
+  },
+  {
+    "id": "prescription-medications",
+    "name": "Prescription Medications",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "pretzels",
+    "name": "Pretzels",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["בייגלה", "פרצלים"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "privacy-screen",
+    "name": "Privacy Screen",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "propane-tank",
+    "name": "Propane Tank",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "protein-bars",
+    "name": "Protein Bars",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "protein-powder",
+    "name": "Protein Powder",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "pudding-cups",
+    "name": "Pudding Cups",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "puffs-baby-snack",
+    "name": "Puffs (baby snack)",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "pulled-pork",
+    "name": "Pulled Pork",
+    "category": "food",
+    "unit": "kg",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "pumpkin-seeds",
+    "name": "Pumpkin Seeds",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "puzzle",
+    "name": "Puzzle",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["פאזל"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "quick-dry-shirt",
+    "name": "Quick-Dry Shirt",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "quinoa",
+    "name": "Quinoa",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "radishes",
+    "name": "Radishes",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "rain-fly",
+    "name": "Rain Fly",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "rain-jacket",
+    "name": "Rain Jacket",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Rain Coat", "Waterproof Jacket", "מעיל גשם"],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "rain-poncho",
+    "name": "Rain Poncho",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "raisin-boxes",
+    "name": "Raisin Boxes",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit", "kids", "snack"]
+  },
+  {
+    "id": "raisins",
+    "name": "Raisins",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["צימוקים"],
+    "tags": ["fruit", "snack"]
+  },
+  {
+    "id": "raspberries",
+    "name": "Raspberries",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "razor",
+    "name": "Razor",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["סכין גילוח", "מכונת גילוח"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "reflective-vest",
+    "name": "Reflective Vest",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "relish",
+    "name": "Relish",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "repair-patches",
+    "name": "Repair Patches",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["tools"]
+  },
+  {
+    "id": "reservation-printouts",
+    "name": "Reservation Printouts",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "ribs",
+    "name": "Ribs",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["צלעות"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "rice",
+    "name": "Rice",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["White Rice", "אורז"],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "rice-cakes",
+    "name": "Rice Cakes",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "rice-noodles",
+    "name": "Rice Noodles",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "rice-rusks",
+    "name": "Rice Rusks",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "road-flares",
+    "name": "Road Flares",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "roasted-red-peppers",
+    "name": "Roasted Red Peppers",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "roof-box",
+    "name": "Roof Box",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "roof-rack-straps",
+    "name": "Roof Rack Straps",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "rope",
+    "name": "Rope",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Ropes", "חבל"],
+    "tags": ["tools"]
+  },
+  {
+    "id": "rv-sewer-hose",
+    "name": "RV Sewer Hose",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "safety-pins",
+    "name": "Safety Pins",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "salad-dressing",
+    "name": "Salad Dressing",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["רוטב סלט"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "salad-mix",
+    "name": "Salad Mix",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "salami",
+    "name": "Salami",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "saline-drops",
+    "name": "Saline Drops",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby", "first-aid"]
+  },
+  {
+    "id": "saline-wound-wash",
+    "name": "Saline Wound Wash",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "salmon-fillet",
+    "name": "Salmon Fillet",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["פילה סלמון"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "salsa",
+    "name": "Salsa",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "salt",
+    "name": "Salt",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Table Salt", "Sea Salt", "מלח"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "sand-toys",
+    "name": "Sand Toys",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["צעצועי חול"],
+    "tags": ["beach", "kids"]
+  },
+  {
+    "id": "sandals",
+    "name": "Sandals",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Flip Flops", "Thongs", "סנדלים"],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "sandwich-bags",
+    "name": "Sandwich Bags",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "sauerkraut",
+    "name": "Sauerkraut",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "sausages",
+    "name": "Sausages",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Sausage", "Bangers", "נקניקיות"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "saw-folding",
+    "name": "Saw (folding)",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["tools"]
+  },
+  {
+    "id": "scarf",
+    "name": "Scarf",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["צעיף"],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "scissors-medical",
+    "name": "Scissors (medical)",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "scooter",
+    "name": "Scooter",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["קורקינט"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "seaweed-snacks",
+    "name": "Seaweed Snacks",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "seitan",
+    "name": "Seitan",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "serving-spoons",
+    "name": "Serving Spoons",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "sewing-kit",
+    "name": "Sewing Kit",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["ערכת תפירה"],
+    "tags": ["tools"]
+  },
+  {
+    "id": "shampoo",
+    "name": "Shampoo",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Hair Shampoo", "שמפו"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "shaving-cream",
+    "name": "Shaving Cream",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "shorts",
+    "name": "Shorts",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מכנסיים קצרים"],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "shovel-camping",
+    "name": "Shovel (camping)",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["tools"]
+  },
+  {
+    "id": "shower-tent",
+    "name": "Shower Tent",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "shrimp",
+    "name": "Shrimp",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Prawns", "שרימפס", "חסילונים"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "sippy-cups",
+    "name": "Sippy Cups",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כוסות שתייה", "כוס קש"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "skewers",
+    "name": "Skewers",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["שיפודים"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "ski-goggles",
+    "name": "Ski Goggles",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "sleep-mask",
+    "name": "Sleep Mask",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מסכת שינה"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "sleeping-bag",
+    "name": "Sleeping Bag",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Sleeping Bags", "שק שינה"],
+    "tags": ["sleep"]
+  },
+  {
+    "id": "sleeping-pad",
+    "name": "Sleeping Pad",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Sleeping Pads", "Sleeping Mat", "מזרן שינה"],
+    "tags": ["sleep"]
+  },
+  {
+    "id": "sliced-cheese",
+    "name": "Sliced Cheese",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "smoke-detector-portable",
+    "name": "Smoke Detector (portable)",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "smoked-salmon",
+    "name": "Smoked Salmon",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["סלמון מעושן"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "smoothie-mix",
+    "name": "Smoothie Mix",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "smores-kit",
+    "name": "S'mores Kit",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "snack-containers",
+    "name": "Snack Containers",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["קופסאות חטיפים"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "snakebite-kit",
+    "name": "Snakebite Kit",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "snap-peas",
+    "name": "Snap Peas",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "snorkel-set",
+    "name": "Snorkel Set",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["beach"]
+  },
+  {
+    "id": "snow-chains",
+    "name": "Snow Chains",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["car", "winter"]
+  },
+  {
+    "id": "snowshoes",
+    "name": "Snowshoes",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "soccer-ball",
+    "name": "Soccer Ball",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כדורגל"],
+    "tags": ["games"]
+  },
+  {
+    "id": "soda",
+    "name": "Soda",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["Pop", "Soft Drink", "Fizzy Drink", "שתייה מוגזת", "סודה"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "solar-charger",
+    "name": "Solar Charger",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Solar Panel", "מטען סולארי"],
+    "tags": ["power"]
+  },
+  {
+    "id": "soy-milk",
+    "name": "Soy Milk",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "soy-sauce",
+    "name": "Soy Sauce",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["רוטב סויה"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "spare-batteries",
+    "name": "Spare Batteries",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["סוללות רזרביות", "סוללות"],
+    "tags": ["power"]
+  },
+  {
+    "id": "spare-glasses",
+    "name": "Spare Glasses",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "sparkling-water",
+    "name": "Sparkling Water",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["מים מוגזים", "סודה"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "spatula",
+    "name": "Spatula",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מרית"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "spigot",
+    "name": "Spigot",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["water"]
+  },
+  {
+    "id": "spinach",
+    "name": "Spinach",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["תרד"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "spirits",
+    "name": "Spirits",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "spirulina",
+    "name": "Spirulina",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "splat-mat",
+    "name": "Splat Mat",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "splint",
+    "name": "Splint",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "sponge",
+    "name": "Sponge",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "sports-drink",
+    "name": "Sports Drink",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["משקה ספורט"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "squeezable-yogurt",
+    "name": "Squeezable Yogurt",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "sriracha",
+    "name": "Sriracha",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "star-chart",
+    "name": "Star Chart",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["navigation"]
+  },
+  {
+    "id": "steak",
+    "name": "Steak",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Steaks", "Beef Steak", "סטייק"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "sterile-gloves",
+    "name": "Sterile Gloves",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "stickers",
+    "name": "Stickers",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "sting-relief-pads",
+    "name": "Sting Relief Pads",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "strawberries",
+    "name": "Strawberries",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["תותים"],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "straws",
+    "name": "Straws",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "string-cheese",
+    "name": "String Cheese",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["גבינת שרוך", "מקלות גבינה"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "string-lights",
+    "name": "String Lights",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["lighting"]
+  },
+  {
+    "id": "stroller",
+    "name": "Stroller",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Pushchair", "Pram", "Buggy", "עגלה", "עגלת תינוק"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "stuff-sack",
+    "name": "Stuff Sack",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["storage"]
+  },
+  {
+    "id": "stuffed-animal",
+    "name": "Stuffed Animal",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["בובה רכה", "דובי"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "sugar",
+    "name": "Sugar",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["סוכר"],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "sun-dried-tomatoes",
+    "name": "Sun-Dried Tomatoes",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "sunburn-relief-spray",
+    "name": "Sunburn Relief Spray",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["ספריי לכוויות שמש"],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "sunflower-seeds",
+    "name": "Sunflower Seeds",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["גרעיני חמנייה", "גרעינים"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "sunglasses",
+    "name": "Sunglasses",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["משקפי שמש"],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "sunscreen",
+    "name": "Sunscreen",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Sunblock", "Sun Cream", "SPF", "קרם הגנה", "קרם שמש"],
+    "tags": ["beach"]
+  },
+  {
+    "id": "super-glue",
+    "name": "Super Glue",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["דבק מהיר", "סופר גלו"],
+    "tags": ["tools"]
+  },
+  {
+    "id": "swaddle",
+    "name": "Swaddle",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "sweet-potatoes",
+    "name": "Sweet Potatoes",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["בטטה", "בטטות"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "swimsuit",
+    "name": "Swimsuit",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [
+      "Swimming Costume",
+      "Bathing Suit",
+      "Trunks",
+      "Bikini",
+      "בגד ים"
+    ],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "swiss-chard",
+    "name": "Swiss Chard",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "tablet",
+    "name": "Tablet",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "tahini",
+    "name": "Tahini",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["טחינה"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "tamari",
+    "name": "Tamari",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "tampons",
+    "name": "Tampons",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "tarp",
+    "name": "Tarp",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Tarps", "Tarpaulin", "ברזנט"],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "tea-bags",
+    "name": "Tea Bags",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["שקיקי תה", "תה"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "teddy-grahams",
+    "name": "Teddy Grahams",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids", "snack"]
+  },
+  {
+    "id": "teething-biscuits",
+    "name": "Teething Biscuits",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "teething-toy",
+    "name": "Teething Toy",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "tempeh",
+    "name": "Tempeh",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "tent",
+    "name": "Tent",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Tents", "אוהל", "אוהלים"],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "tent-footprint",
+    "name": "Tent Footprint",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "tent-stakes",
+    "name": "Tent Stakes",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "thermal-underwear",
+    "name": "Thermal Underwear",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "thermometer",
+    "name": "Thermometer",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מד חום"],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "thermos",
+    "name": "Thermos",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Flask", "Insulated Bottle", "תרמוס"],
+    "tags": ["water"]
+  },
+  {
+    "id": "tick-remover",
+    "name": "Tick Remover",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "tire-repair-kit",
+    "name": "Tire Repair Kit",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "tissues",
+    "name": "Tissues",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["טישו", "ממחטות"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "toddler-bowls",
+    "name": "Toddler Bowls",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "toddler-cutlery",
+    "name": "Toddler Cutlery",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "toddler-plates",
+    "name": "Toddler Plates",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "toddler-snack-bars",
+    "name": "Toddler Snack Bars",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "tofu",
+    "name": "Tofu",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Bean Curd", "טופו"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "toilet-paper",
+    "name": "Toilet Paper",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["TP", "Loo Roll", "נייר טואלט"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "tomatoes",
+    "name": "Tomatoes",
+    "category": "food",
+    "unit": "kg",
+    "aliases": ["Tomato", "עגבניות"],
+    "tags": ["vegetables"]
+  },
+  {
+    "id": "tongs",
+    "name": "Tongs",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["BBQ Tongs", "Grilling Tongs", "מלקחיים"],
+    "tags": ["cooking"]
+  },
+  {
+    "id": "tongue-depressors",
+    "name": "Tongue Depressors",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "toothbrush",
+    "name": "Toothbrush",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מברשת שיניים"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "toothpaste",
+    "name": "Toothpaste",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["משחת שיניים"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "toothpicks",
+    "name": "Toothpicks",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "tortilla-chips",
+    "name": "Tortilla Chips",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "tortillas",
+    "name": "Tortillas",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["Wraps", "טורטיות"],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "tourniquet",
+    "name": "Tourniquet",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "tow-strap",
+    "name": "Tow Strap",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "towels",
+    "name": "Towels",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Towel", "מגבות"],
+    "tags": []
+  },
+  {
+    "id": "toy-cars",
+    "name": "Toy Cars",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["kids"]
+  },
+  {
+    "id": "trail-mix",
+    "name": "Trail Mix",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["GORP", "Scroggin", "תערובת גרעינים"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "trash-bags",
+    "name": "Trash Bags",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [
+      "Garbage Bags",
+      "Bin Bags",
+      "Rubbish Bags",
+      "שקיות זבל",
+      "שקיות אשפה"
+    ],
+    "tags": ["storage"]
+  },
+  {
+    "id": "travel-high-chair",
+    "name": "Travel High Chair",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כיסא אוכל לתינוק"],
+    "tags": ["baby"]
+  },
+  {
+    "id": "travel-pillow",
+    "name": "Travel Pillow",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כרית נסיעות"],
+    "tags": []
+  },
+  {
+    "id": "trekking-poles",
+    "name": "Trekking Poles",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["מקלות הליכה"],
+    "tags": ["tools"]
+  },
+  {
+    "id": "triangle-bandage",
+    "name": "Triangle Bandage",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "tripod",
+    "name": "Tripod",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "tuna-steaks",
+    "name": "Tuna Steaks",
+    "category": "food",
+    "unit": "kg",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "turkey-slices",
+    "name": "Turkey Slices",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["פרוסות הודו"],
+    "tags": ["protein"]
+  },
+  {
+    "id": "turmeric",
+    "name": "Turmeric",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "tweezers",
+    "name": "Tweezers",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["first-aid"]
+  },
+  {
+    "id": "usb-charging-cable",
+    "name": "USB Charging Cable",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כבל טעינה"],
+    "tags": ["power"]
+  },
+  {
+    "id": "vegan-butter",
+    "name": "Vegan Butter",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "vegan-cheese",
+    "name": "Vegan Cheese",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "vegan-cookies",
+    "name": "Vegan Cookies",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "vegan-mayo",
+    "name": "Vegan Mayo",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "vegan-yogurt",
+    "name": "Vegan Yogurt",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": []
+  },
+  {
+    "id": "vegetable-oil",
+    "name": "Vegetable Oil",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["שמן צמחי"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "veggie-burgers",
+    "name": "Veggie Burgers",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "veggie-chips",
+    "name": "Veggie Chips",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["snack"]
+  },
+  {
+    "id": "veggie-hot-dogs",
+    "name": "Veggie Hot Dogs",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "veggie-sausages",
+    "name": "Veggie Sausages",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["protein"]
+  },
+  {
+    "id": "veggie-straws",
+    "name": "Veggie Straws",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids", "snack"]
+  },
+  {
+    "id": "vinegar",
+    "name": "Vinegar",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["חומץ"],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "volleyball",
+    "name": "Volleyball",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["כדורעף"],
+    "tags": ["games"]
+  },
+  {
+    "id": "walkie-talkies",
+    "name": "Walkie-Talkies",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": ["Walkie Talkies", "Two-Way Radios", "ווקי טוקי"],
+    "tags": ["navigation"]
+  },
+  {
+    "id": "walnuts",
+    "name": "Walnuts",
+    "category": "food",
+    "unit": "pack",
+    "aliases": ["אגוזי מלך"],
+    "tags": ["snack"]
+  },
+  {
+    "id": "warm-layers",
+    "name": "Warm Layers",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "wash-basin",
+    "name": "Wash Basin",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "water",
+    "name": "Water",
+    "category": "food",
+    "unit": "l",
+    "aliases": ["Drinking Water", "Bottled Water", "מים"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "water-bladder",
+    "name": "Water Bladder",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["water"]
+  },
+  {
+    "id": "water-bottle",
+    "name": "Water Bottle",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["Water Bottles", "בקבוק מים", "מימייה"],
+    "tags": ["water"]
+  },
+  {
+    "id": "water-filter",
+    "name": "Water Filter",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מסנן מים"],
+    "tags": ["water"]
+  },
+  {
+    "id": "water-guns",
+    "name": "Water Guns",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["אקדחי מים"],
+    "tags": ["kids"]
+  },
+  {
+    "id": "water-hose",
+    "name": "Water Hose",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["water"]
+  },
+  {
+    "id": "water-jug",
+    "name": "Water Jug",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": ["מיכל מים", "ג'ריקן"],
+    "tags": ["water"]
+  },
+  {
+    "id": "water-pressure-regulator",
+    "name": "Water Pressure Regulator",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["water"]
+  },
+  {
+    "id": "water-purification-tablets",
+    "name": "Water Purification Tablets",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["water"]
+  },
+  {
+    "id": "water-shoes",
+    "name": "Water Shoes",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing"]
+  },
+  {
+    "id": "watermelon",
+    "name": "Watermelon",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["אבטיח"],
+    "tags": ["fruit"]
+  },
+  {
+    "id": "waterproof-matches",
+    "name": "Waterproof Matches",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["cooking", "tools"]
+  },
+  {
+    "id": "wd-40",
+    "name": "WD-40",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["tools"]
+  },
+  {
+    "id": "wet-wipes",
+    "name": "Wet Wipes",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Baby Wipes", "מגבונים לחים"],
+    "tags": ["hygiene"]
+  },
+  {
+    "id": "wheel-chocks",
+    "name": "Wheel Chocks",
+    "category": "equipment",
+    "unit": "set",
+    "aliases": [],
+    "tags": ["car"]
+  },
+  {
+    "id": "whistle",
+    "name": "Whistle",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["navigation"]
+  },
+  {
+    "id": "white-noise-machine",
+    "name": "White Noise Machine",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["baby"]
+  },
+  {
+    "id": "whole-milk",
+    "name": "Whole Milk",
+    "category": "food",
+    "unit": "l",
+    "aliases": [],
+    "tags": ["drink"]
+  },
+  {
+    "id": "whole-wheat-bread",
+    "name": "Whole Wheat Bread",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "whole-wheat-pasta",
+    "name": "Whole Wheat Pasta",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "whole-wheat-tortillas",
+    "name": "Whole Wheat Tortillas",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "wild-rice",
+    "name": "Wild Rice",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["pantry"]
+  },
+  {
+    "id": "windbreak",
+    "name": "Windbreak",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["shelter"]
+  },
+  {
+    "id": "windshield-scraper",
+    "name": "Windshield Scraper",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["car", "winter"]
+  },
+  {
+    "id": "wine",
+    "name": "Wine",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Wines", "Red Wine", "White Wine", "יין"],
+    "tags": ["drink"]
+  },
+  {
+    "id": "wool-socks",
+    "name": "Wool Socks",
+    "category": "equipment",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["clothing", "winter"]
+  },
+  {
+    "id": "worcestershire-sauce",
+    "name": "Worcestershire Sauce",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": [],
+    "tags": ["condiments"]
+  },
+  {
+    "id": "yogurt",
+    "name": "Yogurt",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["Yoghurt", "יוגורט"],
+    "tags": ["breakfast"]
+  },
+  {
+    "id": "yogurt-tubes",
+    "name": "Yogurt Tubes",
+    "category": "food",
+    "unit": "pack",
+    "aliases": [],
+    "tags": ["kids", "snack"]
+  },
+  {
+    "id": "zip-ties",
+    "name": "Zip Ties",
+    "category": "equipment",
+    "unit": "pack",
+    "aliases": ["Cable Ties", "Zip-Ties", "אזיקונים"],
+    "tags": ["tools"]
+  },
+  {
+    "id": "zucchini",
+    "name": "Zucchini",
+    "category": "food",
+    "unit": "pcs",
+    "aliases": ["קישוא"],
+    "tags": ["vegetables"]
+  }
 ]

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,0 +1,37 @@
+import { useState, useCallback } from 'react';
+
+function readValue<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return JSON.parse(raw) as T;
+  } catch {
+    return fallback;
+  }
+}
+
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T
+): [T, (value: T | ((prev: T) => T)) => void] {
+  const [storedValue, setStoredValue] = useState<T>(() =>
+    readValue(key, initialValue)
+  );
+
+  const setValue = useCallback(
+    (value: T | ((prev: T) => T)) => {
+      setStoredValue((prev) => {
+        const next = value instanceof Function ? value(prev) : value;
+        try {
+          localStorage.setItem(key, JSON.stringify(next));
+        } catch {
+          // quota exceeded or unavailable
+        }
+        return next;
+      });
+    },
+    [key]
+  );
+
+  return [storedValue, setValue];
+}

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -1,0 +1,30 @@
+import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
+import en from './locales/en.json';
+import he from './locales/he.json';
+
+const STORAGE_KEY = 'chillist-lang';
+
+function getSavedLanguage(): string {
+  try {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (saved === 'en' || saved === 'he') return saved;
+  } catch {
+    // localStorage unavailable (SSR, privacy mode)
+  }
+  return 'en';
+}
+
+i18n.use(initReactI18next).init({
+  resources: {
+    en: { translation: en },
+    he: { translation: he },
+  },
+  lng: getSavedLanguage(),
+  fallbackLng: 'en',
+  interpolation: {
+    escapeValue: false,
+  },
+});
+
+export default i18n;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,0 +1,231 @@
+{
+  "nav": {
+    "plans": "Plans",
+    "about": "About"
+  },
+  "auth": {
+    "signIn": "Sign In",
+    "signUp": "Sign Up",
+    "signOut": "Sign Out",
+    "editProfile": "Edit Profile",
+    "userFallback": "User",
+    "signedInAs": "Signed in as {{email}}",
+    "signedIn": "Signed in",
+    "signOutFailed": "Sign out failed: {{message}}"
+  },
+  "signIn": {
+    "title": "Sign in",
+    "subtitle": "Welcome back to Chillist.",
+    "email": "Email",
+    "password": "Password",
+    "emailPlaceholder": "you@example.com",
+    "passwordPlaceholder": "Your password",
+    "submitting": "Signing in...",
+    "submit": "Sign In",
+    "or": "or",
+    "google": "Sign in with Google",
+    "noAccount": "Don't have an account?",
+    "signUpLink": "Sign up"
+  },
+  "signUp": {
+    "title": "Create an account",
+    "subtitle": "Sign up to start planning with Chillist.",
+    "email": "Email",
+    "password": "Password",
+    "emailPlaceholder": "you@example.com",
+    "passwordPlaceholder": "At least 6 characters",
+    "submitting": "Creating account...",
+    "submit": "Sign Up",
+    "or": "or",
+    "google": "Sign up with Google",
+    "hasAccount": "Already have an account?",
+    "signInLink": "Sign in",
+    "confirmTitle": "Check your email",
+    "confirmMessage": "We sent a confirmation link to your email. Please check your inbox and click the link to activate your account.",
+    "goToSignIn": "Go to Sign In"
+  },
+  "profile": {
+    "title": "Complete your profile",
+    "subtitle": "Add your details so your trip buddies know who you are. All fields are optional.",
+    "firstName": "First name",
+    "lastName": "Last name",
+    "phone": "Phone",
+    "saving": "Saving...",
+    "submit": "Save & Continue",
+    "skip": "Skip for now",
+    "updated": "Profile updated"
+  },
+  "plans": {
+    "title": "My Plans",
+    "createNew": "Create New Plan",
+    "empty": "No plans yet. Create one to get started!",
+    "loading": "Loading plans...",
+    "tryAgain": "Try Again",
+    "participant_one": "{{count}} participant",
+    "participant_other": "{{count}} participants"
+  },
+  "plan": {
+    "details": "Details",
+    "status": "Status",
+    "visibility": "Visibility",
+    "owner": "Owner",
+    "start": "Start",
+    "end": "End",
+    "location": "Location",
+    "na": "N/A",
+    "participants": "Participants",
+    "noParticipants": "No participants yet. Add one to get started!",
+    "addParticipant": "+ Add Participant",
+    "backToPlans": "← Back to Plans",
+    "loading": "Loading plan details...",
+    "notFound": "Plan not found",
+    "filterByPerson": "Filter by person"
+  },
+  "addParticipant": {
+    "firstName": "First Name *",
+    "lastName": "Last Name *",
+    "phone": "Phone *",
+    "email": "Email",
+    "firstNamePlaceholder": "First name",
+    "lastNamePlaceholder": "Last name",
+    "phonePlaceholder": "Phone number",
+    "emailPlaceholder": "Email (optional)",
+    "submitting": "Adding…",
+    "submit": "Add Participant",
+    "cancel": "Cancel"
+  },
+  "planForm": {
+    "title": "Title *",
+    "titlePlaceholder": "Enter plan title",
+    "description": "Description",
+    "descriptionPlaceholder": "Add details about your plan",
+    "status": "Status",
+    "visibility": "Visibility",
+    "ownerLegend": "Owner (you) *",
+    "firstName": "First Name *",
+    "lastName": "Last Name *",
+    "phone": "Phone *",
+    "email": "Email",
+    "firstNamePlaceholder": "First name",
+    "lastNamePlaceholder": "Last name",
+    "phonePlaceholder": "Phone number",
+    "emailPlaceholder": "Email (optional)",
+    "participantsLegend": "Participants (optional)",
+    "participantIndex": "Participant {{index}}",
+    "remove": "Remove",
+    "addParticipant": "+ Add Participant",
+    "locationLegend": "Location (optional)",
+    "locationName": "Name",
+    "locationNamePlaceholder": "Location name",
+    "city": "City",
+    "cityPlaceholder": "City",
+    "country": "Country",
+    "countryPlaceholder": "Country",
+    "region": "Region",
+    "regionPlaceholder": "Region/Province",
+    "oneDay": "One-day plan",
+    "date": "Date *",
+    "startTime": "Start time",
+    "endTime": "End time",
+    "startDate": "Start date *",
+    "endDate": "End date *",
+    "tags": "Tags (comma separated)",
+    "tagsPlaceholder": "e.g. picnic, friends, summer",
+    "submitting": "Creating…",
+    "submit": "Create Plan"
+  },
+  "items": {
+    "title": "Items",
+    "empty": "No items yet. Add one to get started!",
+    "addItem": "+ Add Item",
+    "updateItem": "Update Item",
+    "addItemLabel": "Add Item",
+    "name": "Name *",
+    "namePlaceholder": "Item name",
+    "category": "Category *",
+    "status": "Status *",
+    "quantity": "Quantity *",
+    "unit": "Unit",
+    "notes": "Notes",
+    "notesPlaceholder": "Optional notes",
+    "assignTo": "Assign to",
+    "unassigned": "Unassigned",
+    "saving": "Saving…",
+    "cancel": "Cancel"
+  },
+  "categories": {
+    "equipment": "Equipment",
+    "food": "Food",
+    "noItems": "No {{category}} items"
+  },
+  "itemStatus": {
+    "pending": "Pending",
+    "purchased": "Purchased",
+    "packed": "Packed",
+    "canceled": "Canceled"
+  },
+  "planStatus": {
+    "active": "Active",
+    "draft": "Draft",
+    "archived": "Archived"
+  },
+  "planVisibility": {
+    "public": "Public",
+    "unlisted": "Unlisted",
+    "private": "Private"
+  },
+  "filters": {
+    "all": "All",
+    "buyingList": "Buying List",
+    "packingList": "Packing List",
+    "assigningList": "Assigning List"
+  },
+  "roles": {
+    "owner": "owner",
+    "participant": "participant",
+    "viewer": "viewer"
+  },
+  "errors": {
+    "somethingWentWrong": "Something went wrong",
+    "unexpectedError": "An unexpected error occurred.",
+    "backToPlans": "Back to Plans"
+  },
+  "notFound": {
+    "title": "404 — Page Not Found",
+    "message": "We couldn't find the page you were looking for.",
+    "backToPlans": "Back to Plans"
+  },
+  "about": {
+    "title": "About Us",
+    "welcome": "Welcome to Chillist!"
+  },
+  "validation": {
+    "emailInvalid": "Please enter a valid email",
+    "passwordMin": "Password must be at least 6 characters",
+    "nameRequired": "Name is required",
+    "lastNameRequired": "Last name is required",
+    "phoneRequired": "Phone is required",
+    "titleRequired": "Title is required",
+    "ownerNameRequired": "Owner name is required",
+    "ownerLastNameRequired": "Owner last name is required",
+    "ownerPhoneRequired": "Owner phone is required",
+    "dateRequired": "Date is required",
+    "startDateRequired": "Start date is required",
+    "endDateRequired": "End date is required",
+    "quantityMin": "Quantity must be at least 1"
+  },
+  "units": {
+    "kg": "kg",
+    "g": "g",
+    "lb": "lb",
+    "oz": "oz",
+    "l": "l",
+    "ml": "ml",
+    "pcs": "pcs",
+    "pack": "pack",
+    "set": "set"
+  },
+  "language": {
+    "toggle": "עב"
+  }
+}

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -1,0 +1,231 @@
+{
+  "nav": {
+    "plans": "תוכניות",
+    "about": "אודות"
+  },
+  "auth": {
+    "signIn": "התחברות",
+    "signUp": "הרשמה",
+    "signOut": "התנתקות",
+    "editProfile": "עריכת פרופיל",
+    "userFallback": "משתמש",
+    "signedInAs": "מחובר בתור {{email}}",
+    "signedIn": "מחובר",
+    "signOutFailed": "ההתנתקות נכשלה: {{message}}"
+  },
+  "signIn": {
+    "title": "התחברות",
+    "subtitle": "ברוכים השבים ל-Chillist.",
+    "email": "אימייל",
+    "password": "סיסמה",
+    "emailPlaceholder": "you@example.com",
+    "passwordPlaceholder": "הסיסמה שלך",
+    "submitting": "מתחבר...",
+    "submit": "התחברות",
+    "or": "או",
+    "google": "התחברות עם Google",
+    "noAccount": "אין לך חשבון?",
+    "signUpLink": "הרשמה"
+  },
+  "signUp": {
+    "title": "יצירת חשבון",
+    "subtitle": "הירשם כדי להתחיל לתכנן עם Chillist.",
+    "email": "אימייל",
+    "password": "סיסמה",
+    "emailPlaceholder": "you@example.com",
+    "passwordPlaceholder": "לפחות 6 תווים",
+    "submitting": "יוצר חשבון...",
+    "submit": "הרשמה",
+    "or": "או",
+    "google": "הרשמה עם Google",
+    "hasAccount": "כבר יש לך חשבון?",
+    "signInLink": "התחברות",
+    "confirmTitle": "בדוק את האימייל שלך",
+    "confirmMessage": "שלחנו קישור אישור לאימייל שלך. בדוק את תיבת הדואר הנכנס ולחץ על הקישור כדי להפעיל את החשבון.",
+    "goToSignIn": "עבור להתחברות"
+  },
+  "profile": {
+    "title": "השלם את הפרופיל שלך",
+    "subtitle": "הוסף את הפרטים שלך כדי שחברי הטיול ידעו מי אתה. כל השדות אופציונליים.",
+    "firstName": "שם פרטי",
+    "lastName": "שם משפחה",
+    "phone": "טלפון",
+    "saving": "שומר...",
+    "submit": "שמירה והמשך",
+    "skip": "דלג לעת עתה",
+    "updated": "הפרופיל עודכן"
+  },
+  "plans": {
+    "title": "התוכניות שלי",
+    "createNew": "יצירת תוכנית חדשה",
+    "empty": "אין תוכניות עדיין. צור אחת כדי להתחיל!",
+    "loading": "טוען תוכניות...",
+    "tryAgain": "נסה שוב",
+    "participant_one": "משתתף {{count}}",
+    "participant_other": "{{count}} משתתפים"
+  },
+  "plan": {
+    "details": "פרטים",
+    "status": "סטטוס",
+    "visibility": "נראות",
+    "owner": "בעלים",
+    "start": "התחלה",
+    "end": "סיום",
+    "location": "מיקום",
+    "na": "לא זמין",
+    "participants": "משתתפים",
+    "noParticipants": "אין משתתפים עדיין. הוסף אחד כדי להתחיל!",
+    "addParticipant": "+ הוספת משתתף",
+    "backToPlans": "→ חזרה לתוכניות",
+    "loading": "טוען פרטי תוכנית...",
+    "notFound": "התוכנית לא נמצאה",
+    "filterByPerson": "סינון לפי אדם"
+  },
+  "addParticipant": {
+    "firstName": "שם פרטי *",
+    "lastName": "שם משפחה *",
+    "phone": "טלפון *",
+    "email": "אימייל",
+    "firstNamePlaceholder": "שם פרטי",
+    "lastNamePlaceholder": "שם משפחה",
+    "phonePlaceholder": "מספר טלפון",
+    "emailPlaceholder": "אימייל (אופציונלי)",
+    "submitting": "מוסיף…",
+    "submit": "הוספת משתתף",
+    "cancel": "ביטול"
+  },
+  "planForm": {
+    "title": "כותרת *",
+    "titlePlaceholder": "הזן כותרת לתוכנית",
+    "description": "תיאור",
+    "descriptionPlaceholder": "הוסף פרטים על התוכנית שלך",
+    "status": "סטטוס",
+    "visibility": "נראות",
+    "ownerLegend": "בעלים (אתה) *",
+    "firstName": "שם פרטי *",
+    "lastName": "שם משפחה *",
+    "phone": "טלפון *",
+    "email": "אימייל",
+    "firstNamePlaceholder": "שם פרטי",
+    "lastNamePlaceholder": "שם משפחה",
+    "phonePlaceholder": "מספר טלפון",
+    "emailPlaceholder": "אימייל (אופציונלי)",
+    "participantsLegend": "משתתפים (אופציונלי)",
+    "participantIndex": "משתתף {{index}}",
+    "remove": "הסרה",
+    "addParticipant": "+ הוספת משתתף",
+    "locationLegend": "מיקום (אופציונלי)",
+    "locationName": "שם",
+    "locationNamePlaceholder": "שם המיקום",
+    "city": "עיר",
+    "cityPlaceholder": "עיר",
+    "country": "מדינה",
+    "countryPlaceholder": "מדינה",
+    "region": "אזור",
+    "regionPlaceholder": "אזור/מחוז",
+    "oneDay": "תוכנית ליום אחד",
+    "date": "תאריך *",
+    "startTime": "שעת התחלה",
+    "endTime": "שעת סיום",
+    "startDate": "תאריך התחלה *",
+    "endDate": "תאריך סיום *",
+    "tags": "תגיות (מופרדות בפסיקים)",
+    "tagsPlaceholder": "לדוגמה: פיקניק, חברים, קיץ",
+    "submitting": "יוצר…",
+    "submit": "יצירת תוכנית"
+  },
+  "items": {
+    "title": "פריטים",
+    "empty": "אין פריטים עדיין. הוסף אחד כדי להתחיל!",
+    "addItem": "+ הוספת פריט",
+    "updateItem": "עדכון פריט",
+    "addItemLabel": "הוספת פריט",
+    "name": "שם *",
+    "namePlaceholder": "שם הפריט",
+    "category": "קטגוריה *",
+    "status": "סטטוס *",
+    "quantity": "כמות *",
+    "unit": "יחידה",
+    "notes": "הערות",
+    "notesPlaceholder": "הערות (אופציונלי)",
+    "assignTo": "הקצה ל",
+    "unassigned": "לא מוקצה",
+    "saving": "שומר…",
+    "cancel": "ביטול"
+  },
+  "categories": {
+    "equipment": "ציוד",
+    "food": "אוכל",
+    "noItems": "אין פריטי {{category}}"
+  },
+  "itemStatus": {
+    "pending": "ממתין",
+    "purchased": "נרכש",
+    "packed": "נארז",
+    "canceled": "בוטל"
+  },
+  "planStatus": {
+    "active": "פעיל",
+    "draft": "טיוטה",
+    "archived": "בארכיון"
+  },
+  "planVisibility": {
+    "public": "ציבורי",
+    "unlisted": "לא ברשימה",
+    "private": "פרטי"
+  },
+  "filters": {
+    "all": "הכל",
+    "buyingList": "רשימת קניות",
+    "packingList": "רשימת אריזה",
+    "assigningList": "רשימת הקצאה"
+  },
+  "roles": {
+    "owner": "בעלים",
+    "participant": "משתתף",
+    "viewer": "צופה"
+  },
+  "errors": {
+    "somethingWentWrong": "משהו השתבש",
+    "unexpectedError": "אירעה שגיאה בלתי צפויה.",
+    "backToPlans": "חזרה לתוכניות"
+  },
+  "notFound": {
+    "title": "404 — הדף לא נמצא",
+    "message": "לא הצלחנו למצוא את הדף שחיפשת.",
+    "backToPlans": "חזרה לתוכניות"
+  },
+  "about": {
+    "title": "אודותינו",
+    "welcome": "ברוכים הבאים ל-Chillist!"
+  },
+  "validation": {
+    "emailInvalid": "נא להזין אימייל תקין",
+    "passwordMin": "הסיסמה חייבת להכיל לפחות 6 תווים",
+    "nameRequired": "שם הוא שדה חובה",
+    "lastNameRequired": "שם משפחה הוא שדה חובה",
+    "phoneRequired": "טלפון הוא שדה חובה",
+    "titleRequired": "כותרת היא שדה חובה",
+    "ownerNameRequired": "שם הבעלים הוא שדה חובה",
+    "ownerLastNameRequired": "שם משפחה של הבעלים הוא שדה חובה",
+    "ownerPhoneRequired": "טלפון הבעלים הוא שדה חובה",
+    "dateRequired": "תאריך הוא שדה חובה",
+    "startDateRequired": "תאריך התחלה הוא שדה חובה",
+    "endDateRequired": "תאריך סיום הוא שדה חובה",
+    "quantityMin": "הכמות חייבת להיות לפחות 1"
+  },
+  "units": {
+    "kg": "ק\"ג",
+    "g": "ג",
+    "lb": "ליברה",
+    "oz": "אונקיה",
+    "l": "ל",
+    "ml": "מ\"ל",
+    "pcs": "יח'",
+    "pack": "חב'",
+    "set": "סט"
+  },
+  "language": {
+    "toggle": "EN"
+  }
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import './i18n';
 import './index.css';
 import { App } from './App.tsx';
 

--- a/src/routes/ErrorPage.tsx
+++ b/src/routes/ErrorPage.tsx
@@ -1,27 +1,29 @@
 import { Link } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 
 interface ErrorPageProps {
   error?: Error | null;
 }
 
 export function ErrorPage({ error }: ErrorPageProps) {
+  const { t } = useTranslation();
   return (
     <div
       className="error-page"
       style={{ padding: '2rem', textAlign: 'center' }}
     >
       <h1 style={{ fontSize: '1.75rem', marginBottom: '1rem' }}>
-        Something went wrong
+        {t('errors.somethingWentWrong')}
       </h1>
       <div style={{ color: '#b91c1c', marginBottom: '1rem' }}>
-        {error?.message ?? 'An unexpected error occurred.'}
+        {error?.message ?? t('errors.unexpectedError')}
       </div>
       <div>
         <Link
           to="/plans"
           style={{ color: '#2563eb', textDecoration: 'underline' }}
         >
-          Back to Plans
+          {t('errors.backToPlans')}
         </Link>
       </div>
     </div>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -4,6 +4,7 @@ import NotFound from './not-found.lazy';
 import Header from '../components/Header';
 import { ErrorPage } from './ErrorPage';
 import AuthProvider from '../contexts/AuthProvider';
+import LanguageProvider from '../contexts/LanguageProvider';
 
 function logError(error: Error, context?: string) {
   const errorInfo = {
@@ -37,35 +38,37 @@ export const Route = createRootRoute({
   },
   component: () => {
     return (
-      <AuthProvider>
-        <div className="min-h-screen flex flex-col bg-gray-50">
-          <Toaster
-            position="bottom-center"
-            toastOptions={{
-              duration: 2000,
-              error: {
-                duration: 4000,
-                style: {
-                  background: '#FEF2F2',
-                  color: '#991B1B',
-                  border: '1px solid #FECACA',
+      <LanguageProvider>
+        <AuthProvider>
+          <div className="min-h-screen flex flex-col bg-gray-50">
+            <Toaster
+              position="bottom-center"
+              toastOptions={{
+                duration: 2000,
+                error: {
+                  duration: 4000,
+                  style: {
+                    background: '#FEF2F2',
+                    color: '#991B1B',
+                    border: '1px solid #FECACA',
+                  },
                 },
-              },
-              success: {
-                style: {
-                  background: '#F0FDF4',
-                  color: '#166534',
-                  border: '1px solid #BBF7D0',
+                success: {
+                  style: {
+                    background: '#F0FDF4',
+                    color: '#166534',
+                    border: '1px solid #BBF7D0',
+                  },
                 },
-              },
-            }}
-          />
-          <Header />
-          <main className="flex-1 w-full max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-2 sm:py-6 lg:py-8">
-            <Outlet />
-          </main>
-        </div>
-      </AuthProvider>
+              }}
+            />
+            <Header />
+            <main className="flex-1 w-full max-w-7xl mx-auto px-3 sm:px-6 lg:px-8 py-2 sm:py-6 lg:py-8">
+              <Outlet />
+            </main>
+          </div>
+        </AuthProvider>
+      </LanguageProvider>
     );
   },
 });

--- a/src/routes/about.lazy.tsx
+++ b/src/routes/about.lazy.tsx
@@ -1,14 +1,16 @@
 import { createLazyFileRoute } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 
 export const Route = createLazyFileRoute('/about')({
   component: About,
 });
 
 export function About() {
+  const { t } = useTranslation();
   return (
     <div className="about">
-      <h1>About Us</h1>
-      <p>Welcome to Chillist!</p>
+      <h1>{t('about.title')}</h1>
+      <p>{t('about.welcome')}</p>
     </div>
   );
 }

--- a/src/routes/complete-profile.lazy.tsx
+++ b/src/routes/complete-profile.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 import toast from 'react-hot-toast';
 import { useAuth } from '../contexts/useAuth';
@@ -44,6 +45,7 @@ function CompleteProfileForm({
 }: {
   user: { user_metadata: Record<string, unknown> };
 }) {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const metadata = user.user_metadata;
   const { first, last } = splitFullName(metadata.full_name as string);
@@ -79,7 +81,7 @@ function CompleteProfileForm({
       return;
     }
 
-    toast.success('Profile updated');
+    toast.success(t('profile.updated'));
     navigate({ to: '/plans' });
   }
 
@@ -87,12 +89,9 @@ function CompleteProfileForm({
     <div className="flex min-h-[60vh] items-center justify-center">
       <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-sm sm:p-8">
         <h1 className="text-2xl font-semibold text-gray-900">
-          Complete your profile
+          {t('profile.title')}
         </h1>
-        <p className="mt-1 text-sm text-gray-600">
-          Add your details so your trip buddies know who you are. All fields are
-          optional.
-        </p>
+        <p className="mt-1 text-sm text-gray-600">{t('profile.subtitle')}</p>
 
         <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-4">
           <div>
@@ -100,7 +99,7 @@ function CompleteProfileForm({
               htmlFor="firstName"
               className="block text-sm font-medium text-gray-700"
             >
-              First name
+              {t('profile.firstName')}
             </label>
             <input
               id="firstName"
@@ -122,7 +121,7 @@ function CompleteProfileForm({
               htmlFor="lastName"
               className="block text-sm font-medium text-gray-700"
             >
-              Last name
+              {t('profile.lastName')}
             </label>
             <input
               id="lastName"
@@ -144,7 +143,7 @@ function CompleteProfileForm({
               htmlFor="phone"
               className="block text-sm font-medium text-gray-700"
             >
-              Phone
+              {t('profile.phone')}
             </label>
             <input
               id="phone"
@@ -166,7 +165,7 @@ function CompleteProfileForm({
             disabled={isSubmitting}
             className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isSubmitting ? 'Saving...' : 'Save & Continue'}
+            {isSubmitting ? t('profile.saving') : t('profile.submit')}
           </button>
         </form>
 
@@ -175,7 +174,7 @@ function CompleteProfileForm({
             to="/plans"
             className="text-sm font-medium text-gray-500 hover:text-gray-700"
           >
-            Skip for now
+            {t('profile.skip')}
           </Link>
         </p>
       </div>

--- a/src/routes/not-found.lazy.tsx
+++ b/src/routes/not-found.lazy.tsx
@@ -1,24 +1,24 @@
 import { createLazyFileRoute } from '@tanstack/react-router';
 import { Link } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 
 export const Route = createLazyFileRoute('/not-found')({
   component: NotFound,
 });
 
 function NotFound() {
+  const { t } = useTranslation();
   return (
     <div style={{ maxWidth: 720, margin: '2rem auto', padding: '1rem' }}>
       <h1 style={{ fontSize: '1.5rem', marginBottom: '0.5rem' }}>
-        404 — Page Not Found
+        {t('notFound.title')}
       </h1>
-      <p style={{ marginBottom: '1rem' }}>
-        We couldn't find the page you were looking for.
-      </p>
+      <p style={{ marginBottom: '1rem' }}>{t('notFound.message')}</p>
       <Link
         to="/plans"
         style={{ color: '#2563eb', textDecoration: 'underline' }}
       >
-        Back to Plans
+        {t('notFound.backToPlans')}
       </Link>
     </div>
   );

--- a/src/routes/plan.$planId.lazy.tsx
+++ b/src/routes/plan.$planId.lazy.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createLazyFileRoute } from '@tanstack/react-router';
 import {
   Link,
@@ -28,6 +29,7 @@ export const Route = createLazyFileRoute('/plan/$planId')({
 });
 
 function PlanDetails() {
+  const { t } = useTranslation();
   const { planId } = useParams({ from: '/plan/$planId' });
   const { data: plan, isLoading, error } = usePlan(planId);
   const createItem = useCreateItem(planId);
@@ -43,7 +45,7 @@ function PlanDetails() {
   useScrollRestore(`plan-${planId}`, !isLoading && !!plan);
 
   if (isLoading) {
-    return <div className="text-center">Loading plan details...</div>;
+    return <div className="text-center">{t('plan.loading')}</div>;
   }
 
   if (error) {
@@ -51,7 +53,7 @@ function PlanDetails() {
   }
 
   if (!plan) {
-    throw new Error('Plan not found');
+    throw new Error(t('plan.notFound'));
   }
 
   async function handleAddItem(values: ItemFormValues) {
@@ -159,7 +161,7 @@ function PlanDetails() {
             to="/plans"
             className="text-blue-500 hover:underline text-sm sm:text-base"
           >
-            ← Back to Plans
+            {t('plan.backToPlans')}
           </Link>
         </div>
         <Plan
@@ -173,9 +175,9 @@ function PlanDetails() {
         <div className="mt-6 sm:mt-8">
           <div className="flex items-center justify-between mb-3 sm:mb-4">
             <h2 className="text-lg sm:text-xl font-semibold text-gray-800">
-              Items
+              {t('items.title')}
               {plan.items.length > 0 && (
-                <span className="ml-2 text-sm font-normal text-gray-500">
+                <span className="ms-2 text-sm font-normal text-gray-500">
                   ({plan.items.length})
                 </span>
               )}
@@ -187,7 +189,7 @@ function PlanDetails() {
               {plan.participants.length > 0 && (
                 <div>
                   <p className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2">
-                    Filter by person
+                    {t('plan.filterByPerson')}
                   </p>
                   <ParticipantFilter
                     participants={plan.participants}
@@ -231,7 +233,7 @@ function PlanDetails() {
           {plan.items.length === 0 && !showItemForm && (
             <div className="bg-white rounded-lg shadow-sm p-6 sm:p-8 text-center mb-4">
               <p className="text-gray-500 text-sm sm:text-base">
-                No items yet. Add one to get started!
+                {t('items.empty')}
               </p>
             </div>
           )}
@@ -268,7 +270,7 @@ function PlanDetails() {
               onSubmit={handleFormSubmit}
               onCancel={() => setEditingItemId(null)}
               isSubmitting={updateItemMutation.isPending}
-              submitLabel="Update Item"
+              submitLabel={t('items.updateItem')}
             />
           ) : showItemForm ? (
             <ItemForm
@@ -283,7 +285,7 @@ function PlanDetails() {
               onClick={handleStartCreate}
               className="w-full px-4 py-3 bg-green-600 text-white font-semibold rounded-lg hover:bg-green-700 active:bg-green-800 transition-colors shadow-sm hover:shadow-md"
             >
-              + Add Item
+              {t('items.addItem')}
             </button>
           )}
         </div>

--- a/src/routes/plans.lazy.tsx
+++ b/src/routes/plans.lazy.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { createLazyFileRoute } from '@tanstack/react-router';
+import { useTranslation } from 'react-i18next';
 import { usePlans } from '../hooks/usePlans';
 import { PlansList } from '../components/PlansList';
 import { getApiErrorMessage } from '../core/error-utils';
@@ -9,6 +10,7 @@ export const Route = createLazyFileRoute('/plans')({
 });
 
 function Plans() {
+  const { t } = useTranslation();
   const { data: plans, isLoading, error, refetch } = usePlans();
 
   useEffect(() => {
@@ -24,7 +26,7 @@ function Plans() {
   if (isLoading) {
     return (
       <div className="flex justify-center items-center h-64">
-        <div className="text-gray-600">Loading plans...</div>
+        <div className="text-gray-600">{t('plans.loading')}</div>
       </div>
     );
   }
@@ -43,7 +45,7 @@ function Plans() {
               onClick={() => refetch()}
               className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 transition-colors"
             >
-              Try Again
+              {t('plans.tryAgain')}
             </button>
           )}
         </div>

--- a/src/routes/signin.lazy.tsx
+++ b/src/routes/signin.lazy.tsx
@@ -3,6 +3,7 @@ import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { z } from 'zod';
 import toast from 'react-hot-toast';
+import { useTranslation } from 'react-i18next';
 import { supabase } from '../lib/supabase';
 
 const signInSchema = z.object({
@@ -13,6 +14,7 @@ const signInSchema = z.object({
 type SignInForm = z.infer<typeof signInSchema>;
 
 export function SignIn() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
 
   const {
@@ -58,8 +60,10 @@ export function SignIn() {
   return (
     <div className="flex min-h-[60vh] items-center justify-center">
       <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-sm sm:p-8">
-        <h1 className="text-2xl font-semibold text-gray-900">Sign in</h1>
-        <p className="mt-1 text-sm text-gray-600">Welcome back to Chillist.</p>
+        <h1 className="text-2xl font-semibold text-gray-900">
+          {t('signIn.title')}
+        </h1>
+        <p className="mt-1 text-sm text-gray-600">{t('signIn.subtitle')}</p>
 
         <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-4">
           <div>
@@ -67,7 +71,7 @@ export function SignIn() {
               htmlFor="email"
               className="block text-sm font-medium text-gray-700"
             >
-              Email
+              {t('signIn.email')}
             </label>
             <input
               id="email"
@@ -75,7 +79,7 @@ export function SignIn() {
               autoComplete="email"
               {...register('email')}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-              placeholder="you@example.com"
+              placeholder={t('signIn.emailPlaceholder')}
             />
             {errors.email && (
               <p className="mt-1 text-sm text-red-600">
@@ -89,7 +93,7 @@ export function SignIn() {
               htmlFor="password"
               className="block text-sm font-medium text-gray-700"
             >
-              Password
+              {t('signIn.password')}
             </label>
             <input
               id="password"
@@ -97,7 +101,7 @@ export function SignIn() {
               autoComplete="current-password"
               {...register('password')}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-              placeholder="Your password"
+              placeholder={t('signIn.passwordPlaceholder')}
             />
             {errors.password && (
               <p className="mt-1 text-sm text-red-600">
@@ -111,7 +115,7 @@ export function SignIn() {
             disabled={isSubmitting}
             className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isSubmitting ? 'Signing in...' : 'Sign In'}
+            {isSubmitting ? t('signIn.submitting') : t('signIn.submit')}
           </button>
         </form>
 
@@ -121,7 +125,9 @@ export function SignIn() {
               <div className="w-full border-t border-gray-300" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="bg-white px-2 text-gray-500">or</span>
+              <span className="bg-white px-2 text-gray-500">
+                {t('signIn.or')}
+              </span>
             </div>
           </div>
 
@@ -148,17 +154,17 @@ export function SignIn() {
                 fill="#EA4335"
               />
             </svg>
-            Sign in with Google
+            {t('signIn.google')}
           </button>
         </div>
 
         <p className="mt-6 text-center text-sm text-gray-600">
-          Don&apos;t have an account?{' '}
+          {t('signIn.noAccount')}{' '}
           <Link
             to="/signup"
             className="font-medium text-blue-600 hover:text-blue-500"
           >
-            Sign up
+            {t('signIn.signUpLink')}
           </Link>
         </p>
       </div>

--- a/src/routes/signup.lazy.tsx
+++ b/src/routes/signup.lazy.tsx
@@ -1,6 +1,7 @@
 import { createLazyFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { useForm } from 'react-hook-form';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useTranslation } from 'react-i18next';
 import { z } from 'zod';
 import toast from 'react-hot-toast';
 import { useState } from 'react';
@@ -14,6 +15,7 @@ const signUpSchema = z.object({
 type SignUpForm = z.infer<typeof signUpSchema>;
 
 export function SignUp() {
+  const { t } = useTranslation();
   const navigate = useNavigate();
   const [confirmationSent, setConfirmationSent] = useState(false);
 
@@ -82,17 +84,16 @@ export function SignUp() {
               </svg>
             </div>
             <h2 className="text-xl font-semibold text-gray-900">
-              Check your email
+              {t('signUp.confirmTitle')}
             </h2>
             <p className="mt-2 text-sm text-gray-600">
-              We sent a confirmation link to your email. Please check your inbox
-              and click the link to activate your account.
+              {t('signUp.confirmMessage')}
             </p>
             <Link
               to="/signin"
               className="mt-6 inline-block text-sm font-medium text-blue-600 hover:text-blue-500"
             >
-              Go to Sign In
+              {t('signUp.goToSignIn')}
             </Link>
           </div>
         </div>
@@ -104,11 +105,9 @@ export function SignUp() {
     <div className="flex min-h-[60vh] items-center justify-center">
       <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-sm sm:p-8">
         <h1 className="text-2xl font-semibold text-gray-900">
-          Create an account
+          {t('signUp.title')}
         </h1>
-        <p className="mt-1 text-sm text-gray-600">
-          Sign up to start planning with Chillist.
-        </p>
+        <p className="mt-1 text-sm text-gray-600">{t('signUp.subtitle')}</p>
 
         <form onSubmit={handleSubmit(onSubmit)} className="mt-6 space-y-4">
           <div>
@@ -116,7 +115,7 @@ export function SignUp() {
               htmlFor="email"
               className="block text-sm font-medium text-gray-700"
             >
-              Email
+              {t('signUp.email')}
             </label>
             <input
               id="email"
@@ -124,7 +123,7 @@ export function SignUp() {
               autoComplete="email"
               {...register('email')}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-              placeholder="you@example.com"
+              placeholder={t('signUp.emailPlaceholder')}
             />
             {errors.email && (
               <p className="mt-1 text-sm text-red-600">
@@ -138,7 +137,7 @@ export function SignUp() {
               htmlFor="password"
               className="block text-sm font-medium text-gray-700"
             >
-              Password
+              {t('signUp.password')}
             </label>
             <input
               id="password"
@@ -146,7 +145,7 @@ export function SignUp() {
               autoComplete="new-password"
               {...register('password')}
               className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
-              placeholder="At least 6 characters"
+              placeholder={t('signUp.passwordPlaceholder')}
             />
             {errors.password && (
               <p className="mt-1 text-sm text-red-600">
@@ -160,7 +159,7 @@ export function SignUp() {
             disabled={isSubmitting}
             className="w-full rounded-md bg-blue-600 px-4 py-2 text-sm font-semibold text-white shadow-sm hover:bg-blue-700 focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 focus:outline-none disabled:opacity-50 disabled:cursor-not-allowed"
           >
-            {isSubmitting ? 'Creating account...' : 'Sign Up'}
+            {isSubmitting ? t('signUp.submitting') : t('signUp.submit')}
           </button>
         </form>
 
@@ -170,7 +169,9 @@ export function SignUp() {
               <div className="w-full border-t border-gray-300" />
             </div>
             <div className="relative flex justify-center text-sm">
-              <span className="bg-white px-2 text-gray-500">or</span>
+              <span className="bg-white px-2 text-gray-500">
+                {t('signUp.or')}
+              </span>
             </div>
           </div>
 
@@ -197,17 +198,17 @@ export function SignUp() {
                 fill="#EA4335"
               />
             </svg>
-            Sign up with Google
+            {t('signUp.google')}
           </button>
         </div>
 
         <p className="mt-6 text-center text-sm text-gray-600">
-          Already have an account?{' '}
+          {t('signUp.hasAccount')}{' '}
           <Link
             to="/signin"
             className="font-medium text-blue-600 hover:text-blue-500"
           >
-            Sign in
+            {t('signUp.signInLink')}
           </Link>
         </p>
       </div>

--- a/tests/e2e/i18n.spec.ts
+++ b/tests/e2e/i18n.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('i18n - language switching', () => {
+  test('switches to Hebrew and back to English', async ({ page }) => {
+    await page.goto('/plans');
+
+    const langToggle = page.getByTestId('lang-toggle');
+    await expect(langToggle).toBeVisible();
+    await expect(langToggle).toHaveText('עב');
+
+    const plansNav = page.getByRole('link', { name: 'Plans' });
+    await expect(plansNav).toBeVisible();
+
+    await langToggle.click();
+
+    await expect(page.locator('html')).toHaveAttribute('dir', 'rtl');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'he');
+
+    await expect(langToggle).toHaveText('EN');
+
+    const hebrewPlansNav = page.getByRole('link', { name: 'תוכניות' });
+    await expect(hebrewPlansNav).toBeVisible();
+
+    await langToggle.click();
+
+    await expect(page.locator('html')).toHaveAttribute('dir', 'ltr');
+    await expect(page.locator('html')).toHaveAttribute('lang', 'en');
+    await expect(plansNav).toBeVisible();
+  });
+});

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -1,6 +1,15 @@
 import '@testing-library/jest-dom';
 import { vi } from 'vitest';
 
+import '../src/i18n';
+
+vi.mock('../src/contexts/useLanguage', () => ({
+  useLanguage: () => ({
+    language: 'en' as const,
+    setLanguage: vi.fn(),
+  }),
+}));
+
 vi.mock('../src/lib/supabase', () => ({
   supabase: {
     auth: {

--- a/tests/unit/components/CreatePlan.test.tsx
+++ b/tests/unit/components/CreatePlan.test.tsx
@@ -282,13 +282,14 @@ describe('CreatePlan - PlanForm', () => {
       const addButton = screen.getByText(/\+ add participant/i);
       await user.click(addButton);
 
-      const firstNameInputs = screen.getAllByPlaceholderText(/first name \*/i);
-      const lastNameInputs = screen.getAllByPlaceholderText(/last name \*/i);
-      const phoneInputs = screen.getAllByPlaceholderText(/phone \*/i);
+      const firstNameInputs = screen.getAllByPlaceholderText(/^first name$/i);
+      const lastNameInputs = screen.getAllByPlaceholderText(/^last name$/i);
+      const phoneInputs = screen.getAllByPlaceholderText(/^phone number$/i);
 
-      await user.type(firstNameInputs[0], 'Bob');
-      await user.type(lastNameInputs[0], 'Jones');
-      await user.type(phoneInputs[0], '+9999999999');
+      const pIdx = firstNameInputs.length - 1;
+      await user.type(firstNameInputs[pIdx], 'Bob');
+      await user.type(lastNameInputs[pIdx], 'Jones');
+      await user.type(phoneInputs[pIdx], '+9999999999');
 
       await user.click(screen.getByRole('button', { name: /create plan/i }));
 

--- a/tests/unit/components/Plan.test.tsx
+++ b/tests/unit/components/Plan.test.tsx
@@ -1,0 +1,159 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Plan } from '../../../src/components/Plan';
+import type { PlanWithDetails } from '../../../src/core/schemas/plan';
+
+function buildPlan(overrides?: Partial<PlanWithDetails>): PlanWithDetails {
+  return {
+    planId: 'plan-1',
+    title: 'Camping Trip',
+    description: 'A fun weekend outdoors',
+    status: 'active',
+    visibility: 'public',
+    startDate: '2025-12-20T10:00:00Z',
+    endDate: '2025-12-22T16:00:00Z',
+    location: {
+      locationId: 'loc-1',
+      name: 'Yosemite',
+      city: 'Mariposa',
+      country: 'US',
+      region: 'California',
+    },
+    tags: [],
+    createdAt: '2025-01-01T00:00:00Z',
+    updatedAt: '2025-01-01T00:00:00Z',
+    participants: [
+      {
+        participantId: 'p-1',
+        planId: 'plan-1',
+        name: 'Alex',
+        lastName: 'Smith',
+        displayName: null,
+        role: 'owner',
+        avatarUrl: null,
+        contactEmail: null,
+        contactPhone: '+1234567890',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      },
+    ],
+    items: [],
+    ...overrides,
+  };
+}
+
+describe('Plan', () => {
+  it('renders plan title and description', () => {
+    render(<Plan plan={buildPlan()} />);
+
+    expect(screen.getByText('Camping Trip')).toBeInTheDocument();
+    expect(screen.getByText('A fun weekend outdoors')).toBeInTheDocument();
+  });
+
+  it('renders detail labels from translations', () => {
+    render(<Plan plan={buildPlan()} />);
+
+    expect(screen.getByText('Details')).toBeInTheDocument();
+    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(screen.getByText('Visibility')).toBeInTheDocument();
+    expect(screen.getByText('Owner')).toBeInTheDocument();
+    expect(screen.getByText('Start')).toBeInTheDocument();
+    expect(screen.getByText('End')).toBeInTheDocument();
+    expect(screen.getByText('Location')).toBeInTheDocument();
+  });
+
+  it('shows owner name in details and participant list', () => {
+    render(<Plan plan={buildPlan()} />);
+
+    const matches = screen.getAllByText('Alex Smith');
+    expect(matches).toHaveLength(2);
+  });
+
+  it('shows location details', () => {
+    render(<Plan plan={buildPlan()} />);
+
+    expect(screen.getByText('Yosemite')).toBeInTheDocument();
+    expect(screen.getByText(/Mariposa/)).toBeInTheDocument();
+  });
+
+  it('shows N/A when dates are missing', () => {
+    render(
+      <Plan plan={buildPlan({ startDate: undefined, endDate: undefined })} />
+    );
+
+    const naElements = screen.getAllByText('N/A');
+    expect(naElements.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('renders participant list with role badge', () => {
+    render(<Plan plan={buildPlan()} />);
+
+    expect(screen.getByText('Participants')).toBeInTheDocument();
+    expect(screen.getByText('AS')).toBeInTheDocument();
+    expect(screen.getByText('owner')).toBeInTheDocument();
+  });
+
+  it('shows empty participant message when no participants', () => {
+    render(<Plan plan={buildPlan({ participants: [] })} />);
+
+    expect(
+      screen.getByText('No participants yet. Add one to get started!')
+    ).toBeInTheDocument();
+  });
+
+  it('shows add participant button when handler provided', () => {
+    render(<Plan plan={buildPlan()} onAddParticipant={vi.fn()} />);
+
+    expect(screen.getByText('+ Add Participant')).toBeInTheDocument();
+  });
+
+  it('opens add participant form on button click', async () => {
+    const user = userEvent.setup();
+    render(<Plan plan={buildPlan()} onAddParticipant={vi.fn()} />);
+
+    await user.click(screen.getByText('+ Add Participant'));
+
+    expect(screen.getByText('First Name *')).toBeInTheDocument();
+    expect(screen.getByText('Last Name *')).toBeInTheDocument();
+    expect(screen.getByText('Phone *')).toBeInTheDocument();
+    expect(screen.getByText('Cancel')).toBeInTheDocument();
+  });
+
+  it('submits add participant form and closes it', async () => {
+    const onAdd = vi.fn().mockResolvedValue(undefined);
+    const user = userEvent.setup();
+    render(<Plan plan={buildPlan()} onAddParticipant={onAdd} />);
+
+    await user.click(screen.getByText('+ Add Participant'));
+
+    await user.type(screen.getByPlaceholderText('First name'), 'Bob');
+    await user.type(screen.getByPlaceholderText('Last name'), 'Jones');
+    await user.type(screen.getByPlaceholderText('Phone number'), '+9999999999');
+
+    await user.click(screen.getByText('Add Participant'));
+
+    await waitFor(() => {
+      expect(onAdd).toHaveBeenCalledWith({
+        name: 'Bob',
+        lastName: 'Jones',
+        contactPhone: '+9999999999',
+        contactEmail: undefined,
+      });
+    });
+  });
+
+  it('cancels add participant form', async () => {
+    const user = userEvent.setup();
+    render(<Plan plan={buildPlan()} onAddParticipant={vi.fn()} />);
+
+    await user.click(screen.getByText('+ Add Participant'));
+    expect(screen.getByText('First Name *')).toBeInTheDocument();
+
+    await user.click(screen.getByText('Cancel'));
+
+    await waitFor(() => {
+      expect(screen.queryByText('First Name *')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/tests/unit/contexts/LanguageProvider.test.tsx
+++ b/tests/unit/contexts/LanguageProvider.test.tsx
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { useContext } from 'react';
+import { I18nextProvider } from 'react-i18next';
+import i18n from '../../../src/i18n';
+import {
+  LanguageContext,
+  type LanguageContextValue,
+} from '../../../src/contexts/language-context';
+
+vi.unmock('../../../src/contexts/useLanguage');
+
+import LanguageProvider from '../../../src/contexts/LanguageProvider';
+
+function LanguageConsumer() {
+  const ctx = useContext(LanguageContext) as LanguageContextValue;
+  return (
+    <div>
+      <span data-testid="lang">{ctx.language}</span>
+      <button onClick={() => ctx.setLanguage('he')}>Switch to Hebrew</button>
+      <button onClick={() => ctx.setLanguage('en')}>Switch to English</button>
+    </div>
+  );
+}
+
+function renderWithProvider() {
+  return render(
+    <I18nextProvider i18n={i18n}>
+      <LanguageProvider>
+        <LanguageConsumer />
+      </LanguageProvider>
+    </I18nextProvider>
+  );
+}
+
+describe('LanguageProvider', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.dir = 'ltr';
+    document.documentElement.lang = 'en';
+    i18n.changeLanguage('en');
+  });
+
+  it('defaults to English', () => {
+    renderWithProvider();
+    expect(screen.getByTestId('lang')).toHaveTextContent('en');
+  });
+
+  it('sets dir=ltr and lang=en by default', () => {
+    renderWithProvider();
+    expect(document.documentElement.dir).toBe('ltr');
+    expect(document.documentElement.lang).toBe('en');
+  });
+
+  it('switches to Hebrew and sets dir=rtl', async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByText('Switch to Hebrew'));
+
+    expect(screen.getByTestId('lang')).toHaveTextContent('he');
+    expect(document.documentElement.dir).toBe('rtl');
+    expect(document.documentElement.lang).toBe('he');
+  });
+
+  it('persists language to localStorage', async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByText('Switch to Hebrew'));
+
+    expect(JSON.parse(localStorage.getItem('chillist-lang')!)).toBe('he');
+  });
+
+  it('restores language from localStorage', () => {
+    localStorage.setItem('chillist-lang', JSON.stringify('he'));
+
+    renderWithProvider();
+
+    expect(screen.getByTestId('lang')).toHaveTextContent('he');
+  });
+
+  it('switches back to English from Hebrew', async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByText('Switch to Hebrew'));
+    expect(document.documentElement.dir).toBe('rtl');
+
+    await user.click(screen.getByText('Switch to English'));
+    expect(screen.getByTestId('lang')).toHaveTextContent('en');
+    expect(document.documentElement.dir).toBe('ltr');
+    expect(document.documentElement.lang).toBe('en');
+  });
+
+  it('changes i18n language when switching', async () => {
+    const user = userEvent.setup();
+    renderWithProvider();
+
+    await user.click(screen.getByText('Switch to Hebrew'));
+
+    expect(i18n.language).toBe('he');
+  });
+});

--- a/tests/unit/hooks/useLocalStorage.test.ts
+++ b/tests/unit/hooks/useLocalStorage.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useLocalStorage } from '../../../src/hooks/useLocalStorage';
+
+describe('useLocalStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns the initial value when nothing stored', () => {
+    const { result } = renderHook(() => useLocalStorage('test-key', 'default'));
+    expect(result.current[0]).toBe('default');
+  });
+
+  it('returns stored value when key exists', () => {
+    localStorage.setItem('test-key', JSON.stringify('stored'));
+    const { result } = renderHook(() => useLocalStorage('test-key', 'default'));
+    expect(result.current[0]).toBe('stored');
+  });
+
+  it('updates both state and localStorage on setValue', () => {
+    const { result } = renderHook(() => useLocalStorage('test-key', 'initial'));
+
+    act(() => {
+      result.current[1]('updated');
+    });
+
+    expect(result.current[0]).toBe('updated');
+    expect(JSON.parse(localStorage.getItem('test-key')!)).toBe('updated');
+  });
+
+  it('supports functional updates', () => {
+    const { result } = renderHook(() => useLocalStorage('counter', 0));
+
+    act(() => {
+      result.current[1]((prev) => prev + 1);
+    });
+
+    expect(result.current[0]).toBe(1);
+    expect(JSON.parse(localStorage.getItem('counter')!)).toBe(1);
+  });
+
+  it('handles objects correctly', () => {
+    const { result } = renderHook(() => useLocalStorage('obj', { lang: 'en' }));
+
+    act(() => {
+      result.current[1]({ lang: 'he' });
+    });
+
+    expect(result.current[0]).toEqual({ lang: 'he' });
+    expect(JSON.parse(localStorage.getItem('obj')!)).toEqual({ lang: 'he' });
+  });
+
+  it('returns fallback when stored value is malformed JSON', () => {
+    localStorage.setItem('bad-key', 'not valid json{{{');
+    const { result } = renderHook(() => useLocalStorage('bad-key', 'fallback'));
+    expect(result.current[0]).toBe('fallback');
+  });
+});


### PR DESCRIPTION
## Summary

- Add full i18n support using `i18next` + `react-i18next` with English (default) and Hebrew
- Language toggle button in Header (desktop + mobile) persists preference to localStorage
- All UI text extracted to `src/i18n/locales/en.json` and `he.json` translation files
- RTL support: `<html dir="rtl" lang="he">` set automatically when Hebrew is active, directional Tailwind utilities converted to logical properties (`ms-*`, `me-*`, `start-*`, `end-*`)
- New `LanguageProvider` context with `useLanguage` hook, and reusable `useLocalStorage` hook
- Updated common-items data and Autocomplete component for language-aware suggestions
- Version bump to 1.4.0

## Test plan

- [x] All 288 existing unit tests pass in English (default language)
- [x] New unit tests: `LanguageProvider.test.tsx` (7 tests), `useLocalStorage.test.ts` (6 tests), `Plan.test.tsx` (11 tests)
- [x] New E2E test: `i18n.spec.ts` — switches to Hebrew, verifies nav text changes and `dir=rtl`, switches back
- [x] TypeScript and ESLint pass with zero errors
- [ ] Manual: toggle to Hebrew, verify all pages render in Hebrew with RTL layout
- [ ] Manual: refresh page, verify language preference persists


Made with [Cursor](https://cursor.com)