### PR TITLE
fix: move bulk assign button below subcategory header

### DIFF
--- a/src/components/BulkAssignButton.tsx
+++ b/src/components/BulkAssignButton.tsx
@@ -73,12 +73,12 @@ export default function BulkAssignButton({
     <>
       <Menu as="div" className="relative">
         <MenuButton
-          className="inline-flex items-center justify-center w-7 h-7 text-gray-400 hover:text-blue-600 hover:bg-blue-50 rounded-md transition-colors cursor-pointer"
+          className="inline-flex items-center gap-2 px-3 py-2 text-sm font-medium text-gray-700 bg-white border border-gray-300 rounded-lg hover:bg-gray-50 hover:border-gray-400 transition-colors cursor-pointer"
           aria-label={t('items.bulkAssign')}
           onClick={(e: React.MouseEvent) => e.stopPropagation()}
         >
           <svg
-            className="w-4 h-4"
+            className="w-4 h-4 text-gray-500"
             fill="none"
             viewBox="0 0 24 24"
             stroke="currentColor"
@@ -91,6 +91,7 @@ export default function BulkAssignButton({
               d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0z"
             />
           </svg>
+          <span>{t('items.bulkAssign')}</span>
         </MenuButton>
 
         <MenuItems

--- a/src/components/CategorySection.tsx
+++ b/src/components/CategorySection.tsx
@@ -13,6 +13,7 @@ import {
   OTHER_SUBCATEGORY,
 } from '../data/subcategories';
 import { groupBySubcategory } from '../core/utils/items';
+import BulkAssignButton from './BulkAssignButton';
 import ItemCard from './ItemCard';
 import SubcategorySection from './SubcategorySection';
 
@@ -133,27 +134,68 @@ export default function CategorySection({
                     />
                   )
                 )
-              : items.map((item) => {
-                  const editable = canEditItem ? canEditItem(item) : true;
-                  return (
-                    <ItemCard
-                      key={item.itemId}
-                      item={item}
-                      participants={participants}
-                      listFilter={listFilter}
-                      selfAssignParticipantId={selfAssignParticipantId}
-                      canEdit={editable}
-                      onEdit={
-                        onEditItem ? () => onEditItem(item.itemId) : undefined
-                      }
-                      onUpdate={
-                        onUpdateItem
-                          ? (updates) => onUpdateItem(item.itemId, updates)
-                          : undefined
-                      }
-                    />
-                  );
-                })}
+              : (() => {
+                  if (onBulkAssign && participants.length > 0) {
+                    return (
+                      <>
+                        <div className="px-4 sm:px-5 py-2 border-b border-gray-100">
+                          <BulkAssignButton
+                            items={items}
+                            participants={participants}
+                            onAssign={onBulkAssign}
+                          />
+                        </div>
+                        {items.map((item) => {
+                          const editable = canEditItem
+                            ? canEditItem(item)
+                            : true;
+                          return (
+                            <ItemCard
+                              key={item.itemId}
+                              item={item}
+                              participants={participants}
+                              listFilter={listFilter}
+                              selfAssignParticipantId={selfAssignParticipantId}
+                              canEdit={editable}
+                              onEdit={
+                                onEditItem
+                                  ? () => onEditItem(item.itemId)
+                                  : undefined
+                              }
+                              onUpdate={
+                                onUpdateItem
+                                  ? (updates) =>
+                                      onUpdateItem(item.itemId, updates)
+                                  : undefined
+                              }
+                            />
+                          );
+                        })}
+                      </>
+                    );
+                  }
+                  return items.map((item) => {
+                    const editable = canEditItem ? canEditItem(item) : true;
+                    return (
+                      <ItemCard
+                        key={item.itemId}
+                        item={item}
+                        participants={participants}
+                        listFilter={listFilter}
+                        selfAssignParticipantId={selfAssignParticipantId}
+                        canEdit={editable}
+                        onEdit={
+                          onEditItem ? () => onEditItem(item.itemId) : undefined
+                        }
+                        onUpdate={
+                          onUpdateItem
+                            ? (updates) => onUpdateItem(item.itemId, updates)
+                            : undefined
+                        }
+                      />
+                    );
+                  });
+                })()}
           </div>
         ) : (
           <div className="border-t border-gray-200 px-4 sm:px-5 py-3 sm:py-4 text-center">

--- a/src/components/SubcategorySection.tsx
+++ b/src/components/SubcategorySection.tsx
@@ -33,35 +33,35 @@ export default function SubcategorySection({
           {subcategory}
           <span className="ms-2 text-gray-400">({items.length})</span>
         </h4>
-        <div className="flex items-center gap-1">
-          {onBulkAssign && (
-            <BulkAssignButton
-              items={items}
-              participants={participants}
-              onAssign={onBulkAssign}
-            />
-          )}
-          <svg
-            className="w-4 h-4 text-gray-400 transition-transform group-data-open:rotate-180"
-            fill="none"
-            viewBox="0 0 24 24"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M19 9l-7 7-7-7"
-            />
-          </svg>
-        </div>
+        <svg
+          className="w-4 h-4 text-gray-400 transition-transform group-data-open:rotate-180"
+          fill="none"
+          viewBox="0 0 24 24"
+          stroke="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={2}
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
       </DisclosureButton>
       <DisclosurePanel
         transition
         className="origin-top transition duration-150 ease-out data-closed:-translate-y-4 data-closed:opacity-0"
       >
         <div className="divide-y divide-gray-200">
+          {onBulkAssign && participants.length > 0 && (
+            <div className="px-4 sm:px-5 py-2 border-b border-gray-100">
+              <BulkAssignButton
+                items={items}
+                participants={participants}
+                onAssign={onBulkAssign}
+              />
+            </div>
+          )}
           {renderItemCards({ items, ...cardProps })}
         </div>
       </DisclosurePanel>

--- a/tests/unit/components/ItemsList.test.tsx
+++ b/tests/unit/components/ItemsList.test.tsx
@@ -1,7 +1,16 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeAll } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import ItemsList from '../../../src/components/ItemsList';
 import type { Item } from '../../../src/core/schemas/item';
+import type { Participant } from '../../../src/core/schemas/participant';
+
+beforeAll(() => {
+  global.ResizeObserver = class {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+  };
+});
 
 const equipmentItem: Item = {
   itemId: 'item-1',
@@ -74,5 +83,59 @@ describe('ItemsList', () => {
     expect(screen.getByText('Equipment')).toBeInTheDocument();
     expect(screen.getByText('No equipment items')).toBeInTheDocument();
     expect(screen.getByText('Bananas')).toBeInTheDocument();
+  });
+
+  it('renders bulk assign button per subcategory when onBulkAssign is provided with participants and items', () => {
+    const participants: Participant[] = [
+      {
+        participantId: 'p-1',
+        planId: 'plan-1',
+        name: 'Alex',
+        lastName: 'Smith',
+        contactPhone: '',
+        role: 'owner',
+        rsvpStatus: 'confirmed',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      },
+    ];
+
+    render(
+      <ItemsList
+        items={[equipmentItem, foodItem]}
+        participants={participants}
+        onBulkAssign={vi.fn()}
+      />
+    );
+
+    const buttons = screen.getAllByRole('button', { name: /assign all/i });
+    expect(buttons.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('does not render bulk assign buttons when onBulkAssign is not provided', () => {
+    const participants: Participant[] = [
+      {
+        participantId: 'p-1',
+        planId: 'plan-1',
+        name: 'Alex',
+        lastName: 'Smith',
+        contactPhone: '',
+        role: 'owner',
+        rsvpStatus: 'confirmed',
+        createdAt: '2025-01-01T00:00:00Z',
+        updatedAt: '2025-01-01T00:00:00Z',
+      },
+    ];
+
+    render(
+      <ItemsList
+        items={[equipmentItem, foodItem]}
+        participants={participants}
+      />
+    );
+
+    expect(
+      screen.queryAllByRole('button', { name: /assign all/i })
+    ).toHaveLength(0);
   });
 });


### PR DESCRIPTION
Bulk assign button was not visible on production when placed as a tiny icon in the subcategory header.

- Moved BulkAssignButton from subcategory header row into DisclosurePanel
- Button now appears below subcategory header, above items
- Assigns all items in that subcategory
- Trigger changed from icon-only to visible text+icon button