### PR TITLE
chore: run E2E tests on all browsers in Husky and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,17 +43,17 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-chromium-${{ hashFiles('package-lock.json') }}
+          key: playwright-all-${{ hashFiles('package-lock.json') }}
 
       - name: Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'
-        run: npx playwright install chromium
+        run: npx playwright install chromium firefox webkit
 
       - name: Install Playwright system deps
-        run: npx playwright install-deps chromium
+        run: npx playwright install-deps chromium firefox webkit
 
-      - name: Run E2E tests (Chrome only)
-        run: npx playwright test --project="Desktop Chrome"
+      - name: Run E2E tests (all browsers)
+        run: npx playwright test
         env:
           VITE_AUTH_MOCK: 'true'
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -7,5 +7,5 @@ npx lint-staged
 echo "Running unit tests..."
 npm run test:unit
 
-echo "Running E2E tests (Chrome only)..."
-VITE_AUTH_MOCK=true npx playwright test --project="Desktop Chrome"
+echo "Running E2E tests (all browsers)..."
+CI= VITE_AUTH_MOCK=true npx playwright test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.9.2",
+  "version": "1.9.3",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,10 @@ export default defineConfig({
       use: { ...devices['Desktop Firefox'] },
     },
     {
+      name: 'Desktop Safari',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
       name: 'Mobile Safari',
       use: { ...devices['iPhone 15 Pro'] },
     },


### PR DESCRIPTION
Upgrade pre-commit hook and CI workflow from Chrome-only to full cross-browser E2E coverage (Chrome, Firefox, Desktop Safari, Mobile Safari) matching the deploy pipeline. Add Desktop Safari project to Playwright config.