### PR TITLE
feat: improve expense form item picker with participant filtering, su…

### DIFF
--- a/api/server.ts
+++ b/api/server.ts
@@ -1260,6 +1260,20 @@ export async function buildServer(
       };
 
       store.expenses.push(expense);
+
+      if (expense.itemIds?.length) {
+        for (const item of store.items) {
+          if (!expense.itemIds.includes(item.itemId)) continue;
+          if (item.planId !== request.params.planId) continue;
+          item.assignmentStatusList = item.assignmentStatusList.map((entry) =>
+            entry.participantId === expense.participantId &&
+            entry.status === 'pending'
+              ? { ...entry, status: 'purchased' as const }
+              : entry
+          );
+        }
+      }
+
       void reply.status(201).send(expense);
     }
   );

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "chillist-fe",
   "private": true,
-  "version": "1.18.0",
+  "version": "1.19.0",
   "type": "module",
   "scripts": {
     "predev": "npm run api:fetch",

--- a/src/components/ExpenseForm.tsx
+++ b/src/components/ExpenseForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect, useRef } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
@@ -66,7 +66,27 @@ export default function ExpenseForm({
   });
 
   const selectedItemIds = watch('itemIds') ?? [];
+  const selectedParticipantId = watch('participantId');
   const canSelectParticipant = isOwner;
+
+  const participantItems = useMemo(() => {
+    if (!selectedParticipantId) return [];
+    return items.filter(
+      (item) =>
+        item.isAllParticipants ||
+        item.assignmentStatusList.some(
+          (a) => a.participantId === selectedParticipantId
+        )
+    );
+  }, [items, selectedParticipantId]);
+
+  const prevParticipantIdRef = useRef(selectedParticipantId);
+  useEffect(() => {
+    if (prevParticipantIdRef.current !== selectedParticipantId) {
+      prevParticipantIdRef.current = selectedParticipantId;
+      setValue('itemIds', [], { shouldDirty: true });
+    }
+  }, [selectedParticipantId, setValue]);
 
   return (
     <form
@@ -132,12 +152,19 @@ export default function ExpenseForm({
         />
       </div>
 
-      {items.length > 0 && (
+      {participantItems.length > 0 ? (
         <ItemMultiSelect
-          items={items}
+          items={participantItems}
           selectedIds={selectedItemIds}
           onChange={(ids) => setValue('itemIds', ids, { shouldDirty: true })}
         />
+      ) : (
+        selectedParticipantId &&
+        items.length > 0 && (
+          <p className="text-sm text-gray-400 text-center py-2">
+            {t('expenses.noItemsForParticipant')}
+          </p>
+        )
       )}
 
       <div className="flex justify-end gap-3 pt-2">
@@ -185,12 +212,14 @@ function ItemMultiSelect({
   }, [items, search]);
 
   const grouped = useMemo(() => {
-    const map = new Map<string, Item[]>();
+    const map = new Map<string, Map<string, Item[]>>();
     for (const item of filtered) {
-      const key = item.category;
-      const list = map.get(key) ?? [];
-      list.push(item);
-      map.set(key, list);
+      const category = item.category;
+      const subcategory = item.subcategory ?? 'Other';
+      if (!map.has(category)) map.set(category, new Map());
+      const catMap = map.get(category)!;
+      if (!catMap.has(subcategory)) catMap.set(subcategory, []);
+      catMap.get(subcategory)!.push(item);
     }
     return map;
   }, [filtered]);
@@ -200,6 +229,20 @@ function ItemMultiSelect({
       ? selectedIds.filter((id) => id !== itemId)
       : [...selectedIds, itemId];
     onChange(next);
+  }
+
+  function toggleSubcategory(subcatItems: Item[]) {
+    const ids = subcatItems.map((i) => i.itemId);
+    const allSelected = ids.every((id) => selectedIds.includes(id));
+    if (allSelected) {
+      onChange(selectedIds.filter((id) => !ids.includes(id)));
+    } else {
+      const merged = [...selectedIds];
+      for (const id of ids) {
+        if (!merged.includes(id)) merged.push(id);
+      }
+      onChange(merged);
+    }
   }
 
   function getItemName(itemId: string): string {
@@ -291,38 +334,73 @@ function ItemMultiSelect({
                 {t('expenses.noItemsInPlan')}
               </p>
             )}
-            {Array.from(grouped.entries()).map(([category, categoryItems]) => (
+            {Array.from(grouped.entries()).map(([category, subcatMap]) => (
               <div key={category}>
-                <div className="px-3 py-1 text-xs font-semibold text-gray-500 uppercase bg-gray-50 sticky top-0">
+                <div className="px-3 py-1 text-xs font-semibold text-gray-500 uppercase bg-gray-50 sticky top-0 z-10">
                   {t(`items.${category}`)}
                 </div>
-                {categoryItems.map((item) => {
-                  const checked = selectedIds.includes(item.itemId);
-                  return (
-                    <label
-                      key={item.itemId}
-                      className={clsx(
-                        'flex items-center gap-3 px-3 py-2 cursor-pointer hover:bg-gray-50 transition-colors',
-                        checked && 'bg-blue-50/50'
-                      )}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => toggleItem(item.itemId)}
-                        className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
-                      />
-                      <span className="text-sm text-gray-700 truncate">
-                        {item.name}
-                      </span>
-                      {item.quantity > 1 && (
-                        <span className="text-xs text-gray-400 shrink-0">
-                          ×{item.quantity}
-                        </span>
-                      )}
-                    </label>
-                  );
-                })}
+                {Array.from(subcatMap.entries()).map(
+                  ([subcategory, subcatItems]) => {
+                    const subcatIds = subcatItems.map((i) => i.itemId);
+                    const selectedCount = subcatIds.filter((id) =>
+                      selectedIds.includes(id)
+                    ).length;
+                    const allSelected = selectedCount === subcatIds.length;
+                    const someSelected = selectedCount > 0 && !allSelected;
+
+                    return (
+                      <div key={subcategory}>
+                        <label
+                          data-testid={`subcat-${subcategory}`}
+                          className="flex items-center gap-3 px-3 py-1.5 bg-gray-50/60 cursor-pointer hover:bg-gray-100 transition-colors border-t border-gray-100"
+                        >
+                          <input
+                            type="checkbox"
+                            ref={(el) => {
+                              if (el) el.indeterminate = someSelected;
+                            }}
+                            checked={allSelected}
+                            onChange={() => toggleSubcategory(subcatItems)}
+                            className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                          />
+                          <span className="text-xs font-medium text-gray-600 truncate">
+                            {t(`subcategories.${subcategory}`, subcategory)}
+                          </span>
+                          <span className="text-xs text-gray-400 shrink-0">
+                            ({subcatItems.length})
+                          </span>
+                        </label>
+                        {subcatItems.map((item) => {
+                          const checked = selectedIds.includes(item.itemId);
+                          return (
+                            <label
+                              key={item.itemId}
+                              className={clsx(
+                                'flex items-center gap-3 ps-8 pe-3 py-2 cursor-pointer hover:bg-gray-50 transition-colors',
+                                checked && 'bg-blue-50/50'
+                              )}
+                            >
+                              <input
+                                type="checkbox"
+                                checked={checked}
+                                onChange={() => toggleItem(item.itemId)}
+                                className="h-4 w-4 rounded border-gray-300 text-blue-600 focus:ring-blue-500"
+                              />
+                              <span className="text-sm text-gray-700 truncate">
+                                {item.name}
+                              </span>
+                              {item.quantity > 1 && (
+                                <span className="text-xs text-gray-400 shrink-0">
+                                  ×{item.quantity}
+                                </span>
+                              )}
+                            </label>
+                          );
+                        })}
+                      </div>
+                    );
+                  }
+                )}
               </div>
             ))}
           </div>

--- a/src/hooks/useCreateExpense.ts
+++ b/src/hooks/useCreateExpense.ts
@@ -9,6 +9,7 @@ export function useCreateExpense(planId: string) {
     mutationFn: (body: ExpenseCreate) => createExpense(planId, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['expenses', planId] });
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
     },
   });
 }

--- a/src/hooks/useUpdateExpense.ts
+++ b/src/hooks/useUpdateExpense.ts
@@ -15,6 +15,7 @@ export function useUpdateExpense(planId: string) {
       updateExpense(expenseId, updates),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: ['expenses', planId] });
+      queryClient.invalidateQueries({ queryKey: ['plan', planId] });
     },
   });
 }

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -570,6 +570,7 @@
     "selectItems": "Link to plan items",
     "searchItems": "Search items…",
     "noItemsInPlan": "No items in this plan yet",
+    "noItemsForParticipant": "No items assigned to this participant",
     "itemsSelected": "{{count}} item linked",
     "itemsSelected_other": "{{count}} items linked",
     "settlementTitle": "Settlement",

--- a/src/i18n/locales/es.json
+++ b/src/i18n/locales/es.json
@@ -547,6 +547,7 @@
     "selectItems": "Vincular a artículos del plan",
     "searchItems": "Buscar artículos…",
     "noItemsInPlan": "Aún no hay artículos en este plan",
+    "noItemsForParticipant": "No hay artículos asignados a este participante",
     "itemsSelected": "{{count}} artículo vinculado",
     "itemsSelected_other": "{{count}} artículos vinculados",
     "settlementTitle": "Liquidación",

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -570,6 +570,7 @@
     "selectItems": "קישור לפריטי התוכנית",
     "searchItems": "חיפוש פריטים…",
     "noItemsInPlan": "אין עדיין פריטים בתוכנית",
+    "noItemsForParticipant": "אין פריטים משויכים למשתתף זה",
     "itemsSelected": "פריט אחד מקושר",
     "itemsSelected_other": "{{count}} פריטים מקושרים",
     "settlementTitle": "התחשבנות",

--- a/src/routes/expenses.$planId.lazy.tsx
+++ b/src/routes/expenses.$planId.lazy.tsx
@@ -301,7 +301,7 @@ function ExpensesContent({
                           {getParticipantName(tr.from)}
                         </span>
                         <svg
-                          className="w-4 h-4 text-gray-400 shrink-0"
+                          className="w-4 h-4 text-gray-400 shrink-0 rtl:-scale-x-100"
                           fill="none"
                           viewBox="0 0 24 24"
                           stroke="currentColor"

--- a/tests/unit/components/ExpenseForm.test.tsx
+++ b/tests/unit/components/ExpenseForm.test.tsx
@@ -236,9 +236,23 @@ describe('ExpenseForm', () => {
         planId: 'plan-1',
         name: 'Tent',
         category: 'equipment',
+        subcategory: 'Venue Setup and Layout',
         quantity: 1,
         unit: 'pcs',
-        assignmentStatusList: [],
+        assignmentStatusList: [{ participantId: 'p-owner', status: 'pending' }],
+        isAllParticipants: false,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        itemId: 'item-3',
+        planId: 'plan-1',
+        name: 'Flashlight',
+        category: 'equipment',
+        subcategory: 'Venue Setup and Layout',
+        quantity: 2,
+        unit: 'pcs',
+        assignmentStatusList: [{ participantId: 'p-owner', status: 'pending' }],
         isAllParticipants: false,
         createdAt: '2026-01-01T00:00:00Z',
         updatedAt: '2026-01-01T00:00:00Z',
@@ -248,9 +262,36 @@ describe('ExpenseForm', () => {
         planId: 'plan-1',
         name: 'Water Bottles',
         category: 'food',
+        subcategory: 'Beverages (non-alcoholic)',
         quantity: 6,
         unit: 'pcs',
+        assignmentStatusList: [{ participantId: 'p-owner', status: 'pending' }],
+        isAllParticipants: false,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        itemId: 'item-4',
+        planId: 'plan-1',
+        name: 'Shared Cooler',
+        category: 'equipment',
+        subcategory: 'Food Storage and Cooling',
+        quantity: 1,
+        unit: 'pcs',
         assignmentStatusList: [],
+        isAllParticipants: true,
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+      },
+      {
+        itemId: 'item-5',
+        planId: 'plan-1',
+        name: 'Bob Only Snacks',
+        category: 'food',
+        subcategory: 'Snacks and Chips',
+        quantity: 3,
+        unit: 'pcs',
+        assignmentStatusList: [{ participantId: 'p-bob', status: 'pending' }],
         isAllParticipants: false,
         createdAt: '2026-01-01T00:00:00Z',
         updatedAt: '2026-01-01T00:00:00Z',
@@ -259,16 +300,21 @@ describe('ExpenseForm', () => {
 
     function renderWithItems(props?: {
       defaultValues?: Record<string, unknown>;
+      isOwner?: boolean;
+      currentParticipantId?: string;
     }) {
       return render(
         <ExpenseForm
           participants={participants}
           items={items}
-          isOwner={true}
-          currentParticipantId="p-owner"
+          isOwner={props?.isOwner ?? true}
+          currentParticipantId={props?.currentParticipantId ?? 'p-owner'}
           onSubmit={handleSubmit}
           onCancel={handleCancel}
-          defaultValues={props?.defaultValues}
+          defaultValues={{
+            participantId: 'p-owner',
+            ...props?.defaultValues,
+          }}
         />
       );
     }
@@ -285,37 +331,122 @@ describe('ExpenseForm', () => {
       ).not.toBeInTheDocument();
     });
 
-    it('expands item list and shows items grouped by category', async () => {
+    it('filters items by selected participant', () => {
+      renderWithItems();
+      expect(screen.getByTestId('toggle-item-select')).toBeInTheDocument();
+      expect(screen.queryByText('Bob Only Snacks')).not.toBeInTheDocument();
+    });
+
+    it('shows isAllParticipants items for any participant', () => {
+      renderWithItems({ defaultValues: { participantId: 'p-bob' } });
+      expect(screen.getByTestId('toggle-item-select')).toBeInTheDocument();
+    });
+
+    it('shows no items message when participant has no assigned items', () => {
+      const noAssignmentItems: Item[] = [
+        {
+          itemId: 'item-x',
+          planId: 'plan-1',
+          name: 'Unassigned Item',
+          category: 'equipment',
+          quantity: 1,
+          unit: 'pcs',
+          assignmentStatusList: [{ participantId: 'p-bob', status: 'pending' }],
+          isAllParticipants: false,
+          createdAt: '2026-01-01T00:00:00Z',
+          updatedAt: '2026-01-01T00:00:00Z',
+        },
+      ];
+      render(
+        <ExpenseForm
+          participants={participants}
+          items={noAssignmentItems}
+          isOwner={true}
+          currentParticipantId="p-owner"
+          onSubmit={handleSubmit}
+          onCancel={handleCancel}
+          defaultValues={{ participantId: 'p-owner' }}
+        />
+      );
+      expect(
+        screen.getByText(/no items assigned to this participant/i)
+      ).toBeInTheDocument();
+    });
+
+    it('expands item list and shows items grouped by subcategory', async () => {
       renderWithItems();
       const user = userEvent.setup();
       await user.click(screen.getByTestId('toggle-item-select'));
       expect(screen.getByText('Tent')).toBeInTheDocument();
       expect(screen.getByText('Water Bottles')).toBeInTheDocument();
+      expect(screen.getByText('Shared Cooler')).toBeInTheDocument();
+      expect(
+        screen.getByTestId('subcat-Venue Setup and Layout')
+      ).toBeInTheDocument();
+      expect(
+        screen.getByTestId('subcat-Food Storage and Cooling')
+      ).toBeInTheDocument();
     });
 
-    it('selects and deselects items via checkbox', async () => {
+    it('selects and deselects an item via checkbox', async () => {
       renderWithItems();
       const user = userEvent.setup();
       await user.click(screen.getByTestId('toggle-item-select'));
 
-      const checkboxes = screen.getAllByRole('checkbox');
-      await user.click(checkboxes[0]);
-      expect(checkboxes[0]).toBeChecked();
+      const tentLabel = screen.getByText('Tent').closest('label')!;
+      const tentCheckbox = tentLabel.querySelector(
+        'input[type="checkbox"]'
+      ) as HTMLInputElement;
+      await user.click(tentCheckbox);
+      expect(tentCheckbox).toBeChecked();
 
-      await user.click(checkboxes[0]);
-      expect(checkboxes[0]).not.toBeChecked();
+      await user.click(tentCheckbox);
+      expect(tentCheckbox).not.toBeChecked();
+    });
+
+    it('bulk-selects all items in a subcategory', async () => {
+      renderWithItems();
+      const user = userEvent.setup();
+      await user.click(screen.getByTestId('toggle-item-select'));
+
+      const subcatLabel = screen.getByTestId('subcat-Venue Setup and Layout');
+      const subcatCheckbox = subcatLabel.querySelector(
+        'input[type="checkbox"]'
+      ) as HTMLInputElement;
+      await user.click(subcatCheckbox);
+
+      const tentInList = screen
+        .getAllByText('Tent')
+        .find((el) => el.closest('label'))!;
+      const tentCheckbox = tentInList
+        .closest('label')!
+        .querySelector('input[type="checkbox"]') as HTMLInputElement;
+      const flashInList = screen
+        .getAllByText('Flashlight')
+        .find((el) => el.closest('label'))!;
+      const flashCheckbox = flashInList
+        .closest('label')!
+        .querySelector('input[type="checkbox"]') as HTMLInputElement;
+      expect(tentCheckbox).toBeChecked();
+      expect(flashCheckbox).toBeChecked();
+
+      await user.click(subcatCheckbox);
+      expect(tentCheckbox).not.toBeChecked();
+      expect(flashCheckbox).not.toBeChecked();
     });
 
     it('submits with selected itemIds', async () => {
       renderWithItems();
       const user = userEvent.setup();
 
-      await user.selectOptions(screen.getByRole('combobox'), 'p-owner');
       await user.type(getAmountInput(), '50');
       await user.click(screen.getByTestId('toggle-item-select'));
 
-      const checkboxes = screen.getAllByRole('checkbox');
-      await user.click(checkboxes[0]);
+      const tentLabel = screen.getByText('Tent').closest('label')!;
+      const tentCheckbox = tentLabel.querySelector(
+        'input[type="checkbox"]'
+      ) as HTMLInputElement;
+      await user.click(tentCheckbox);
 
       await user.click(screen.getByTestId('expense-form-submit'));
 


### PR DESCRIPTION
…bcategory grouping, and bulk-select

- Filter linked items by selected participant (assigned items + isAllParticipants)
- Clear stale item selections when participant changes
- Group items by category > subcategory (items without subcategory go under "Other")
- Add checkbox on subcategory headers for bulk select/deselect with indeterminate state
- Show "no items assigned" message when participant has no items
- Add i18n key expenses.noItemsForParticipant in en/he/es
- Fix RTL arrow direction in settlement transfers
- Update ExpenseForm tests with participant-aware fixtures and new coverage

Made-with: Cursor