### PR TITLE
feat: JWT 401 retry with token refresh and auth error modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.9.3",
+  "version": "1.10.0",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",

--- a/src/components/AuthErrorModal.tsx
+++ b/src/components/AuthErrorModal.tsx
@@ -1,0 +1,45 @@
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from '@tanstack/react-router';
+import Modal from './shared/Modal';
+
+interface AuthErrorModalProps {
+  open: boolean;
+  onDismiss: () => void;
+}
+
+export default function AuthErrorModal({
+  open,
+  onDismiss,
+}: AuthErrorModalProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  function handleSignIn() {
+    onDismiss();
+    navigate({ to: '/sign-in' });
+  }
+
+  return (
+    <Modal open={open} onClose={onDismiss} title={t('auth.sessionExpired')}>
+      <div className="px-4 sm:px-6 pb-4 sm:pb-6">
+        <p className="text-gray-600 mb-6">{t('auth.sessionExpiredMessage')}</p>
+        <div className="flex flex-col-reverse sm:flex-row gap-3 sm:justify-end">
+          <button
+            type="button"
+            onClick={onDismiss}
+            className="w-full sm:w-auto px-4 py-2.5 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            {t('auth.dismiss')}
+          </button>
+          <button
+            type="button"
+            onClick={handleSignIn}
+            className="w-full sm:w-auto px-4 py-2.5 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            {t('auth.signIn')}
+          </button>
+        </div>
+      </div>
+    </Modal>
+  );
+}

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -4,12 +4,15 @@ import toast from 'react-hot-toast';
 import i18n from '../i18n';
 import { supabase } from '../lib/supabase';
 import { fetchAuthMe } from '../core/api';
+import { onAuthError } from '../core/auth-error';
 import { AuthContext } from './auth-context';
+import AuthErrorModal from '../components/AuthErrorModal';
 
 export default function AuthProvider({ children }: { children: ReactNode }) {
   const [session, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+  const [authErrorOpen, setAuthErrorOpen] = useState(false);
 
   useEffect(() => {
     supabase.auth.getSession().then(({ data: { session: initial } }) => {
@@ -45,6 +48,12 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
+  useEffect(() => {
+    return onAuthError(() => {
+      setAuthErrorOpen(true);
+    });
+  }, []);
+
   const signOut = useCallback(async () => {
     const { error } = await supabase.auth.signOut();
     if (error) {
@@ -55,6 +64,10 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
   return (
     <AuthContext.Provider value={{ session, user, loading, signOut }}>
       {children}
+      <AuthErrorModal
+        open={authErrorOpen}
+        onDismiss={() => setAuthErrorOpen(false)}
+      />
     </AuthContext.Provider>
   );
 }

--- a/src/core/auth-error.ts
+++ b/src/core/auth-error.ts
@@ -1,0 +1,14 @@
+type AuthErrorListener = () => void;
+
+const listeners = new Set<AuthErrorListener>();
+
+export function onAuthError(cb: AuthErrorListener) {
+  listeners.add(cb);
+  return () => {
+    listeners.delete(cb);
+  };
+}
+
+export function emitAuthError() {
+  listeners.forEach((cb) => cb());
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -11,7 +11,10 @@
     "userFallback": "User",
     "signedInAs": "Signed in as {{email}}",
     "signedIn": "Signed in",
-    "signOutFailed": "Sign out failed: {{message}}"
+    "signOutFailed": "Sign out failed: {{message}}",
+    "sessionExpired": "Session Expired",
+    "sessionExpiredMessage": "Your session has expired or is invalid. Please sign in again to continue.",
+    "dismiss": "Dismiss"
   },
   "signIn": {
     "title": "Sign in",
@@ -204,7 +207,9 @@
   "errors": {
     "somethingWentWrong": "Something went wrong",
     "unexpectedError": "An unexpected error occurred.",
-    "backToPlans": "Back to Plans"
+    "backToPlans": "Back to Plans",
+    "planNotFound": "Plan not found",
+    "planNoAccess": "This plan doesn't exist or you don't have access to it. If you're the owner, try signing in."
   },
   "notFound": {
     "title": "404 — Page Not Found",

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -11,7 +11,10 @@
     "userFallback": "משתמש",
     "signedInAs": "מחובר בתור {{email}}",
     "signedIn": "מחובר",
-    "signOutFailed": "ההתנתקות נכשלה: {{message}}"
+    "signOutFailed": "ההתנתקות נכשלה: {{message}}",
+    "sessionExpired": "פג תוקף ההתחברות",
+    "sessionExpiredMessage": "ההתחברות שלך פגה או אינה תקינה. יש להתחבר מחדש כדי להמשיך.",
+    "dismiss": "סגירה"
   },
   "signIn": {
     "title": "התחברות",
@@ -204,7 +207,9 @@
   "errors": {
     "somethingWentWrong": "משהו השתבש",
     "unexpectedError": "אירעה שגיאה בלתי צפויה.",
-    "backToPlans": "חזרה לתוכניות"
+    "backToPlans": "חזרה לתוכניות",
+    "planNotFound": "התוכנית לא נמצאה",
+    "planNoAccess": "תוכנית זו לא קיימת או שאין לך גישה אליה. אם אתה הבעלים, נסה להתחבר."
   },
   "notFound": {
     "title": "404 — הדף לא נמצא",

--- a/src/routes/ErrorPage.tsx
+++ b/src/routes/ErrorPage.tsx
@@ -1,31 +1,35 @@
 import { Link } from '@tanstack/react-router';
 import { useTranslation } from 'react-i18next';
 
+interface ErrorWithStatus extends Error {
+  status?: number;
+}
+
 interface ErrorPageProps {
   error?: Error | null;
 }
 
 export function ErrorPage({ error }: ErrorPageProps) {
   const { t } = useTranslation();
+  const status = (error as ErrorWithStatus | undefined)?.status;
+  const is404 = status === 404;
+
   return (
-    <div
-      className="error-page"
-      style={{ padding: '2rem', textAlign: 'center' }}
-    >
-      <h1 style={{ fontSize: '1.75rem', marginBottom: '1rem' }}>
-        {t('errors.somethingWentWrong')}
+    <div className="py-16 px-4 text-center">
+      <h1 className="text-2xl font-bold text-gray-900 mb-3">
+        {is404 ? t('errors.planNotFound') : t('errors.somethingWentWrong')}
       </h1>
-      <div style={{ color: '#b91c1c', marginBottom: '1rem' }}>
-        {error?.message ?? t('errors.unexpectedError')}
-      </div>
-      <div>
-        <Link
-          to="/plans"
-          style={{ color: '#2563eb', textDecoration: 'underline' }}
-        >
-          {t('errors.backToPlans')}
-        </Link>
-      </div>
+      <p className="text-gray-600 mb-6 max-w-md mx-auto">
+        {is404
+          ? t('errors.planNoAccess')
+          : (error?.message ?? t('errors.unexpectedError'))}
+      </p>
+      <Link
+        to="/plans"
+        className="text-blue-600 hover:text-blue-800 underline font-medium"
+      >
+        {t('errors.backToPlans')}
+      </Link>
     </div>
   );
 }

--- a/tests/helpers/supabase-mock.ts
+++ b/tests/helpers/supabase-mock.ts
@@ -44,6 +44,10 @@ export function createSupabaseMock(
         error: null,
       }),
       signOut: vi.fn().mockResolvedValue({ error: null }),
+      refreshSession: vi.fn().mockResolvedValue({
+        data: { session },
+        error: session ? null : { message: 'No session' },
+      }),
       updateUser: vi.fn().mockResolvedValue({
         data: { user: session?.user ?? null },
         error: null,

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -39,6 +39,10 @@ vi.mock('../src/lib/supabase', () => ({
         error: null,
       }),
       signOut: vi.fn().mockResolvedValue({ error: null }),
+      refreshSession: vi.fn().mockResolvedValue({
+        data: { session: null },
+        error: { message: 'No session' },
+      }),
       updateUser: vi.fn().mockResolvedValue({
         data: { user: null },
         error: null,

--- a/tests/unit/components/AuthErrorModal.test.tsx
+++ b/tests/unit/components/AuthErrorModal.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+const mockNavigate = vi.fn();
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const actual = (await importOriginal()) as Record<string, any>;
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+import AuthErrorModal from '../../../src/components/AuthErrorModal';
+
+describe('AuthErrorModal', () => {
+  it('renders nothing when closed', () => {
+    render(<AuthErrorModal open={false} onDismiss={vi.fn()} />);
+    expect(screen.queryByText('Session Expired')).not.toBeInTheDocument();
+  });
+
+  it('renders title and message when open', () => {
+    render(<AuthErrorModal open={true} onDismiss={vi.fn()} />);
+    expect(screen.getByText('Session Expired')).toBeInTheDocument();
+    expect(
+      screen.getByText(/Your session has expired or is invalid/)
+    ).toBeInTheDocument();
+  });
+
+  it('calls onDismiss when Dismiss button is clicked', async () => {
+    const onDismiss = vi.fn();
+    const user = userEvent.setup();
+    render(<AuthErrorModal open={true} onDismiss={onDismiss} />);
+
+    await user.click(screen.getByText('Dismiss'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+  });
+
+  it('navigates to /sign-in and dismisses when Sign In is clicked', async () => {
+    const onDismiss = vi.fn();
+    const user = userEvent.setup();
+    render(<AuthErrorModal open={true} onDismiss={onDismiss} />);
+
+    await user.click(screen.getByText('Sign In'));
+    expect(onDismiss).toHaveBeenCalledOnce();
+    expect(mockNavigate).toHaveBeenCalledWith({ to: '/sign-in' });
+  });
+});

--- a/tests/unit/components/ErrorPage.test.tsx
+++ b/tests/unit/components/ErrorPage.test.tsx
@@ -34,6 +34,30 @@ describe('Error and NotFound UIs', () => {
     ).toBeInTheDocument();
   });
 
+  it('shows plan-specific message for 404 errors', () => {
+    const error404 = new Error('Not Found') as Error & { status: number };
+    error404.status = 404;
+
+    render(<ErrorPage error={error404} />);
+
+    expect(screen.getByText('Plan not found')).toBeInTheDocument();
+    expect(
+      screen.getByText(/This plan doesn't exist or you don't have access/)
+    ).toBeInTheDocument();
+    expect(screen.queryByText('Something went wrong')).not.toBeInTheDocument();
+  });
+
+  it('shows generic message for non-404 errors', () => {
+    const error500 = new Error('Server error') as Error & { status: number };
+    error500.status = 500;
+
+    render(<ErrorPage error={error500} />);
+
+    expect(screen.getByText(/Something went wrong/i)).toBeInTheDocument();
+    expect(screen.getByText('Server error')).toBeInTheDocument();
+    expect(screen.queryByText('Plan not found')).not.toBeInTheDocument();
+  });
+
   it('shows ErrorPage UI when a child component throws', () => {
     // Component that throws during render
     const Bomb = () => {

--- a/tests/unit/core/auth-error.test.ts
+++ b/tests/unit/core/auth-error.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest';
+import { emitAuthError, onAuthError } from '../../../src/core/auth-error';
+
+describe('auth-error event bus', () => {
+  it('calls listener when emitAuthError is called', () => {
+    const listener = vi.fn();
+    const unsubscribe = onAuthError(listener);
+
+    emitAuthError();
+    expect(listener).toHaveBeenCalledOnce();
+
+    unsubscribe();
+  });
+
+  it('supports multiple listeners', () => {
+    const listener1 = vi.fn();
+    const listener2 = vi.fn();
+    const unsub1 = onAuthError(listener1);
+    const unsub2 = onAuthError(listener2);
+
+    emitAuthError();
+    expect(listener1).toHaveBeenCalledOnce();
+    expect(listener2).toHaveBeenCalledOnce();
+
+    unsub1();
+    unsub2();
+  });
+
+  it('stops calling listener after unsubscribe', () => {
+    const listener = vi.fn();
+    const unsubscribe = onAuthError(listener);
+
+    emitAuthError();
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsubscribe();
+    emitAuthError();
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when no listeners are registered', () => {
+    expect(() => emitAuthError()).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary

- Add 401 retry logic to `api.ts` `request()`: on 401, refreshes the Supabase session and retries once before failing
- Create `AuthErrorModal` component (uses existing `Modal`) that shows when JWT auth fails after retry — with "Sign In" and "Dismiss" buttons
- Wire the modal via a global auth error event bus (`src/core/auth-error.ts`) that bridges the non-React API layer with the React UI
- Add JWT injection to `api-client.ts` (openapi-fetch) via `authFetch` wrapper — previously this client had no auth headers
- Improve `ErrorPage` to show plan-specific 404 message ("Plan not found or no access") instead of generic error
- Add i18n keys for session expired modal and plan access errors (EN + HE)
- Bump version to 1.10.0

## Test plan

- [x] Typecheck passes
- [x] Lint passes
- [x] 348 unit tests pass (39 files) — includes 15 new tests
- [x] 48 E2E tests pass (Chrome, Firefox, Desktop Safari, Mobile Safari)
- [ ] Manual: Sign in, create a plan, verify JWT sent in request headers
- [ ] Manual: Let token expire, trigger API call, verify modal appears with Sign In / Dismiss
- [ ] Manual: Access someone else's unlisted plan while signed out, verify 404 page

Closes #92

Made with [Cursor](https://cursor.com)