### PR TITLE
feat: add admin delete button on plans list with confirmation modal

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.13.0",
+  "version": "1.14.0",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -64,8 +64,12 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
     navigate({ to: '/' });
   }, [queryClient, navigate]);
 
+  const isAdmin =
+    (user?.app_metadata as Record<string, unknown> | undefined)?.role ===
+    'admin';
+
   return (
-    <AuthContext.Provider value={{ session, user, loading, signOut }}>
+    <AuthContext.Provider value={{ session, user, loading, isAdmin, signOut }}>
       {children}
       <AuthErrorModal
         open={authErrorOpen}

--- a/src/contexts/auth-context.ts
+++ b/src/contexts/auth-context.ts
@@ -5,6 +5,7 @@ export interface AuthContextValue {
   session: Session | null;
   user: User | null;
   loading: boolean;
+  isAdmin: boolean;
   signOut: () => Promise<void>;
 }
 

--- a/src/core/api.generated.ts
+++ b/src/core/api.generated.ts
@@ -297,7 +297,7 @@ export interface paths {
     post?: never;
     /**
      * Delete a plan
-     * @description Delete a plan by its ID. Cascade delete handles related items, participants, and assignments.
+     * @description Delete a plan by its ID. Requires JWT. Admin can delete any plan; owner can delete their own. Cascade delete handles related items, participants, and assignments.
      */
     delete: {
       parameters: {
@@ -317,6 +317,15 @@ export interface paths {
           };
           content: {
             'application/json': components['schemas']['def-12'];
+          };
+        };
+        /** @description Default Response */
+        401: {
+          headers: {
+            [name: string]: unknown;
+          };
+          content: {
+            'application/json': components['schemas']['def-0'];
           };
         };
         /** @description Default Response */

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -341,5 +341,14 @@
   "language": {
     "en": "EN",
     "he": "עב"
+  },
+  "admin": {
+    "deletePlan": "Delete",
+    "deleteConfirmTitle": "Delete Plan?",
+    "deleteConfirmMessage": "Are you sure you want to delete <strong>{{title}}</strong>? This action cannot be undone.",
+    "deleteConfirm": "Delete",
+    "deleteCancel": "Cancel",
+    "deleted": "Plan deleted",
+    "deleting": "Deleting…"
   }
 }

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -341,5 +341,14 @@
   "language": {
     "en": "EN",
     "he": "עב"
+  },
+  "admin": {
+    "deletePlan": "מחיקה",
+    "deleteConfirmTitle": "למחוק את התוכנית?",
+    "deleteConfirmMessage": "האם אתה בטוח שברצונך למחוק את <strong>{{title}}</strong>? לא ניתן לבטל פעולה זו.",
+    "deleteConfirm": "מחיקה",
+    "deleteCancel": "ביטול",
+    "deleted": "התוכנית נמחקה",
+    "deleting": "מוחק…"
   }
 }

--- a/src/lib/mock-supabase-auth.ts
+++ b/src/lib/mock-supabase-auth.ts
@@ -4,6 +4,7 @@ interface MockUser {
   id: string;
   email: string;
   user_metadata: Record<string, unknown>;
+  app_metadata: Record<string, unknown>;
   aud: string;
   role: string;
 }
@@ -33,7 +34,10 @@ function makeFakeJwt(email: string, userId: string): string {
   return `${header}.${payload}.mock-signature`;
 }
 
-function buildSession(email: string): MockSession {
+function buildSession(
+  email: string,
+  appMetadata: Record<string, unknown> = {}
+): MockSession {
   const userId = crypto.randomUUID();
   return {
     access_token: makeFakeJwt(email, userId),
@@ -44,6 +48,7 @@ function buildSession(email: string): MockSession {
       id: userId,
       email,
       user_metadata: { full_name: email.split('@')[0] },
+      app_metadata: appMetadata,
       aud: 'authenticated',
       role: 'authenticated',
     },

--- a/tests/unit/components/CreatePlan.test.tsx
+++ b/tests/unit/components/CreatePlan.test.tsx
@@ -9,6 +9,7 @@ vi.mock('../../../src/contexts/useAuth', () => ({
     session: null,
     user: null,
     loading: false,
+    isAdmin: false,
     signOut: vi.fn(),
   }),
 }));

--- a/tests/unit/components/Header.test.tsx
+++ b/tests/unit/components/Header.test.tsx
@@ -36,6 +36,7 @@ function authUser(overrides?: {
       user_metadata: overrides?.user_metadata ?? {},
     } as never,
     loading: false,
+    isAdmin: false,
     signOut: vi.fn(),
   };
 }
@@ -51,6 +52,7 @@ describe('Header', () => {
         session: null,
         user: null,
         loading: false,
+        isAdmin: false,
         signOut: vi.fn(),
       });
 
@@ -65,6 +67,7 @@ describe('Header', () => {
         session: null,
         user: null,
         loading: true,
+        isAdmin: false,
         signOut: vi.fn(),
       });
 
@@ -79,6 +82,7 @@ describe('Header', () => {
         session: null,
         user: null,
         loading: false,
+        isAdmin: false,
         signOut: vi.fn(),
       });
 
@@ -94,6 +98,7 @@ describe('Header', () => {
         session: null,
         user: null,
         loading: false,
+        isAdmin: false,
         signOut: vi.fn(),
       });
 
@@ -270,6 +275,7 @@ describe('Header', () => {
         session: null,
         user: null,
         loading: false,
+        isAdmin: false,
         signOut: vi.fn(),
       });
 

--- a/tests/unit/routes/CreatePlanNavigation.test.tsx
+++ b/tests/unit/routes/CreatePlanNavigation.test.tsx
@@ -16,6 +16,7 @@ vi.mock('../../../src/contexts/useAuth', () => ({
     session: null,
     user: null,
     loading: false,
+    isAdmin: false,
     signOut: vi.fn(),
   }),
 }));

--- a/tests/unit/routes/complete-profile.test.tsx
+++ b/tests/unit/routes/complete-profile.test.tsx
@@ -41,6 +41,7 @@ describe('Complete Profile Page', () => {
         user_metadata: {},
       } as never,
       loading: false,
+      isAdmin: false,
       signOut: vi.fn(),
     });
     mockSupabase.auth.updateUser.mockResolvedValue({
@@ -88,6 +89,7 @@ describe('Complete Profile Page', () => {
         user_metadata: { full_name: 'Alex Guberman' },
       } as never,
       loading: false,
+      isAdmin: false,
       signOut: vi.fn(),
     });
 
@@ -111,6 +113,7 @@ describe('Complete Profile Page', () => {
         },
       } as never,
       loading: false,
+      isAdmin: false,
       signOut: vi.fn(),
     });
 
@@ -314,6 +317,7 @@ describe('Complete Profile Page', () => {
       session: null,
       user: null,
       loading: false,
+      isAdmin: false,
       signOut: vi.fn(),
     });
 


### PR DESCRIPTION
## Summary
- Detect admin role from Supabase `app_metadata.role` and expose `isAdmin` flag via `AuthContext`
- Show trash icon delete button on every plan card in the plans list for admin users only; non-admin users see no delete buttons
- Clicking delete opens a confirmation modal with the plan title; on confirm, calls `DELETE /plans/:planId`, removes the plan from the list, and shows a toast notification

## Test plan
- [x] Unit tests: admin/non-admin visibility, modal open/close, delete mutation called with correct planId
- [x] E2E tests across Chrome, Firefox, Safari (desktop + mobile): admin sees buttons, non-admin does not, unauthenticated does not, full delete flow, cancel flow
- [x] All 361 unit tests pass
- [x] All 68 E2E tests pass
- [x] TypeScript typecheck passes
- [x] ESLint passes

Closes #103

Made with [Cursor](https://cursor.com)