### PR TITLE
feat: Guest invite claim flow and continue-without-auth preferences

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.14.0",
+  "version": "1.15.0",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",

--- a/src/contexts/AuthProvider.tsx
+++ b/src/contexts/AuthProvider.tsx
@@ -6,6 +6,8 @@ import { useNavigate } from '@tanstack/react-router';
 import i18n from '../i18n';
 import { supabase } from '../lib/supabase';
 import { onAuthError } from '../core/auth-error';
+import { claimInvite } from '../core/api';
+import { getPendingInvite, clearPendingInvite } from '../core/pending-invite';
 import { AuthContext } from './auth-context';
 import AuthErrorModal from '../components/AuthErrorModal';
 
@@ -35,6 +37,14 @@ export default function AuthProvider({ children }: { children: ReactNode }) {
         toast.success(
           email ? i18n.t('auth.signedInAs', { email }) : i18n.t('auth.signedIn')
         );
+
+        const pending = getPendingInvite();
+        if (pending) {
+          clearPendingInvite();
+          claimInvite(pending.planId, pending.inviteToken).catch(() => {
+            /* claim failed (already claimed, invalid token, etc.) — silently ignore */
+          });
+        }
       }
 
       if (event === 'SIGNED_OUT') {

--- a/src/core/api.ts
+++ b/src/core/api.ts
@@ -217,6 +217,33 @@ export async function fetchPlanByInvite(
   return invitePlanResponseSchema.parse(data);
 }
 
+export async function saveGuestPreferences(
+  planId: string,
+  inviteToken: string,
+  preferences: {
+    adultsCount?: number;
+    kidsCount?: number;
+    foodPreferences?: string;
+    allergies?: string;
+    notes?: string;
+  }
+): Promise<void> {
+  await publicRequest(`/plans/${planId}/invite/${inviteToken}/preferences`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(preferences),
+  });
+}
+
+export async function claimInvite(
+  planId: string,
+  inviteToken: string
+): Promise<void> {
+  await request(`/plans/${planId}/claim/${inviteToken}`, {
+    method: 'POST',
+  });
+}
+
 // --- Participants ---
 
 export async function fetchParticipants(

--- a/src/core/pending-invite.ts
+++ b/src/core/pending-invite.ts
@@ -1,0 +1,34 @@
+const STORAGE_KEY = 'chillist-pending-invite';
+
+interface PendingInvite {
+  planId: string;
+  inviteToken: string;
+}
+
+export function storePendingInvite(planId: string, inviteToken: string): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ planId, inviteToken }));
+  } catch {
+    /* quota exceeded or unavailable */
+  }
+}
+
+export function getPendingInvite(): PendingInvite | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as PendingInvite;
+    if (parsed.planId && parsed.inviteToken) return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function clearPendingInvite(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* unavailable */
+  }
+}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -362,7 +362,9 @@
     "noDescription": "No description provided.",
     "signInToJoin": "Sign in to join this plan",
     "signUpToJoin": "or create an account",
-    "goToPlan": "Go to plan"
+    "continueAsGuest": "Continue without signing in",
+    "goToPlan": "Go to plan",
+    "guestPreferencesTitle": "Your Preferences"
   },
   "language": {
     "en": "EN",

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -362,7 +362,9 @@
     "noDescription": "אין תיאור.",
     "signInToJoin": "התחבר כדי להצטרף לתוכנית",
     "signUpToJoin": "או צור חשבון",
-    "goToPlan": "מעבר לתוכנית"
+    "continueAsGuest": "המשך בלי להתחבר",
+    "goToPlan": "מעבר לתוכנית",
+    "guestPreferencesTitle": "ההעדפות שלך"
   },
   "language": {
     "en": "EN",

--- a/tests/e2e/fixtures.ts
+++ b/tests/e2e/fixtures.ts
@@ -430,6 +430,28 @@ export async function mockInviteRoute(
   );
 
   await page.route(
+    `${API_PATTERN}/plans/${plan.planId}/invite/${inviteToken}/preferences`,
+    async (route) => {
+      if (route.request().method() === 'PATCH') {
+        const matched = plan.participants.find(
+          (p) => p.inviteToken === inviteToken
+        );
+        await route.fulfill({
+          json: {
+            participantId: matched?.participantId ?? 'unknown',
+            displayName:
+              matched?.displayName ??
+              `${matched?.name ?? ''} ${matched?.lastName ?? ''}`.trim(),
+            role: matched?.role ?? 'participant',
+          },
+        });
+      } else {
+        await route.continue();
+      }
+    }
+  );
+
+  await page.route(
     `${API_PATTERN}/plans/${plan.planId}/invite/invalid-token-*`,
     async (route) => {
       if (route.request().method() === 'GET') {

--- a/tests/unit/api/server.test.ts
+++ b/tests/unit/api/server.test.ts
@@ -451,6 +451,45 @@ describe('mock server', () => {
     }
   });
 
+  it('PATCH /plans/:planId/invite/:inviteToken/preferences saves guest preferences', async () => {
+    const server = await buildServer({
+      initialData: createTestData(),
+      persist: false,
+      logger: false,
+    });
+    try {
+      const response = await server.inject({
+        method: 'PATCH',
+        url: '/plans/plan-1/invite/claimable-invite-token-xyz789/preferences',
+        payload: { adultsCount: 2, kidsCount: 1, foodPreferences: 'Vegan' },
+      });
+      expect(response.statusCode).toBe(200);
+      const body = response.json() as Record<string, unknown>;
+      expect(body.participantId).toBe('participant-2');
+      expect(body.displayName).toBeTruthy();
+    } finally {
+      await server.close();
+    }
+  });
+
+  it('PATCH /plans/:planId/invite/:inviteToken/preferences returns 404 for invalid token', async () => {
+    const server = await buildServer({
+      initialData: createTestData(),
+      persist: false,
+      logger: false,
+    });
+    try {
+      const response = await server.inject({
+        method: 'PATCH',
+        url: '/plans/plan-1/invite/nonexistent-token/preferences',
+        payload: { adultsCount: 1 },
+      });
+      expect(response.statusCode).toBe(404);
+    } finally {
+      await server.close();
+    }
+  });
+
   it('POST /plans/:planId/claim/:inviteToken returns 400 when already claimed', async () => {
     const header = btoa(JSON.stringify({ alg: 'none', typ: 'JWT' }));
     const payload = btoa(JSON.stringify({ sub: 'some-user' }));

--- a/tests/unit/core/pending-invite.test.ts
+++ b/tests/unit/core/pending-invite.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  storePendingInvite,
+  getPendingInvite,
+  clearPendingInvite,
+} from '../../../src/core/pending-invite';
+
+describe('pending-invite localStorage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('stores and retrieves a pending invite', () => {
+    storePendingInvite('plan-123', 'token-abc');
+    const result = getPendingInvite();
+    expect(result).toEqual({ planId: 'plan-123', inviteToken: 'token-abc' });
+  });
+
+  it('returns null when nothing stored', () => {
+    expect(getPendingInvite()).toBeNull();
+  });
+
+  it('clears the pending invite', () => {
+    storePendingInvite('plan-123', 'token-abc');
+    clearPendingInvite();
+    expect(getPendingInvite()).toBeNull();
+  });
+
+  it('returns null for corrupted data', () => {
+    localStorage.setItem('chillist-pending-invite', '{bad json');
+    expect(getPendingInvite()).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Add localStorage handoff for invite claim: stores `planId` + `inviteToken` when guest clicks sign-in/sign-up from invite page; `AuthProvider` auto-claims via `POST /plans/:planId/claim/:inviteToken` after `SIGNED_IN` event, linking the participant to the user before redirect
- Add "Continue without signing in" button on invite page — opens preferences modal, saves via public `PATCH` endpoint, then redirects to the plan
- Full unit + E2E test coverage for all new flows (132 E2E tests passing across Chrome, Firefox, Safari)

## Files changed

| File | Change |
|------|--------|
| `src/core/pending-invite.ts` | New — localStorage helpers (store/get/clear pending invite) |
| `src/core/api.ts` | Add `claimInvite()` and `saveGuestPreferences()` API functions |
| `src/contexts/AuthProvider.tsx` | Auto-claim on `SIGNED_IN` event using pending invite from localStorage |
| `src/routes/invite.$planId.$inviteToken.lazy.tsx` | Guest CTA button + preferences modal + storePendingInvite on auth links |
| `api/server.ts` | Mock endpoint for `PATCH /plans/:planId/invite/:inviteToken/preferences` |
| `src/i18n/locales/{en,he}.json` | New translation keys for guest flow |
| `tests/unit/core/pending-invite.test.ts` | Unit tests for localStorage helpers |
| `tests/unit/core/api.test.ts` | Unit tests for `claimInvite` and `saveGuestPreferences` |
| `tests/unit/api/server.test.ts` | Unit tests for mock preferences endpoint |
| `tests/e2e/main-flow.spec.ts` | E2E tests for guest preferences modal + localStorage handoff |
| `tests/e2e/fixtures.ts` | E2E mock helper for preferences endpoint |
| `package.json` | Version bump 1.14.0 → 1.15.0 |

## Test plan

- [x] All 132 E2E tests pass (Chrome, Firefox, Mobile Safari)
- [x] All unit tests pass
- [x] TypeScript type check passes
- [x] Lint passes
- [x] Guest can "Continue without signing in" → sees preferences modal → saves → redirects to plan
- [x] Guest can skip preferences → redirects to plan
- [x] Sign-in/sign-up from invite stores pending invite in localStorage
- [x] After auth, AuthProvider auto-claims and clears localStorage

Closes #107

Made with [Cursor](https://cursor.com)