### PR TITLE
fix: handle mobile viewport in i18n E2E test for Mobile Safari

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",


### PR DESCRIPTION
## Summary
- The i18n E2E test failed on Mobile Safari because `lang-toggle` is inside the desktop nav (`hidden sm:flex`), invisible on mobile viewports
- Uses Playwright's `isMobile` fixture to branch: on mobile, opens hamburger menu and uses `lang-toggle-mobile`; on desktop, uses `lang-toggle` directly
- Verified passing on all 3 browser projects (Chrome, Firefox, Mobile Safari)

## Test plan
- [x] `npx playwright test tests/e2e/i18n.spec.ts` passes on all 3 projects locally
- [x] `npm run typecheck && npm run lint && npm run test:unit` all pass
- [ ] CI passes on this PR


Made with [Cursor](https://cursor.com)