### PR TITLE
feat: add Google Maps location picker and map display

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -10,3 +10,7 @@ VITE_AUTH_MOCK=true
 # Supabase Auth (required when VITE_AUTH_MOCK is not "true")
 VITE_SUPABASE_URL=https://your-project.supabase.co
 VITE_SUPABASE_ANON_KEY=your-supabase-anon-key
+
+# Google Maps (optional — enables location autocomplete + map display)
+# Requires Maps JavaScript API + Places API enabled in Google Cloud Console
+VITE_GOOGLE_MAPS_API_KEY=your-google-maps-api-key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -102,6 +102,7 @@ jobs:
           VITE_API_URL: ${{ vars.VITE_API_URL }}
           VITE_SUPABASE_URL: ${{ vars.VITE_SUPABASE_URL }}
           VITE_SUPABASE_ANON_KEY: ${{ vars.VITE_SUPABASE_ANON_KEY }}
+          VITE_GOOGLE_MAPS_API_KEY: ${{ vars.VITE_GOOGLE_MAPS_API_KEY }}
 
       - name: Deploy to Cloudflare Pages
         uses: cloudflare/wrangler-action@v3

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "chillist-fe",
-  "version": "1.6.1",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chillist-fe",
-      "version": "1.6.1",
+      "version": "1.7.0",
       "dependencies": {
         "@headlessui/react": "2.2.9",
         "@hookform/resolvers": "^5.2.2",
         "@supabase/supabase-js": "2.95.3",
         "@tanstack/react-query": "^5.90.7",
         "@tanstack/react-router": "^1.134.15",
-        "@vis.gl/react-google-maps": "^1.7.1",
+        "@vis.gl/react-google-maps": "1.7.1",
         "clsx": "2.1.1",
         "i18next": "23.16.8",
         "openapi-fetch": "^0.15.0",
@@ -32,6 +32,7 @@
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.0",
         "@testing-library/user-event": "^14.6.1",
+        "@types/google.maps": "^3.58.1",
         "@types/node": "^24.6.0",
         "@types/react": "^19.1.16",
         "@types/react-dom": "^19.1.9",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.7.0",
+  "version": "1.8.0",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",
@@ -50,6 +50,7 @@
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.0",
     "@testing-library/user-event": "^14.6.1",
+    "@types/google.maps": "^3.58.1",
     "@types/node": "^24.6.0",
     "@types/react": "^19.1.16",
     "@types/react-dom": "^19.1.9",

--- a/src/components/LocationAutocomplete.tsx
+++ b/src/components/LocationAutocomplete.tsx
@@ -1,0 +1,158 @@
+import { useEffect, useRef, Component, type ReactNode } from 'react';
+import {
+  APIProvider,
+  Map,
+  AdvancedMarker,
+  Pin,
+  useMapsLibrary,
+} from '@vis.gl/react-google-maps';
+import { useTranslation } from 'react-i18next';
+
+const MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY || '';
+
+export interface PlaceResult {
+  name: string;
+  city?: string;
+  country?: string;
+  region?: string;
+  latitude: number;
+  longitude: number;
+}
+
+interface LocationAutocompleteProps {
+  onPlaceSelect: (place: PlaceResult) => void;
+  latitude?: number | null;
+  longitude?: number | null;
+}
+
+class MapErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}
+
+function AutocompleteInput({
+  onPlaceSelect,
+}: {
+  onPlaceSelect: (place: PlaceResult) => void;
+}) {
+  const { t } = useTranslation();
+  const inputRef = useRef<HTMLInputElement>(null);
+  const callbackRef = useRef(onPlaceSelect);
+  callbackRef.current = onPlaceSelect;
+  const autocompleteRef = useRef<google.maps.places.Autocomplete | null>(null);
+
+  const places = useMapsLibrary('places');
+
+  useEffect(() => {
+    if (!places || !inputRef.current) return;
+
+    try {
+      const autocomplete = new places.Autocomplete(inputRef.current, {
+        fields: ['name', 'geometry', 'address_components'],
+      });
+      autocompleteRef.current = autocomplete;
+
+      autocomplete.addListener('place_changed', () => {
+        const place = autocomplete.getPlace();
+        if (!place.geometry?.location) return;
+
+        const components = place.address_components || [];
+        const get = (type: string) =>
+          components.find((c) => c.types.includes(type))?.long_name;
+
+        callbackRef.current({
+          name: place.name || '',
+          city:
+            get('locality') ||
+            get('sublocality') ||
+            get('administrative_area_level_2'),
+          country: get('country'),
+          region: get('administrative_area_level_1'),
+          latitude: place.geometry.location.lat(),
+          longitude: place.geometry.location.lng(),
+        });
+      });
+    } catch {
+      // Google Maps API failed to initialize — input remains a plain text field
+    }
+
+    return () => {
+      try {
+        if (autocompleteRef.current) {
+          google.maps.event.clearInstanceListeners(autocompleteRef.current);
+        }
+      } catch {
+        // google namespace unavailable — nothing to clean up
+      }
+      autocompleteRef.current = null;
+    };
+  }, [places]);
+
+  return (
+    <input
+      ref={inputRef}
+      type="text"
+      placeholder={t('planForm.locationSearchPlaceholder')}
+      className="w-full rounded-md border border-gray-300 px-3 py-1.5 text-sm shadow-sm focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none"
+    />
+  );
+}
+
+function MapPreview({
+  latitude,
+  longitude,
+}: {
+  latitude: number;
+  longitude: number;
+}) {
+  const center = { lat: latitude, lng: longitude };
+
+  return (
+    <div className="rounded-lg overflow-hidden border border-gray-200 h-[180px] sm:h-[200px]">
+      <Map
+        defaultCenter={center}
+        defaultZoom={14}
+        gestureHandling="cooperative"
+        disableDefaultUI
+        mapId="DEMO_MAP_ID"
+        style={{ width: '100%', height: '100%' }}
+      >
+        <AdvancedMarker position={center}>
+          <Pin />
+        </AdvancedMarker>
+      </Map>
+    </div>
+  );
+}
+
+export default function LocationAutocomplete({
+  onPlaceSelect,
+  latitude,
+  longitude,
+}: LocationAutocompleteProps) {
+  if (!MAPS_API_KEY) return null;
+
+  return (
+    <MapErrorBoundary>
+      <APIProvider apiKey={MAPS_API_KEY}>
+        <div className="space-y-3">
+          <AutocompleteInput onPlaceSelect={onPlaceSelect} />
+          {latitude != null && longitude != null && (
+            <MapPreview latitude={latitude} longitude={longitude} />
+          )}
+        </div>
+      </APIProvider>
+    </MapErrorBoundary>
+  );
+}

--- a/src/components/LocationMap.tsx
+++ b/src/components/LocationMap.tsx
@@ -1,0 +1,57 @@
+import { Component, type ReactNode } from 'react';
+import {
+  APIProvider,
+  Map,
+  AdvancedMarker,
+  Pin,
+} from '@vis.gl/react-google-maps';
+
+const MAPS_API_KEY = import.meta.env.VITE_GOOGLE_MAPS_API_KEY || '';
+
+interface LocationMapProps {
+  latitude: number;
+  longitude: number;
+}
+
+class MapErrorBoundary extends Component<
+  { children: ReactNode },
+  { hasError: boolean }
+> {
+  state = { hasError: false };
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  render() {
+    if (this.state.hasError) return null;
+    return this.props.children;
+  }
+}
+
+export default function LocationMap({ latitude, longitude }: LocationMapProps) {
+  if (!MAPS_API_KEY) return null;
+
+  const center = { lat: latitude, lng: longitude };
+
+  return (
+    <MapErrorBoundary>
+      <APIProvider apiKey={MAPS_API_KEY}>
+        <div className="rounded-lg overflow-hidden border border-gray-200 h-[200px] sm:h-[250px] w-full sm:w-[300px] shrink-0">
+          <Map
+            defaultCenter={center}
+            defaultZoom={13}
+            gestureHandling="cooperative"
+            disableDefaultUI={false}
+            mapId="DEMO_MAP_ID"
+            style={{ width: '100%', height: '100%' }}
+          >
+            <AdvancedMarker position={center}>
+              <Pin />
+            </AdvancedMarker>
+          </Map>
+        </div>
+      </APIProvider>
+    </MapErrorBoundary>
+  );
+}

--- a/src/components/Plan.tsx
+++ b/src/components/Plan.tsx
@@ -12,6 +12,7 @@ import type {
 import { FormLabel } from './shared/FormLabel';
 import { FormInput } from './shared/FormInput';
 import Modal from './shared/Modal';
+import LocationMap from './LocationMap';
 
 function formatDateShort(iso: string): string {
   const d = new Date(iso);
@@ -165,7 +166,8 @@ export function Plan({
   const [showManageModal, setShowManageModal] = useState(false);
   const [showAddForm, setShowAddForm] = useState(false);
 
-  const { title, description, startDate, endDate, participants } = plan;
+  const { title, description, startDate, endDate, participants, location } =
+    plan;
   const owner = participants.find((p) => p.role === 'owner');
 
   async function handleAddParticipant(participant: ParticipantCreate) {
@@ -226,6 +228,34 @@ export function Plan({
             </p>
           </div>
         </div>
+
+        {location && (
+          <div>
+            <p className="text-xs font-medium text-blue-500 uppercase tracking-wider mb-2">
+              {t('plan.location')}
+            </p>
+            <div className="flex flex-col sm:flex-row gap-3 sm:gap-4">
+              {location.latitude != null && location.longitude != null && (
+                <LocationMap
+                  latitude={location.latitude}
+                  longitude={location.longitude}
+                />
+              )}
+              <div className="flex-1 min-w-0">
+                <p className="text-sm sm:text-base font-semibold text-gray-800">
+                  {location.name}
+                </p>
+                {(location.city || location.region || location.country) && (
+                  <p className="text-xs text-gray-500 mt-0.5">
+                    {[location.city, location.region, location.country]
+                      .filter(Boolean)
+                      .join(', ')}
+                  </p>
+                )}
+              </div>
+            </div>
+          </div>
+        )}
 
         <div>
           <p className="text-xs font-medium text-blue-500 uppercase tracking-wider mb-2">

--- a/src/components/PlanForm.tsx
+++ b/src/components/PlanForm.tsx
@@ -20,6 +20,8 @@ import {
   detectCountryFromPhone,
   getDefaultCountryByLanguage,
 } from '../data/country-codes';
+import LocationAutocomplete from './LocationAutocomplete';
+import type { PlaceResult } from './LocationAutocomplete';
 
 const locationFormSchema = z
   .object({
@@ -27,6 +29,8 @@ const locationFormSchema = z
     city: z.string().optional(),
     country: z.string().optional(),
     region: z.string().optional(),
+    latitude: z.number().nullish(),
+    longitude: z.number().nullish(),
   })
   .optional();
 
@@ -160,6 +164,19 @@ export default function PlanForm({
   });
 
   const oneDay = watch('oneDay');
+  const locationData = watch('location');
+
+  function handlePlaceSelect(place: PlaceResult) {
+    setValue('location', {
+      ...locationData,
+      name: place.name,
+      city: place.city || '',
+      country: place.country || '',
+      region: place.region || '',
+      latitude: place.latitude,
+      longitude: place.longitude,
+    });
+  }
 
   useEffect(() => {
     const subscription = watch((values, { name }) => {
@@ -207,10 +224,15 @@ export default function PlanForm({
     city?: string;
     country?: string;
     region?: string;
+    latitude?: number | null;
+    longitude?: number | null;
   }) => {
     if (!loc) return false;
-    return [loc.name, loc.city, loc.country, loc.region].some(
-      (v) => v && v.trim().length > 0
+    return (
+      [loc.name, loc.city, loc.country, loc.region].some(
+        (v) => v && v.trim().length > 0
+      ) ||
+      (loc.latitude != null && loc.longitude != null)
     );
   };
 
@@ -496,6 +518,11 @@ export default function PlanForm({
             {t('planForm.locationLegend')}
           </legend>
           <div className="space-y-4">
+            <LocationAutocomplete
+              onPlaceSelect={handlePlaceSelect}
+              latitude={locationData?.latitude}
+              longitude={locationData?.longitude}
+            />
             <div>
               <FormLabel>{t('planForm.locationName')}</FormLabel>
               <FormInput

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -125,6 +125,7 @@
     "remove": "Remove",
     "addParticipant": "+ Add Participant",
     "locationLegend": "Location (optional)",
+    "locationSearchPlaceholder": "Search for a location...",
     "locationName": "Name",
     "locationNamePlaceholder": "Location name",
     "city": "City",

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -125,6 +125,7 @@
     "remove": "הסרה",
     "addParticipant": "+ הוספת משתתף",
     "locationLegend": "מיקום (אופציונלי)",
+    "locationSearchPlaceholder": "חפש מיקום...",
     "locationName": "שם",
     "locationNamePlaceholder": "שם המיקום",
     "city": "עיר",

--- a/src/routes/create-plan.tsx
+++ b/src/routes/create-plan.tsx
@@ -21,7 +21,7 @@ function splitFullName(fullName?: string): { first: string; last: string } {
 export function CreatePlan() {
   const navigate = useNavigate();
   const createPlan = useCreatePlan();
-  const { user } = useAuth();
+  const { user, loading } = useAuth();
 
   const defaultOwner = useMemo((): DefaultOwner | undefined => {
     if (!user) return undefined;
@@ -42,6 +42,14 @@ export function CreatePlan() {
     } else {
       navigate({ to: '/plans' });
     }
+  }
+
+  if (loading) {
+    return (
+      <div className="flex justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-blue-600 border-t-transparent" />
+      </div>
+    );
   }
 
   return (

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -10,6 +10,15 @@ vi.mock('../src/contexts/useLanguage', () => ({
   }),
 }));
 
+vi.mock('@vis.gl/react-google-maps', () => ({
+  APIProvider: ({ children }: { children: unknown }) => children,
+  Map: () => null,
+  AdvancedMarker: () => null,
+  Pin: () => null,
+  useMapsLibrary: () => null,
+  useApiIsLoaded: () => false,
+}));
+
 vi.mock('../src/lib/supabase', () => ({
   supabase: {
     auth: {

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -5,7 +5,7 @@
     "useDefineForClassFields": true,
     "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "types": ["vite/client"],
+    "types": ["vite/client", "google.maps"],
     "skipLibCheck": true,
 
     /* Bundler mode */


### PR DESCRIPTION
## Summary
- Add Google Places Autocomplete to the plan creation form for smart location search — selecting a place auto-fills name, city, country, region, lat/lng and shows a mini map preview
- Add interactive Google Map with pin on the plan detail page, responsive layout (full-width on mobile, side-by-side with text on desktop)
- Both components wrapped in error boundaries and degrade gracefully when no API key is set or the Google Maps API fails
- Add `VITE_GOOGLE_MAPS_API_KEY` env var (optional), deploy workflow updated to pass it during build
- Global mock for `@vis.gl/react-google-maps` in test setup so all existing tests pass
- Add loading spinner to create-plan page while auth state loads

## Test plan
- [ ] Set `VITE_GOOGLE_MAPS_API_KEY` in `.env` and verify autocomplete suggestions appear when typing in the location search field
- [ ] Select a place and confirm all fields (name, city, country, region) auto-fill and mini map preview shows
- [ ] Create a plan with a location and verify the plan detail page shows the map with a pin alongside the text description
- [ ] Remove the API key from `.env` and verify the form still works with manual text fields (no map, no crash)
- [ ] Verify responsive layout: map full-width on mobile, side-by-side on desktop
- [ ] Add `VITE_GOOGLE_MAPS_API_KEY` as a GitHub repo variable for production deploys

Made with [Cursor](https://cursor.com)