### PR TITLE
fix: remove redundant /auth/me calls and add integration tests to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+      - name: Run integration tests
+        run: npm run test:integ
+
       - name: Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Run unit tests
         run: npm run test:unit
 
+      - name: Run integration tests
+        run: npm run test:integ
+
       - name: Build
         run: npm run build
         env:

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.11.0",
+  "version": "1.11.1",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -3,7 +3,6 @@ import type { Session, User } from '@supabase/supabase-js';
 import toast from 'react-hot-toast';
 import i18n from '../i18n';
 import { supabase } from '../lib/supabase';
-import { fetchAuthMe } from '../core/api';
 import { onAuthError } from '../core/auth-error';
 import { AuthContext } from './auth-context';
 import AuthErrorModal from '../components/AuthErrorModal';
@@ -28,13 +27,10 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
       setUser(newSession?.user ?? null);
 
       if (event === 'SIGNED_IN') {
-        fetchAuthMe()
-          .then((res) => {
-            toast.success(i18n.t('auth.signedInAs', { email: res.user.email }));
-          })
-          .catch(() => {
-            toast.success(i18n.t('auth.signedIn'));
-          });
+        const email = newSession?.user?.email;
+        toast.success(
+          email ? i18n.t('auth.signedInAs', { email }) : i18n.t('auth.signedIn')
+        );
       }
 
       if (event === 'SIGNED_OUT') {


### PR DESCRIPTION
Stop calling fetchAuthMe() from onAuthStateChange — the user email is already in the Supabase session, eliminating 8+ 401 errors on page load. Add integration test step to ci.yml and deploy.yml.