### PR TITLE
feat: gate visibility options by auth state and rename unlisted to in…

### DIFF
--- a/api/mock.ts
+++ b/api/mock.ts
@@ -25,7 +25,7 @@ const planSchema = z.object({
   title: z.string(),
   description: z.string().nullable().optional(),
   status: z.enum(['draft', 'active', 'archived']),
-  visibility: z.enum(['public', 'unlisted', 'private']),
+  visibility: z.enum(['public', 'invite_only', 'private']),
   ownerParticipantId: z.string().nullable().optional(),
   location: locationSchema.nullable().optional(),
   startDate: z.string().datetime().nullable().optional(),

--- a/api/server.ts
+++ b/api/server.ts
@@ -31,7 +31,7 @@ function statusColor(code: number): string {
 }
 
 const planStatusSchema = z.enum(['draft', 'active', 'archived']);
-const planVisibilitySchema = z.enum(['public', 'unlisted', 'private']);
+const planVisibilitySchema = z.enum(['public', 'invite_only', 'private']);
 const itemStatusSchema = z.enum(['pending', 'purchased', 'packed', 'canceled']);
 const itemCategorySchema = z.enum(['equipment', 'food']);
 const unitSchema = z.enum([

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.11.1",
+  "version": "1.12.0",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",

--- a/src/components/PlanForm.tsx
+++ b/src/components/PlanForm.tsx
@@ -13,6 +13,7 @@ import {
 import { FormLabel } from './shared/FormLabel';
 import { FormInput, FormTextarea, FormSelect } from './shared/FormInput';
 import { useLanguage } from '../contexts/useLanguage';
+import { useAuth } from '../contexts/useAuth';
 import {
   countryCodes,
   getFlagEmoji,
@@ -134,6 +135,8 @@ export default function PlanForm({
 }: PlanFormProps) {
   const { t } = useTranslation();
   const { language } = useLanguage();
+  const { user } = useAuth();
+  const isAuthenticated = !!user;
   const ownerPhone = resolveOwnerPhone(defaultOwner, language);
   const defaultPhoneCountry = getDefaultCountryByLanguage(language);
   const {
@@ -147,7 +150,7 @@ export default function PlanForm({
     resolver: zodResolver(createPlanFormSchema),
     defaultValues: {
       status: 'draft',
-      visibility: 'private',
+      visibility: isAuthenticated ? 'private' : 'public',
       oneDay: false,
       participants: [],
       ownerName: defaultOwner?.ownerName ?? '',
@@ -332,9 +335,16 @@ export default function PlanForm({
           <div>
             <FormLabel>{t('planForm.visibility')}</FormLabel>
             <FormSelect {...register('visibility')}>
-              <option value="public">{t('planVisibility.public')}</option>
-              <option value="unlisted">{t('planVisibility.unlisted')}</option>
-              <option value="private">{t('planVisibility.private')}</option>
+              {isAuthenticated ? (
+                <>
+                  <option value="private">{t('planVisibility.private')}</option>
+                  <option value="invite_only">
+                    {t('planVisibility.invite_only')}
+                  </option>
+                </>
+              ) : (
+                <option value="public">{t('planVisibility.public')}</option>
+              )}
             </FormSelect>
           </div>
         </div>

--- a/src/core/api.generated.ts
+++ b/src/core/api.generated.ts
@@ -1258,7 +1258,7 @@ export interface components {
       /** @enum {string} */
       status: 'draft' | 'active' | 'archived';
       /** @enum {string} */
-      visibility: 'public' | 'unlisted' | 'private';
+      visibility: 'public' | 'invite_only' | 'private';
       /** Format: uuid */
       ownerParticipantId?: string | null;
       /** Format: uuid */
@@ -1290,7 +1290,7 @@ export interface components {
       title: string;
       description?: string | null;
       /** @enum {string} */
-      visibility?: 'public' | 'unlisted' | 'private';
+      visibility?: 'public' | 'invite_only' | 'private';
       location?: components['schemas']['def-4'] | null;
       /** Format: date-time */
       startDate?: string | null;
@@ -1303,7 +1303,7 @@ export interface components {
       title: string;
       description?: string | null;
       /** @enum {string} */
-      visibility?: 'public' | 'unlisted' | 'private';
+      visibility?: 'public' | 'invite_only' | 'private';
       location?: components['schemas']['def-4'] | null;
       /** Format: date-time */
       startDate?: string | null;
@@ -1320,7 +1320,7 @@ export interface components {
       /** @enum {string} */
       status?: 'draft' | 'active' | 'archived';
       /** @enum {string} */
-      visibility?: 'public' | 'unlisted' | 'private';
+      visibility?: 'public' | 'invite_only' | 'private';
       location?: components['schemas']['def-4'] | null;
       /** Format: date-time */
       startDate?: string | null;
@@ -1506,7 +1506,7 @@ export interface components {
       /** @enum {string} */
       status: 'draft' | 'active' | 'archived';
       /** @enum {string} */
-      visibility: 'public' | 'unlisted' | 'private';
+      visibility: 'public' | 'invite_only' | 'private';
       /** Format: uuid */
       ownerParticipantId?: string | null;
       /** Format: uuid */

--- a/src/core/schemas/plan.ts
+++ b/src/core/schemas/plan.ts
@@ -13,7 +13,7 @@ const PLAN_STATUS_VALUES = [
 ] as const satisfies readonly BEPlan['status'][];
 const PLAN_VISIBILITY_VALUES = [
   'public',
-  'unlisted',
+  'invite_only',
   'private',
 ] as const satisfies readonly BEPlan['visibility'][];
 

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -198,7 +198,7 @@
   },
   "planVisibility": {
     "public": "Public",
-    "unlisted": "Unlisted",
+    "invite_only": "Invited Only",
     "private": "Private"
   },
   "filters": {

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -198,7 +198,7 @@
   },
   "planVisibility": {
     "public": "ציבורי",
-    "unlisted": "לא ברשימה",
+    "invite_only": "מוזמנים בלבד",
     "private": "פרטי"
   },
   "filters": {

--- a/tests/unit/components/CreatePlan.test.tsx
+++ b/tests/unit/components/CreatePlan.test.tsx
@@ -4,6 +4,15 @@ import userEvent from '@testing-library/user-event';
 import PlanForm from '../../../src/components/PlanForm';
 import type { DefaultOwner } from '../../../src/components/PlanForm';
 
+vi.mock('../../../src/contexts/useAuth', () => ({
+  useAuth: () => ({
+    session: null,
+    user: null,
+    loading: false,
+    signOut: vi.fn(),
+  }),
+}));
+
 vi.mock('uuid', () => ({
   v5: vi.fn(
     (name: string) => `uuid-${name.toLowerCase().replace(/\s+/g, '-')}`


### PR DESCRIPTION
…vite_only

Signed-in users see Private and Invited Only visibility options. Non-signed-in users see only Public. Synced with BE enum rename (unlisted -> invite_only) and updated translations, mock server, Zod schemas, and tests.