### PR TITLE
fix: unit select unclickable in production edit modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.6.0",
+  "version": "1.6.1",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",

--- a/src/components/ItemCard.tsx
+++ b/src/components/ItemCard.tsx
@@ -245,15 +245,7 @@ export default function ItemCard({
             />
             <InlineSelect
               value={item.unit}
-              onChange={(unit) => {
-                console.log('[ItemCard] unit onChange:', {
-                  itemName: item.name,
-                  from: item.unit,
-                  to: unit,
-                  disabled: isEquipment,
-                });
-                onUpdate({ unit });
-              }}
+              onChange={(unit) => onUpdate({ unit })}
               options={resolvedUnitOptions}
               disabled={isEquipment}
               buttonClassName={clsx(

--- a/src/components/ItemForm.tsx
+++ b/src/components/ItemForm.tsx
@@ -270,52 +270,24 @@ export default function ItemForm({
 
         <div>
           <FormLabel>{t('items.unit')}</FormLabel>
-          <Controller
-            name="unit"
-            control={control}
-            render={({ field }) => (
-              <FormSelect
-                value={field.value}
-                onClick={() =>
-                  console.log('[ItemForm] unit CLICKED:', {
-                    value: field.value,
-                    disabled: isEquipment,
-                    inModal,
-                  })
-                }
-                onChange={(e) => {
-                  console.log('[ItemForm] unit onChange:', {
-                    from: field.value,
-                    to: e.target.value,
-                    disabled: isEquipment,
-                  });
-                  field.onChange(e);
-                }}
-                onBlur={field.onBlur}
-                name={field.name}
-                ref={field.ref}
-                disabled={isEquipment}
-                compact
-              >
-                {isEquipment ? (
-                  <option value="pcs">{t('units.pcs')}</option>
-                ) : (
-                  UNIT_GROUPS.map((group) => (
-                    <optgroup
-                      key={group.groupLabelKey}
-                      label={t(group.groupLabelKey)}
-                    >
-                      {group.options.map((opt) => (
-                        <option key={opt.value} value={opt.value}>
-                          {t(opt.labelKey)}
-                        </option>
-                      ))}
-                    </optgroup>
-                  ))
-                )}
-              </FormSelect>
+          <FormSelect {...register('unit')} disabled={isEquipment} compact>
+            {isEquipment ? (
+              <option value="pcs">{t('units.pcs')}</option>
+            ) : (
+              UNIT_GROUPS.map((group) => (
+                <optgroup
+                  key={group.groupLabelKey}
+                  label={t(group.groupLabelKey)}
+                >
+                  {group.options.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {t(opt.labelKey)}
+                    </option>
+                  ))}
+                </optgroup>
+              ))
             )}
-          />
+          </FormSelect>
         </div>
       </div>
 

--- a/src/components/shared/InlineSelect.tsx
+++ b/src/components/shared/InlineSelect.tsx
@@ -33,13 +33,6 @@ export default function InlineSelect<T extends string>({
   return (
     <Listbox value={value} onChange={onChange} disabled={disabled}>
       <ListboxButton
-        onClick={() =>
-          console.log('[InlineSelect] CLICKED:', {
-            value,
-            disabled,
-            ariaLabel,
-          })
-        }
         className={clsx(
           'cursor-pointer transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 focus-visible:ring-offset-1 rounded',
           disabled && 'cursor-default opacity-60',

--- a/tests/e2e/main-flow.spec.ts
+++ b/tests/e2e/main-flow.spec.ts
@@ -140,6 +140,44 @@ test.describe('Item CRUD', () => {
     await expect(tentCard).toContainText('4');
   });
 
+  test('edits all item fields via modal form', async ({ page }) => {
+    const plan = buildTestPlan();
+    await mockPlanRoutes(page, plan);
+
+    await page.goto(`/plan/${plan.planId}`);
+    await expect(page.getByText('Bread')).toBeVisible({ timeout: 10000 });
+
+    await page.getByLabel('Edit Bread').click();
+    const editForm = page.locator('form:has(button:text("Update Item"))');
+    await expect(editForm).toBeVisible();
+
+    const nameInput = editForm.getByPlaceholder('Item name');
+    await nameInput.clear();
+    await nameInput.fill('Granola');
+    await nameInput.press('Escape');
+
+    await editForm.locator('input[type="number"]').fill('5');
+    await editForm.locator('select[name="unit"]').selectOption('kg');
+    await editForm.locator('select[name="status"]').selectOption('purchased');
+    await editForm.locator('textarea').fill('Organic whole grain');
+    await editForm
+      .locator('select[name="assignedParticipantId"]')
+      .selectOption({ label: 'Bob Helper' });
+
+    await editForm.getByRole('button', { name: 'Update Item' }).click();
+    await expect(editForm).toBeHidden({ timeout: 5000 });
+
+    const itemCard = page
+      .locator('[class*="border-l-"]')
+      .filter({ hasText: 'Granola' });
+    await expect(itemCard).toBeVisible({ timeout: 5000 });
+    await expect(itemCard).toContainText('5');
+    await expect(itemCard).toContainText('Kilogram');
+    await expect(itemCard).toContainText('Purchased');
+    await expect(itemCard).toContainText('Organic whole grain');
+    await expect(itemCard).toContainText('Bob Helper');
+  });
+
   test('changes item status inline', async ({ page }) => {
     const plan = buildTestPlan();
     await mockPlanRoutes(page, plan);

--- a/tests/unit/components/CreatePlan.test.tsx
+++ b/tests/unit/components/CreatePlan.test.tsx
@@ -237,7 +237,9 @@ describe('CreatePlan - PlanForm', () => {
 
       await user.type(getInputByLabel(/start date/i), '2025-12-20');
       await user.type(getInputByLabel(/start time/i), '09:00');
+      await user.clear(getInputByLabel(/end date/i));
       await user.type(getInputByLabel(/end date/i), '2025-12-22');
+      await user.clear(getInputByLabel(/end time/i));
       await user.type(getInputByLabel(/end time/i), '18:00');
 
       await user.type(


### PR DESCRIPTION
## Summary
- Revert unit `<select>` from `Controller` (controlled) to `register` (uncontrolled), matching all other working selects in the form. The `Controller` approach caused the native select to become non-interactive in production builds while working fine on the local dev server.
- Remove debug `console.log` statements from ItemForm, ItemCard, and InlineSelect.
- Add E2E test that edits all item fields (name, quantity, unit, status, notes, assignment) via the modal form — passes on Chrome, Firefox, and Mobile Safari.

## Test plan
- [x] Unit tests: 302 passed
- [x] E2E tests: 21 passed (Chrome, Firefox, Mobile Safari)
- [x] Production build: succeeds
- [ ] Verify unit select is clickable on production after deploy

Closes #82

Made with [Cursor](https://cursor.com)