### PR TITLE
feat: wizard-based plan creation/edit with estimation fields

### DIFF
--- a/src/components/BulkItemAddWizard.tsx
+++ b/src/components/BulkItemAddWizard.tsx
@@ -34,6 +34,7 @@ interface BulkItemAddWizardProps {
   existingItems?: Map<string, string>;
   onCancel?: (itemIds: string[]) => Promise<void>;
   planPoints?: number;
+  inline?: boolean;
 }
 
 export default function BulkItemAddWizard({
@@ -43,6 +44,7 @@ export default function BulkItemAddWizard({
   existingItems,
   onCancel,
   planPoints,
+  inline,
 }: BulkItemAddWizardProps) {
   const { t } = useTranslation();
   const { language } = useLanguage();
@@ -346,6 +348,61 @@ export default function BulkItemAddWizard({
           ? t(`subcategories.${subcategory}`, subcategory)
           : t('items.bulkAddSelectItems');
 
+  const content = (
+    <div className={inline ? '' : 'px-4 sm:px-6 pb-4 sm:pb-6'}>
+      {step === 'category' && (
+        <CategoryStep
+          onSelect={(cat) => {
+            setCategory(cat);
+            setStep('subcategory');
+          }}
+        />
+      )}
+
+      {step === 'subcategory' && category && (
+        <SubcategoryStep
+          subcategories={subcategories}
+          onSelect={(sub) => {
+            setSubcategory(sub);
+            setStep('items');
+          }}
+          onBack={() => {
+            setStep('category');
+            setCategory(null);
+          }}
+        />
+      )}
+
+      {step === 'items' && (
+        <ItemsStep
+          filteredItems={filteredItems}
+          subcategoryItems={subcategoryItems}
+          selected={selected}
+          allFilteredSelected={allFilteredSelected}
+          search={search}
+          selectedCount={selectedCount}
+          hasWork={hasWork}
+          isSubmitting={isSubmitting}
+          getExistingItemId={getExistingItemId}
+          uncheckedExisting={uncheckedExisting}
+          onSearchChange={setSearch}
+          onAddCustom={addCustomItem}
+          onToggleItem={toggleItem}
+          onToggleSelectAll={toggleSelectAll}
+          onUpdateQuantity={updateQuantity}
+          onSubmit={handleSubmit}
+          onBack={() => {
+            setStep('subcategory');
+            setSubcategory(null);
+            setSearch('');
+          }}
+        />
+      )}
+    </div>
+  );
+
+  if (inline) return content;
+
   return (
     <Modal
       open={open}
@@ -354,56 +411,7 @@ export default function BulkItemAddWizard({
       testId="bulk-item-add-wizard"
       showCloseButton
     >
-      <div className="px-4 sm:px-6 pb-4 sm:pb-6">
-        {step === 'category' && (
-          <CategoryStep
-            onSelect={(cat) => {
-              setCategory(cat);
-              setStep('subcategory');
-            }}
-          />
-        )}
-
-        {step === 'subcategory' && category && (
-          <SubcategoryStep
-            subcategories={subcategories}
-            onSelect={(sub) => {
-              setSubcategory(sub);
-              setStep('items');
-            }}
-            onBack={() => {
-              setStep('category');
-              setCategory(null);
-            }}
-          />
-        )}
-
-        {step === 'items' && (
-          <ItemsStep
-            filteredItems={filteredItems}
-            subcategoryItems={subcategoryItems}
-            selected={selected}
-            allFilteredSelected={allFilteredSelected}
-            search={search}
-            selectedCount={selectedCount}
-            hasWork={hasWork}
-            isSubmitting={isSubmitting}
-            getExistingItemId={getExistingItemId}
-            uncheckedExisting={uncheckedExisting}
-            onSearchChange={setSearch}
-            onAddCustom={addCustomItem}
-            onToggleItem={toggleItem}
-            onToggleSelectAll={toggleSelectAll}
-            onUpdateQuantity={updateQuantity}
-            onSubmit={handleSubmit}
-            onBack={() => {
-              setStep('subcategory');
-              setSubcategory(null);
-              setSearch('');
-            }}
-          />
-        )}
-      </div>
+      {content}
     </Modal>
   );
 }

--- a/src/components/CreatePlanWizard.tsx
+++ b/src/components/CreatePlanWizard.tsx
@@ -1,0 +1,895 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { v5 as uuidv5 } from 'uuid';
+import { useTranslation } from 'react-i18next';
+import { useNavigate } from '@tanstack/react-router';
+import toast from 'react-hot-toast';
+import clsx from 'clsx';
+
+import type { User } from '@supabase/supabase-js';
+import { FormLabel } from './shared/FormLabel';
+import { FormInput, FormTextarea, FormSelect } from './shared/FormInput';
+import PreferencesFields from './shared/PreferencesFields';
+import LocationAutocomplete from './LocationAutocomplete';
+import type { PlaceResult } from './LocationAutocomplete';
+import BulkItemAddWizard from './BulkItemAddWizard';
+import {
+  DEFAULT_PLAN_LANGUAGE,
+  DEFAULT_PLAN_CURRENCY,
+  SUPPORTED_LANGUAGES,
+  SUPPORTED_CURRENCIES,
+  LANGUAGE_META,
+} from '../contexts/language-context';
+import { combinePhone } from '../data/country-codes';
+import { splitFullName } from '../core/profile-utils';
+import { useCreatePlan } from '../hooks/useCreatePlan';
+import { useUpdateParticipant } from '../hooks/useUpdateParticipant';
+import { useCreateItem } from '../hooks/useCreateItem';
+import { getApiErrorMessage } from '../core/error-utils';
+import type {
+  PlanCreateWithOwner,
+  PlanWithDetails,
+} from '../core/schemas/plan';
+import type { ItemCreate } from '../core/schemas/item';
+
+type WizardStep = 1 | 2 | 3;
+
+const locationFormSchema = z
+  .object({
+    name: z.string().optional(),
+    city: z.string().optional(),
+    country: z.string().optional(),
+    region: z.string().optional(),
+    latitude: z.number().nullish(),
+    longitude: z.number().nullish(),
+  })
+  .optional();
+
+const step1Schema = z
+  .object({
+    title: z.string().min(1, 'Title is required'),
+    description: z.string().optional(),
+    defaultLang: z.string().max(10).optional(),
+    currency: z.string().max(10).optional(),
+    oneDay: z.boolean().optional(),
+    singleDate: z
+      .string()
+      .min(1, 'Date is required')
+      .optional()
+      .or(z.literal('')),
+    singleStartTime: z.string().optional(),
+    singleEndTime: z.string().optional(),
+    startDateDate: z
+      .string()
+      .min(1, 'Start date is required')
+      .optional()
+      .or(z.literal('')),
+    startDateTime: z.string().optional(),
+    endDateDate: z.string().optional(),
+    endDateTime: z.string().optional(),
+    location: locationFormSchema,
+  })
+  .refine((data) => !data.oneDay || !!data.singleDate, {
+    message: 'Date is required',
+    path: ['singleDate'],
+  })
+  .refine((data) => data.oneDay || !!data.startDateDate, {
+    message: 'Start date is required',
+    path: ['startDateDate'],
+  })
+  .refine((data) => data.oneDay || !!data.endDateDate, {
+    message: 'End date is required',
+    path: ['endDateDate'],
+  });
+
+type Step1Values = z.infer<typeof step1Schema>;
+
+function buildStep2Schema(t: (key: string) => string) {
+  return z.object({
+    adultsCount: z.coerce
+      .number({ invalid_type_error: t('validation.adultsCountInvalid') })
+      .int()
+      .min(1, t('validation.adultsCountMin'))
+      .optional(),
+    kidsCount: z.coerce
+      .number({ invalid_type_error: t('validation.kidsCountInvalid') })
+      .int()
+      .min(0, t('validation.kidsCountMin'))
+      .optional(),
+    foodPreferences: z.string().optional(),
+    allergies: z.string().optional(),
+    notes: z.string().optional(),
+    estimatedAdults: z.coerce
+      .number({ invalid_type_error: t('validation.adultsCountInvalid') })
+      .int()
+      .min(0, t('validation.kidsCountMin'))
+      .optional(),
+    estimatedKids: z.coerce
+      .number({ invalid_type_error: t('validation.kidsCountInvalid') })
+      .int()
+      .min(0, t('validation.kidsCountMin'))
+      .optional(),
+  });
+}
+
+type Step2Values = {
+  adultsCount?: number;
+  kidsCount?: number;
+  foodPreferences?: string;
+  allergies?: string;
+  notes?: string;
+  estimatedAdults?: number;
+  estimatedKids?: number;
+};
+
+interface CreatePlanWizardProps {
+  user: User | null;
+}
+
+function StepIndicator({
+  currentStep,
+  completedSteps,
+}: {
+  currentStep: WizardStep;
+  completedSteps: Set<number>;
+}) {
+  const { t } = useTranslation();
+  const steps = [
+    { num: 1, label: t('wizard.step1Title') },
+    { num: 2, label: t('wizard.step2Title') },
+    { num: 3, label: t('wizard.step3Title') },
+  ];
+
+  return (
+    <div className="flex items-center justify-center gap-0 mb-6">
+      {steps.map((step, i) => (
+        <div key={step.num} className="flex items-center">
+          <div className="flex flex-col items-center">
+            <div
+              className={clsx(
+                'w-8 h-8 rounded-full flex items-center justify-center text-sm font-semibold transition-colors',
+                step.num === currentStep && 'bg-blue-600 text-white',
+                completedSteps.has(step.num) &&
+                  step.num !== currentStep &&
+                  'bg-green-500 text-white',
+                !completedSteps.has(step.num) &&
+                  step.num !== currentStep &&
+                  'bg-gray-200 text-gray-500'
+              )}
+            >
+              {completedSteps.has(step.num) && step.num !== currentStep ? (
+                <svg
+                  className="w-4 h-4"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={3}
+                    d="M5 13l4 4L19 7"
+                  />
+                </svg>
+              ) : (
+                step.num
+              )}
+            </div>
+            <span
+              className={clsx(
+                'text-xs mt-1 font-medium',
+                step.num === currentStep ? 'text-blue-600' : 'text-gray-400'
+              )}
+            >
+              {step.label}
+            </span>
+          </div>
+          {i < steps.length - 1 && (
+            <div
+              className={clsx(
+                'w-12 sm:w-20 h-0.5 mx-1 sm:mx-2 mb-5',
+                completedSteps.has(step.num) ? 'bg-green-400' : 'bg-gray-200'
+              )}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function getCurrentHour00(): string {
+  const now = new Date();
+  return `${String(now.getHours()).padStart(2, '0')}:00`;
+}
+
+function isDateToday(dateStr: string): boolean {
+  if (!dateStr || !/^\d{4}-\d{2}-\d{2}$/.test(dateStr)) return false;
+  const [y, m, d] = dateStr.split('-').map(Number);
+  const selected = new Date(y, m - 1, d);
+  const today = new Date();
+  return (
+    selected.getFullYear() === today.getFullYear() &&
+    selected.getMonth() === today.getMonth() &&
+    selected.getDate() === today.getDate()
+  );
+}
+
+const UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+function makeDateTime(date?: string, time?: string) {
+  if (!date) return undefined;
+  const hhmm = time || '00:00';
+  return `${date}T${hhmm}:00Z`;
+}
+
+function hasLocationData(loc?: {
+  name?: string;
+  city?: string;
+  country?: string;
+  region?: string;
+  latitude?: number | null;
+  longitude?: number | null;
+}) {
+  if (!loc) return false;
+  return (
+    [loc.name, loc.city, loc.country, loc.region].some(
+      (v) => v && v.trim().length > 0
+    ) ||
+    (loc.latitude != null && loc.longitude != null)
+  );
+}
+
+export default function CreatePlanWizard({ user }: CreatePlanWizardProps) {
+  const { t } = useTranslation();
+  const navigate = useNavigate();
+
+  const [step, setStep] = useState<WizardStep>(1);
+  const [completedSteps, setCompletedSteps] = useState<Set<number>>(new Set());
+  const [step1Data, setStep1Data] = useState<Step1Values | null>(null);
+  const [createdPlan, setCreatedPlan] = useState<PlanWithDetails | null>(null);
+  const [isCreating, setIsCreating] = useState(false);
+
+  const createPlan = useCreatePlan();
+  const updateParticipant = useUpdateParticipant(createdPlan?.planId ?? '');
+  const createItem = useCreateItem(createdPlan?.planId ?? '');
+
+  function navigateToPlan() {
+    if (createdPlan?.planId) {
+      navigate({ to: '/plan/$planId', params: { planId: createdPlan.planId } });
+    } else {
+      navigate({ to: '/plans' });
+    }
+  }
+
+  function handleStep1Submit(values: Step1Values) {
+    setStep1Data(values);
+    setCompletedSteps((prev) => new Set([...prev, 1]));
+    setStep(2);
+  }
+
+  async function handleStep2Submit(values: Step2Values) {
+    if (!step1Data || !user) return;
+    setIsCreating(true);
+
+    try {
+      const meta = user.user_metadata ?? {};
+      const { first, last } = splitFullName(meta.full_name as string);
+      const ownerName = (meta.first_name as string) || first || 'Owner';
+      const ownerLastName = (meta.last_name as string) || last || '';
+      const ownerPhone = (meta.phone as string) || '';
+      const ownerEmail = user.email ?? '';
+
+      const payload: PlanCreateWithOwner = {
+        title: step1Data.title,
+        description: step1Data.description || undefined,
+        visibility: 'invite_only',
+        owner: {
+          name: ownerName.trim(),
+          lastName: ownerLastName.trim() || ownerName.trim(),
+          contactPhone: combinePhone(undefined, ownerPhone) || '+0000000000',
+          contactEmail: ownerEmail.trim() || undefined,
+        },
+        startDate: step1Data.oneDay
+          ? makeDateTime(step1Data.singleDate, step1Data.singleStartTime)
+          : makeDateTime(step1Data.startDateDate, step1Data.startDateTime),
+        endDate: step1Data.oneDay
+          ? makeDateTime(step1Data.singleDate, step1Data.singleEndTime)
+          : makeDateTime(step1Data.endDateDate, step1Data.endDateTime),
+        defaultLang: step1Data.defaultLang ?? DEFAULT_PLAN_LANGUAGE,
+        currency: step1Data.currency ?? DEFAULT_PLAN_CURRENCY,
+        location: hasLocationData(step1Data.location)
+          ? {
+              ...step1Data.location,
+              locationId: uuidv5(
+                step1Data.location!.name || step1Data.title,
+                UUID_NAMESPACE
+              ),
+              name: step1Data.location!.name || step1Data.title,
+            }
+          : undefined,
+        estimatedAdults: values.estimatedAdults ?? undefined,
+        estimatedKids: values.estimatedKids ?? undefined,
+      };
+
+      const created = await createPlan.mutateAsync(payload);
+      if (!created?.planId) {
+        navigate({ to: '/plans' });
+        return;
+      }
+
+      setCreatedPlan(created);
+
+      const ownerId = created.participants.find(
+        (p) => p.role === 'owner'
+      )?.participantId;
+
+      if (ownerId) {
+        try {
+          await updateParticipant.mutateAsync({
+            participantId: ownerId,
+            updates: {
+              rsvpStatus: 'confirmed',
+              adultsCount: values.adultsCount ?? null,
+              kidsCount: values.kidsCount ?? null,
+              foodPreferences: values.foodPreferences || null,
+              allergies: values.allergies || null,
+              notes: values.notes || null,
+            },
+          });
+        } catch (err) {
+          const { title, message } = getApiErrorMessage(
+            err instanceof Error ? err : new Error(String(err))
+          );
+          console.error(
+            `[CreatePlanWizard] Failed to update owner preferences: ${title}: ${message}`
+          );
+        }
+      }
+
+      setCompletedSteps((prev) => new Set([...prev, 2]));
+      setStep(3);
+    } catch (err) {
+      const { title, message } = getApiErrorMessage(
+        err instanceof Error ? err : new Error(String(err))
+      );
+      toast.error(`${title}: ${message}`);
+    } finally {
+      setIsCreating(false);
+    }
+  }
+
+  async function handleBulkItemsAdd(items: ItemCreate[]) {
+    const results = await Promise.allSettled(
+      items.map((item) => createItem.mutateAsync(item))
+    );
+    const succeeded = results.filter((r) => r.status === 'fulfilled').length;
+    const failed = results.filter((r) => r.status === 'rejected').length;
+    if (failed === 0) {
+      toast.success(t('items.bulkAddSuccess', { count: succeeded }));
+    } else if (succeeded > 0) {
+      toast.error(
+        t('items.bulkAddPartial', {
+          successCount: succeeded,
+          errorCount: failed,
+        })
+      );
+    } else {
+      toast.error(t('items.bulkAddError'));
+    }
+  }
+
+  return (
+    <div className="w-full">
+      <div className="bg-white rounded-lg shadow-sm p-4 sm:p-6 lg:p-8">
+        <StepIndicator currentStep={step} completedSteps={completedSteps} />
+
+        {step === 1 && (
+          <Step1Form onSubmit={handleStep1Submit} defaultValues={step1Data} />
+        )}
+
+        {step === 2 && (
+          <Step2Form
+            onSubmit={handleStep2Submit}
+            onBack={() => setStep(1)}
+            isCreating={isCreating}
+          />
+        )}
+
+        {step === 3 && createdPlan && (
+          <Step3Items
+            onAdd={handleBulkItemsAdd}
+            onSkip={navigateToPlan}
+            onDone={navigateToPlan}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Step1Form({
+  onSubmit,
+  defaultValues,
+}: {
+  onSubmit: (values: Step1Values) => void;
+  defaultValues: Step1Values | null;
+}) {
+  const { t } = useTranslation();
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+    watch,
+    setValue,
+  } = useForm<Step1Values>({
+    resolver: zodResolver(step1Schema),
+    defaultValues: defaultValues ?? {
+      oneDay: false,
+      defaultLang: DEFAULT_PLAN_LANGUAGE,
+      currency: DEFAULT_PLAN_CURRENCY,
+    },
+  });
+
+  const oneDay = watch('oneDay');
+  const locationData = watch('location');
+  const locationNameRef = useRef<HTMLInputElement | null>(null);
+  const singleStartTimeRef = useRef<HTMLInputElement | null>(null);
+  const startDateTimeRef = useRef<HTMLInputElement | null>(null);
+  const endDateDateRef = useRef<HTMLInputElement | null>(null);
+  const endDateTimeRef = useRef<HTMLInputElement | null>(null);
+  const skipEndDateShowPickerRef = useRef(false);
+  const skipStartTimeChainRef = useRef(false);
+
+  function openPicker(inputRef: { current: HTMLInputElement | null }) {
+    setTimeout(() => {
+      if (!inputRef.current) return;
+      try {
+        inputRef.current.dataset.pickerOpenedMs = String(Date.now());
+        inputRef.current.showPicker?.();
+      } catch {
+        /* showPicker may throw outside user-gesture contexts */
+      }
+    }, 50);
+  }
+
+  function handleStartTimeBlur() {
+    const val = startDateTimeRef.current?.value;
+    if (!val || !/^\d{2}:\d{2}$/.test(val)) return;
+    openPicker(endDateDateRef);
+  }
+
+  const { ref: locationNameFormRef, ...locationNameRest } = register(
+    'location.name' as const
+  );
+  const { ref: singleStartRef, ...singleStartRest } =
+    register('singleStartTime');
+  const { ref: startDateTimeFormRef, ...startDateTimeRest } =
+    register('startDateTime');
+  const { ref: endDateDateFormRef, ...endDateDateRest } =
+    register('endDateDate');
+  const { ref: endDateTimeFormRef, ...endDateTimeRest } =
+    register('endDateTime');
+
+  function handlePlaceSelect(place: PlaceResult) {
+    setValue('location', {
+      ...locationData,
+      name: place.name,
+      city: place.city || '',
+      country: place.country || '',
+      region: place.region || '',
+      latitude: place.latitude,
+      longitude: place.longitude,
+    });
+  }
+
+  useEffect(() => {
+    const subscription = watch((values, { name }) => {
+      if (name === 'singleDate' && values.oneDay) {
+        if (
+          values.singleDate &&
+          /^\d{4}-\d{2}-\d{2}$/.test(values.singleDate)
+        ) {
+          const startTime = isDateToday(values.singleDate)
+            ? getCurrentHour00()
+            : '08:00';
+          setValue('singleStartTime', startTime);
+          setValue('singleEndTime', startTime);
+          openPicker(singleStartTimeRef);
+        }
+        return;
+      }
+      if (name === 'singleStartTime' && values.oneDay) {
+        if (
+          values.singleStartTime &&
+          /^\d{2}:\d{2}$/.test(values.singleStartTime)
+        ) {
+          setValue('singleEndTime', values.singleStartTime);
+        }
+        return;
+      }
+      if (name === 'endDateDate' && !values.oneDay) {
+        if (skipEndDateShowPickerRef.current) {
+          skipEndDateShowPickerRef.current = false;
+          return;
+        }
+        if (
+          values.endDateDate &&
+          /^\d{4}-\d{2}-\d{2}$/.test(values.endDateDate)
+        ) {
+          const endTime = isDateToday(values.endDateDate)
+            ? getCurrentHour00()
+            : '08:00';
+          setValue('endDateTime', endTime);
+          openPicker(endDateTimeRef);
+        }
+        return;
+      }
+      if (name !== 'startDateDate' && name !== 'startDateTime') return;
+      if (values.oneDay) return;
+      if (
+        !values.startDateDate ||
+        !/^\d{4}-\d{2}-\d{2}$/.test(values.startDateDate)
+      )
+        return;
+      let startTime = values.startDateTime;
+      if (name === 'startDateDate') {
+        startTime = isDateToday(values.startDateDate)
+          ? getCurrentHour00()
+          : '08:00';
+        skipStartTimeChainRef.current = true;
+        setValue('startDateTime', startTime);
+        skipEndDateShowPickerRef.current = true;
+        setValue(
+          'endDateDate',
+          (() => {
+            const [y, m, d] = values.startDateDate!.split('-').map(Number);
+            const end = new Date(y, m - 1, d + 1);
+            return `${end.getFullYear()}-${String(end.getMonth() + 1).padStart(2, '0')}-${String(end.getDate()).padStart(2, '0')}`;
+          })()
+        );
+        setValue('endDateTime', startTime);
+        openPicker(startDateTimeRef);
+        return;
+      }
+      if (skipStartTimeChainRef.current) {
+        skipStartTimeChainRef.current = false;
+        return;
+      }
+      if (!startTime || !/^\d{2}:\d{2}$/.test(startTime)) return;
+      setValue('endDateTime', startTime);
+      const [year, month, day] = values.startDateDate.split('-').map(Number);
+      const d = new Date(year, month - 1, day + 1);
+      const endDate = `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, '0')}-${String(d.getDate()).padStart(2, '0')}`;
+      skipEndDateShowPickerRef.current = true;
+      setValue('endDateDate', endDate);
+    });
+    return () => subscription.unsubscribe();
+  }, [watch, setValue]);
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="space-y-6"
+      data-testid="wizard-step1"
+    >
+      <div>
+        <FormLabel>{t('planForm.title')}</FormLabel>
+        <FormInput
+          {...register('title')}
+          placeholder={t('planForm.titlePlaceholder')}
+        />
+        {errors.title && (
+          <p className="text-sm text-red-600 mt-1">{errors.title.message}</p>
+        )}
+      </div>
+
+      <div>
+        <FormLabel>{t('planForm.description')}</FormLabel>
+        <FormTextarea
+          {...register('description')}
+          placeholder={t('planForm.descriptionPlaceholder')}
+          rows={3}
+        />
+      </div>
+
+      <div className="relative">
+        <FormLabel>{t('planForm.locationLegend')}</FormLabel>
+        <FormInput
+          {...locationNameRest}
+          ref={(el) => {
+            locationNameFormRef(el);
+            locationNameRef.current = el;
+          }}
+          placeholder={t('wizard.locationPlaceholder')}
+          autoComplete="off"
+        />
+        <LocationAutocomplete
+          onPlaceSelect={handlePlaceSelect}
+          latitude={locationData?.latitude}
+          longitude={locationData?.longitude}
+          inputRef={locationNameRef}
+        />
+      </div>
+
+      <div className="space-y-4">
+        <div className="flex items-center gap-3">
+          <input
+            type="checkbox"
+            {...register('oneDay')}
+            id="wizardOneDay"
+            className="w-4 h-4 text-blue-600 rounded focus:ring-2 focus:ring-blue-500 cursor-pointer"
+          />
+          <label
+            htmlFor="wizardOneDay"
+            className="text-sm font-medium text-gray-700 cursor-pointer"
+          >
+            {t('planForm.oneDay')}
+          </label>
+        </div>
+
+        {oneDay ? (
+          <div className="grid grid-cols-2 sm:grid-cols-3 gap-3 sm:gap-4 bg-blue-50 p-3 sm:p-4 rounded-lg">
+            <div className="col-span-2 sm:col-span-1">
+              <FormLabel>{t('planForm.date')}</FormLabel>
+              <FormInput type="date" {...register('singleDate')} compact />
+              {errors.singleDate && (
+                <p className="text-sm text-red-600 mt-1">
+                  {errors.singleDate.message}
+                </p>
+              )}
+            </div>
+            <div>
+              <FormLabel>{t('planForm.startTime')}</FormLabel>
+              <FormInput
+                type="time"
+                {...singleStartRest}
+                ref={(el) => {
+                  singleStartRef(el);
+                  singleStartTimeRef.current = el;
+                }}
+                compact
+              />
+            </div>
+            <div>
+              <FormLabel>{t('planForm.endTime')}</FormLabel>
+              <FormInput type="time" {...register('singleEndTime')} compact />
+            </div>
+          </div>
+        ) : (
+          <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 bg-blue-50 p-3 sm:p-4 rounded-lg">
+            <div>
+              <FormLabel>{t('planForm.startDate')}</FormLabel>
+              <FormInput type="date" {...register('startDateDate')} compact />
+              {errors.startDateDate && (
+                <p className="text-sm text-red-600 mt-1">
+                  {errors.startDateDate.message}
+                </p>
+              )}
+            </div>
+            <div>
+              <FormLabel>{t('planForm.startTime')}</FormLabel>
+              <FormInput
+                type="time"
+                {...startDateTimeRest}
+                ref={(el) => {
+                  startDateTimeFormRef(el);
+                  startDateTimeRef.current = el;
+                }}
+                onBlur={(e) => {
+                  startDateTimeRest.onBlur(e);
+                  handleStartTimeBlur();
+                }}
+                compact
+              />
+            </div>
+            <div>
+              <FormLabel>{t('planForm.endDate')}</FormLabel>
+              <FormInput
+                type="date"
+                {...endDateDateRest}
+                ref={(el) => {
+                  endDateDateFormRef(el);
+                  endDateDateRef.current = el;
+                }}
+                compact
+              />
+              {errors.endDateDate && (
+                <p className="text-sm text-red-600 mt-1">
+                  {errors.endDateDate.message}
+                </p>
+              )}
+            </div>
+            <div>
+              <FormLabel>{t('planForm.endTime')}</FormLabel>
+              <FormInput
+                type="time"
+                {...endDateTimeRest}
+                ref={(el) => {
+                  endDateTimeFormRef(el);
+                  endDateTimeRef.current = el;
+                }}
+                compact
+              />
+            </div>
+          </div>
+        )}
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+        <div>
+          <FormLabel>{t('planForm.defaultLang')}</FormLabel>
+          <FormSelect {...register('defaultLang')}>
+            {SUPPORTED_LANGUAGES.map((code) => (
+              <option key={code} value={code}>
+                {LANGUAGE_META[code].nativeLabel}
+              </option>
+            ))}
+          </FormSelect>
+        </div>
+        <div>
+          <FormLabel>{t('planForm.currency')}</FormLabel>
+          <FormSelect {...register('currency')}>
+            {SUPPORTED_CURRENCIES.map((c) => (
+              <option key={c.code} value={c.code}>
+                {c.symbol} {c.label}
+              </option>
+            ))}
+          </FormSelect>
+        </div>
+      </div>
+
+      <div className="pt-4">
+        <button
+          type="submit"
+          className="w-full px-4 py-3 bg-blue-600 text-white text-base sm:text-lg font-semibold rounded-lg hover:bg-blue-700 active:bg-blue-800 transition-colors shadow-sm hover:shadow-md"
+        >
+          {t('wizard.next')}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function Step2Form({
+  onSubmit,
+  onBack,
+  isCreating,
+}: {
+  onSubmit: (values: Step2Values) => void;
+  onBack: () => void;
+  isCreating: boolean;
+}) {
+  const { t } = useTranslation();
+  const schema = useMemo(() => buildStep2Schema(t), [t]);
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Step2Values>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      adultsCount: 1,
+      kidsCount: undefined,
+      foodPreferences: '',
+      allergies: '',
+      notes: '',
+      estimatedAdults: undefined,
+      estimatedKids: undefined,
+    },
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="space-y-6"
+      data-testid="wizard-step2"
+    >
+      <section className="rounded-lg border border-blue-200 bg-blue-50/50 p-4 sm:p-5 space-y-4">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">
+            {t('preferences.ownerSectionTitle')}
+          </h3>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {t('preferences.ownerSectionSubtitle')}
+          </p>
+        </div>
+
+        <PreferencesFields register={register} errors={errors} compact />
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-gray-50/50 p-4 sm:p-5 space-y-4">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">
+            {t('preferences.estimationSectionTitle')}
+          </h3>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {t('preferences.estimationSectionSubtitle')}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <FormLabel>{t('preferences.estimatedAdults')}</FormLabel>
+            <FormInput
+              type="number"
+              min={0}
+              {...register('estimatedAdults')}
+              placeholder={t('preferences.estimatedAdultsPlaceholder')}
+              compact
+            />
+            {errors.estimatedAdults && (
+              <p className="text-sm text-red-600 mt-1">
+                {errors.estimatedAdults.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <FormLabel>{t('preferences.estimatedKids')}</FormLabel>
+            <FormInput
+              type="number"
+              min={0}
+              {...register('estimatedKids')}
+              placeholder={t('preferences.estimatedKidsPlaceholder')}
+              compact
+            />
+            {errors.estimatedKids && (
+              <p className="text-sm text-red-600 mt-1">
+                {errors.estimatedKids.message}
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={isCreating}
+          className="px-4 py-2.5 border border-gray-300 text-gray-700 font-semibold rounded-lg hover:bg-gray-50 active:bg-gray-100 disabled:opacity-50 transition-colors text-sm"
+        >
+          {t('wizard.back')}
+        </button>
+        <button
+          type="submit"
+          disabled={isCreating}
+          className="flex-1 px-4 py-3 bg-blue-600 text-white text-base font-semibold rounded-lg hover:bg-blue-700 active:bg-blue-800 disabled:opacity-50 disabled:cursor-not-allowed transition-colors shadow-sm"
+        >
+          {isCreating ? t('wizard.creating') : t('wizard.next')}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function Step3Items({
+  onAdd,
+  onSkip,
+  onDone,
+}: {
+  onAdd: (items: ItemCreate[]) => Promise<void>;
+  onSkip: () => void;
+  onDone: () => void;
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <div data-testid="wizard-step3">
+      <BulkItemAddWizard open={true} onClose={onDone} onAdd={onAdd} inline />
+      <div className="mt-4">
+        <button
+          type="button"
+          onClick={onSkip}
+          className="w-full px-4 py-2.5 border border-gray-300 text-gray-700 font-semibold rounded-lg hover:bg-gray-50 active:bg-gray-100 transition-colors text-sm"
+          data-testid="wizard-skip-items"
+        >
+          {t('wizard.skipItems')}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/EditPlanForm.tsx
+++ b/src/components/EditPlanForm.tsx
@@ -1,15 +1,17 @@
-import { useRef } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { v5 as uuidv5 } from 'uuid';
 import { useTranslation } from 'react-i18next';
+import clsx from 'clsx';
 
 import {
   planStatusSchema,
   type PlanWithDetails,
   type PlanPatch,
 } from '../core/schemas/plan';
+import type { Participant } from '../core/schemas/participant';
 import {
   SUPPORTED_LANGUAGES,
   SUPPORTED_CURRENCIES,
@@ -20,8 +22,11 @@ import {
 } from '../contexts/language-context';
 import { FormLabel } from './shared/FormLabel';
 import { FormInput, FormTextarea, FormSelect } from './shared/FormInput';
+import PreferencesFields from './shared/PreferencesFields';
 import LocationAutocomplete from './LocationAutocomplete';
 import type { PlaceResult } from './LocationAutocomplete';
+
+type EditStep = 1 | 2;
 
 const locationFormSchema = z
   .object({
@@ -34,7 +39,7 @@ const locationFormSchema = z
   })
   .optional();
 
-const editPlanFormSchema = z
+const step1Schema = z
   .object({
     title: z.string().min(1, 'Title is required'),
     description: z.string().optional(),
@@ -69,11 +74,53 @@ const editPlanFormSchema = z
     path: ['startDateDate'],
   });
 
-type FormValues = z.infer<typeof editPlanFormSchema>;
+type Step1Values = z.infer<typeof step1Schema>;
+
+function buildStep2Schema(t: (key: string) => string) {
+  return z.object({
+    adultsCount: z.coerce
+      .number({ invalid_type_error: t('validation.adultsCountInvalid') })
+      .int()
+      .min(1, t('validation.adultsCountMin'))
+      .optional(),
+    kidsCount: z.coerce
+      .number({ invalid_type_error: t('validation.kidsCountInvalid') })
+      .int()
+      .min(0, t('validation.kidsCountMin'))
+      .optional(),
+    foodPreferences: z.string().optional(),
+    allergies: z.string().optional(),
+    notes: z.string().optional(),
+    estimatedAdults: z.coerce
+      .number({ invalid_type_error: t('validation.adultsCountInvalid') })
+      .int()
+      .min(0, t('validation.kidsCountMin'))
+      .optional(),
+    estimatedKids: z.coerce
+      .number({ invalid_type_error: t('validation.kidsCountInvalid') })
+      .int()
+      .min(0, t('validation.kidsCountMin'))
+      .optional(),
+  });
+}
+
+type Step2Values = z.infer<ReturnType<typeof buildStep2Schema>>;
+
+export interface EditPlanSubmitPayload {
+  planPatch: PlanPatch;
+  ownerPreferences: {
+    adultsCount?: number | null;
+    kidsCount?: number | null;
+    foodPreferences?: string | null;
+    allergies?: string | null;
+    notes?: string | null;
+  };
+}
 
 interface EditPlanFormProps {
   plan: PlanWithDetails;
-  onSubmit: (updates: PlanPatch) => void | Promise<void>;
+  ownerParticipant?: Participant | null;
+  onSubmit: (payload: EditPlanSubmitPayload) => void | Promise<void>;
   onCancel: () => void;
   isSubmitting?: boolean;
 }
@@ -94,14 +141,174 @@ function isSameDate(start?: string | null, end?: string | null): boolean {
   return start.slice(0, 10) === end.slice(0, 10);
 }
 
+const UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
+
+function makeDateTime(date?: string, time?: string) {
+  if (!date) return undefined;
+  const hhmm = time || '00:00';
+  return `${date}T${hhmm}:00Z`;
+}
+
+function hasLocationData(loc?: {
+  name?: string;
+  city?: string;
+  country?: string;
+  region?: string;
+  latitude?: number | null;
+  longitude?: number | null;
+}) {
+  if (!loc) return false;
+  return (
+    [loc.name, loc.city, loc.country, loc.region].some(
+      (v) => v && v.trim().length > 0
+    ) ||
+    (loc.latitude != null && loc.longitude != null)
+  );
+}
+
+function EditStepIndicator({ currentStep }: { currentStep: EditStep }) {
+  const { t } = useTranslation();
+  const steps = [
+    { num: 1, label: t('wizard.step1Title') },
+    { num: 2, label: t('wizard.step2Title') },
+  ];
+
+  return (
+    <div className="flex items-center justify-center gap-0 mb-5">
+      {steps.map((step, i) => (
+        <div key={step.num} className="flex items-center">
+          <div className="flex flex-col items-center">
+            <div
+              className={clsx(
+                'w-7 h-7 rounded-full flex items-center justify-center text-xs font-semibold transition-colors',
+                step.num === currentStep
+                  ? 'bg-blue-600 text-white'
+                  : 'bg-gray-200 text-gray-500'
+              )}
+            >
+              {step.num}
+            </div>
+            <span
+              className={clsx(
+                'text-xs mt-1 font-medium',
+                step.num === currentStep ? 'text-blue-600' : 'text-gray-400'
+              )}
+            >
+              {step.label}
+            </span>
+          </div>
+          {i < steps.length - 1 && (
+            <div className="w-12 sm:w-16 h-0.5 mx-1 sm:mx-2 mb-5 bg-gray-200" />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
 export default function EditPlanForm({
   plan,
+  ownerParticipant,
   onSubmit,
   onCancel,
   isSubmitting = false,
 }: EditPlanFormProps) {
-  const { t } = useTranslation();
+  const [step, setStep] = useState<EditStep>(1);
+  const [step1Data, setStep1Data] = useState<Step1Values | null>(null);
 
+  function handleStep1Next(values: Step1Values) {
+    setStep1Data(values);
+    setStep(2);
+  }
+
+  async function handleStep2Submit(values: Step2Values) {
+    const s1 = step1Data;
+    if (!s1) return;
+
+    const parseTags = (csv?: string) =>
+      csv
+        ? csv
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined;
+
+    const planPatch: PlanPatch = {
+      title: s1.title,
+      description: s1.description || null,
+      status: s1.status,
+      defaultLang: s1.defaultLang ?? null,
+      currency: s1.currency ?? null,
+      startDate: s1.oneDay
+        ? makeDateTime(s1.singleDate, s1.singleStartTime)
+        : makeDateTime(s1.startDateDate, s1.startDateTime),
+      endDate: s1.oneDay
+        ? makeDateTime(s1.singleDate, s1.singleEndTime)
+        : makeDateTime(s1.endDateDate, s1.endDateTime),
+      tags: parseTags(s1.tagsCsv),
+      location: hasLocationData(s1.location)
+        ? {
+            ...s1.location,
+            locationId:
+              plan.location?.locationId ??
+              uuidv5(s1.location!.name || s1.title, UUID_NAMESPACE),
+            name: s1.location!.name || s1.title,
+          }
+        : null,
+      estimatedAdults: values.estimatedAdults ?? null,
+      estimatedKids: values.estimatedKids ?? null,
+    };
+
+    await onSubmit({
+      planPatch,
+      ownerPreferences: {
+        adultsCount: values.adultsCount ?? null,
+        kidsCount: values.kidsCount ?? null,
+        foodPreferences: values.foodPreferences || null,
+        allergies: values.allergies || null,
+        notes: values.notes || null,
+      },
+    });
+  }
+
+  return (
+    <div className="px-4 sm:px-6 pb-4 sm:pb-6">
+      <EditStepIndicator currentStep={step} />
+
+      {step === 1 && (
+        <EditStep1Form
+          plan={plan}
+          defaultValues={step1Data}
+          onNext={handleStep1Next}
+          onCancel={onCancel}
+        />
+      )}
+
+      {step === 2 && (
+        <EditStep2Form
+          plan={plan}
+          ownerParticipant={ownerParticipant}
+          onSubmit={handleStep2Submit}
+          onBack={() => setStep(1)}
+          isSubmitting={isSubmitting}
+        />
+      )}
+    </div>
+  );
+}
+
+function EditStep1Form({
+  plan,
+  defaultValues,
+  onNext,
+  onCancel,
+}: {
+  plan: PlanWithDetails;
+  defaultValues: Step1Values | null;
+  onNext: (values: Step1Values) => void;
+  onCancel: () => void;
+}) {
+  const { t } = useTranslation();
   const oneDay = isSameDate(plan.startDate, plan.endDate);
 
   const {
@@ -110,9 +317,9 @@ export default function EditPlanForm({
     formState: { errors },
     watch,
     setValue,
-  } = useForm<FormValues>({
-    resolver: zodResolver(editPlanFormSchema),
-    defaultValues: {
+  } = useForm<Step1Values>({
+    resolver: zodResolver(step1Schema),
+    defaultValues: defaultValues ?? {
       title: plan.title,
       description: plan.description ?? '',
       status: plan.status,
@@ -166,74 +373,11 @@ export default function EditPlanForm({
     });
   }
 
-  const parseTags = (csv?: string) =>
-    csv
-      ? csv
-          .split(',')
-          .map((t) => t.trim())
-          .filter(Boolean)
-      : undefined;
-
-  const makeDateTime = (date?: string, time?: string) => {
-    if (!date) return undefined;
-    const hhmm = time || '00:00';
-    return `${date}T${hhmm}:00Z`;
-  };
-
-  const UUID_NAMESPACE = '6ba7b810-9dad-11d1-80b4-00c04fd430c8';
-  const generateLocationId = (name: string) => {
-    return uuidv5(name, UUID_NAMESPACE);
-  };
-
-  const hasLocationData = (loc?: {
-    name?: string;
-    city?: string;
-    country?: string;
-    region?: string;
-    latitude?: number | null;
-    longitude?: number | null;
-  }) => {
-    if (!loc) return false;
-    return (
-      [loc.name, loc.city, loc.country, loc.region].some(
-        (v) => v && v.trim().length > 0
-      ) ||
-      (loc.latitude != null && loc.longitude != null)
-    );
-  };
-
-  async function handleFormSubmit(values: FormValues): Promise<void> {
-    const updates: PlanPatch = {
-      title: values.title,
-      description: values.description || null,
-      status: values.status,
-      defaultLang: values.defaultLang ?? null,
-      currency: values.currency ?? null,
-      startDate: values.oneDay
-        ? makeDateTime(values.singleDate, values.singleStartTime)
-        : makeDateTime(values.startDateDate, values.startDateTime),
-      endDate: values.oneDay
-        ? makeDateTime(values.singleDate, values.singleEndTime)
-        : makeDateTime(values.endDateDate, values.endDateTime),
-      tags: parseTags(values.tagsCsv),
-      location: hasLocationData(values.location)
-        ? {
-            ...values.location,
-            locationId:
-              plan.location?.locationId ??
-              generateLocationId(values.location!.name || values.title),
-            name: values.location!.name || values.title,
-          }
-        : null,
-    };
-
-    await onSubmit(updates);
-  }
-
   return (
     <form
-      onSubmit={handleSubmit(handleFormSubmit)}
-      className="px-4 sm:px-6 pb-4 sm:pb-6 space-y-5"
+      onSubmit={handleSubmit(onNext)}
+      className="space-y-5"
+      data-testid="edit-wizard-step1"
     >
       <div>
         <FormLabel>{t('planForm.title')}</FormLabel>
@@ -255,91 +399,24 @@ export default function EditPlanForm({
         />
       </div>
 
-      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
-        <div>
-          <FormLabel>{t('planForm.status')}</FormLabel>
-          <FormSelect {...register('status')}>
-            <option value="active">{t('planStatus.active')}</option>
-            <option value="draft">{t('planStatus.draft')}</option>
-            <option value="archived">{t('planStatus.archived')}</option>
-          </FormSelect>
-        </div>
-
-        <div>
-          <FormLabel>{t('planForm.defaultLang')}</FormLabel>
-          <FormSelect {...register('defaultLang')}>
-            {SUPPORTED_LANGUAGES.map((code) => (
-              <option key={code} value={code}>
-                {LANGUAGE_META[code].nativeLabel}
-              </option>
-            ))}
-          </FormSelect>
-        </div>
-
-        <div>
-          <FormLabel>{t('planForm.currency')}</FormLabel>
-          <FormSelect {...register('currency')}>
-            {SUPPORTED_CURRENCIES.map((c) => (
-              <option key={c.code} value={c.code}>
-                {c.symbol} {c.label}
-              </option>
-            ))}
-          </FormSelect>
-        </div>
+      <div className="relative">
+        <FormLabel>{t('planForm.locationLegend')}</FormLabel>
+        <FormInput
+          {...locationNameRest}
+          ref={(el) => {
+            locationNameFormRef(el);
+            locationNameRef.current = el;
+          }}
+          placeholder={t('wizard.locationPlaceholder')}
+          autoComplete="off"
+        />
+        <LocationAutocomplete
+          onPlaceSelect={handlePlaceSelect}
+          latitude={locationData?.latitude}
+          longitude={locationData?.longitude}
+          inputRef={locationNameRef}
+        />
       </div>
-
-      <fieldset className="border border-gray-200 rounded-lg p-4 sm:p-5">
-        <legend className="text-sm font-semibold text-gray-700 px-2 mb-3">
-          {t('planForm.locationLegend')}
-        </legend>
-        <div className="space-y-4">
-          <div className="relative">
-            <FormLabel>{t('planForm.locationName')}</FormLabel>
-            <FormInput
-              {...locationNameRest}
-              ref={(el) => {
-                locationNameFormRef(el);
-                locationNameRef.current = el;
-              }}
-              placeholder={t('planForm.locationNamePlaceholder')}
-              compact
-              autoComplete="off"
-            />
-            <LocationAutocomplete
-              onPlaceSelect={handlePlaceSelect}
-              latitude={locationData?.latitude}
-              longitude={locationData?.longitude}
-              inputRef={locationNameRef}
-            />
-          </div>
-          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-            <div>
-              <FormLabel>{t('planForm.city')}</FormLabel>
-              <FormInput
-                {...register('location.city' as const)}
-                placeholder={t('planForm.cityPlaceholder')}
-                compact
-              />
-            </div>
-            <div>
-              <FormLabel>{t('planForm.country')}</FormLabel>
-              <FormInput
-                {...register('location.country' as const)}
-                placeholder={t('planForm.countryPlaceholder')}
-                compact
-              />
-            </div>
-          </div>
-          <div>
-            <FormLabel>{t('planForm.region')}</FormLabel>
-            <FormInput
-              {...register('location.region' as const)}
-              placeholder={t('planForm.regionPlaceholder')}
-              compact
-            />
-          </div>
-        </div>
-      </fieldset>
 
       <div className="space-y-4">
         <div className="flex items-center gap-3">
@@ -404,6 +481,37 @@ export default function EditPlanForm({
         )}
       </div>
 
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <div>
+          <FormLabel>{t('planForm.status')}</FormLabel>
+          <FormSelect {...register('status')}>
+            <option value="active">{t('planStatus.active')}</option>
+            <option value="draft">{t('planStatus.draft')}</option>
+            <option value="archived">{t('planStatus.archived')}</option>
+          </FormSelect>
+        </div>
+        <div>
+          <FormLabel>{t('planForm.defaultLang')}</FormLabel>
+          <FormSelect {...register('defaultLang')}>
+            {SUPPORTED_LANGUAGES.map((code) => (
+              <option key={code} value={code}>
+                {LANGUAGE_META[code].nativeLabel}
+              </option>
+            ))}
+          </FormSelect>
+        </div>
+        <div>
+          <FormLabel>{t('planForm.currency')}</FormLabel>
+          <FormSelect {...register('currency')}>
+            {SUPPORTED_CURRENCIES.map((c) => (
+              <option key={c.code} value={c.code}>
+                {c.symbol} {c.label}
+              </option>
+            ))}
+          </FormSelect>
+        </div>
+      </div>
+
       <div>
         <FormLabel>{t('planForm.tags')}</FormLabel>
         <FormInput
@@ -416,9 +524,125 @@ export default function EditPlanForm({
         <button
           type="button"
           onClick={onCancel}
-          className="flex-1 px-4 py-2.5 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 active:bg-gray-100 transition-colors font-medium"
+          className="px-4 py-2.5 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 active:bg-gray-100 transition-colors font-medium text-sm"
         >
           {t('items.cancel')}
+        </button>
+        <button
+          type="submit"
+          className="flex-1 px-4 py-2.5 bg-blue-600 text-white font-semibold rounded-lg hover:bg-blue-700 active:bg-blue-800 transition-colors"
+        >
+          {t('wizard.next')}
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function EditStep2Form({
+  plan,
+  ownerParticipant,
+  onSubmit,
+  onBack,
+  isSubmitting,
+}: {
+  plan: PlanWithDetails;
+  ownerParticipant?: Participant | null;
+  onSubmit: (values: Step2Values) => void | Promise<void>;
+  onBack: () => void;
+  isSubmitting: boolean;
+}) {
+  const { t } = useTranslation();
+  const schema = useMemo(() => buildStep2Schema(t), [t]);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<Step2Values>({
+    resolver: zodResolver(schema),
+    defaultValues: {
+      adultsCount: ownerParticipant?.adultsCount ?? 1,
+      kidsCount: ownerParticipant?.kidsCount ?? undefined,
+      foodPreferences: ownerParticipant?.foodPreferences ?? '',
+      allergies: ownerParticipant?.allergies ?? '',
+      notes: ownerParticipant?.notes ?? '',
+      estimatedAdults: plan.estimatedAdults ?? undefined,
+      estimatedKids: plan.estimatedKids ?? undefined,
+    },
+  });
+
+  return (
+    <form
+      onSubmit={handleSubmit(onSubmit)}
+      className="space-y-5"
+      data-testid="edit-wizard-step2"
+    >
+      <section className="rounded-lg border border-blue-200 bg-blue-50/50 p-4 sm:p-5 space-y-4">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">
+            {t('preferences.ownerSectionTitle')}
+          </h3>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {t('preferences.ownerSectionSubtitle')}
+          </p>
+        </div>
+
+        <PreferencesFields register={register} errors={errors} compact />
+      </section>
+
+      <section className="rounded-lg border border-gray-200 bg-gray-50/50 p-4 sm:p-5 space-y-4">
+        <div>
+          <h3 className="text-base font-semibold text-gray-900">
+            {t('preferences.estimationSectionTitle')}
+          </h3>
+          <p className="text-sm text-gray-500 mt-0.5">
+            {t('preferences.estimationSectionSubtitle')}
+          </p>
+        </div>
+
+        <div className="grid grid-cols-2 gap-3">
+          <div>
+            <FormLabel>{t('preferences.estimatedAdults')}</FormLabel>
+            <FormInput
+              type="number"
+              min={0}
+              {...register('estimatedAdults')}
+              placeholder={t('preferences.estimatedAdultsPlaceholder')}
+              compact
+            />
+            {errors.estimatedAdults && (
+              <p className="text-sm text-red-600 mt-1">
+                {errors.estimatedAdults.message}
+              </p>
+            )}
+          </div>
+          <div>
+            <FormLabel>{t('preferences.estimatedKids')}</FormLabel>
+            <FormInput
+              type="number"
+              min={0}
+              {...register('estimatedKids')}
+              placeholder={t('preferences.estimatedKidsPlaceholder')}
+              compact
+            />
+            {errors.estimatedKids && (
+              <p className="text-sm text-red-600 mt-1">
+                {errors.estimatedKids.message}
+              </p>
+            )}
+          </div>
+        </div>
+      </section>
+
+      <div className="flex gap-3 pt-2">
+        <button
+          type="button"
+          onClick={onBack}
+          disabled={isSubmitting}
+          className="px-4 py-2.5 border border-gray-300 text-gray-700 font-semibold rounded-lg hover:bg-gray-50 active:bg-gray-100 disabled:opacity-50 transition-colors text-sm"
+        >
+          {t('wizard.back')}
         </button>
         <button
           type="submit"

--- a/src/core/api.generated.ts
+++ b/src/core/api.generated.ts
@@ -2854,6 +2854,10 @@ export interface components {
       defaultLang?: string | null;
       /** @description ISO 4217 currency code (e.g. USD, EUR, ILS) */
       currency?: string | null;
+      /** @description Estimated number of adult participants for this plan */
+      estimatedAdults?: number | null;
+      /** @description Estimated number of child participants for this plan */
+      estimatedKids?: number | null;
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */
@@ -2899,6 +2903,10 @@ export interface components {
       defaultLang?: string;
       /** @description ISO 4217 currency code (e.g. USD, EUR, ILS) */
       currency?: string;
+      /** @description Estimated number of adult participants for this plan */
+      estimatedAdults?: number;
+      /** @description Estimated number of child participants for this plan */
+      estimatedKids?: number;
       owner: components['schemas']['def-9'];
       participants?: components['schemas']['def-21'][];
     };
@@ -2920,6 +2928,10 @@ export interface components {
       defaultLang?: string | null;
       /** @description ISO 4217 currency code (e.g. USD, EUR, ILS). Send null to clear. */
       currency?: string | null;
+      /** @description Estimated number of adult participants. Send null to clear. */
+      estimatedAdults?: number | null;
+      /** @description Estimated number of child participants. Send null to clear. */
+      estimatedKids?: number | null;
     };
     /** PlanIdParam */
     'def-12': {
@@ -3142,6 +3154,10 @@ export interface components {
       defaultLang?: string | null;
       /** @description ISO 4217 currency code (e.g. USD, EUR, ILS) */
       currency?: string | null;
+      /** @description Estimated number of adult participants for this plan */
+      estimatedAdults?: number | null;
+      /** @description Estimated number of child participants for this plan */
+      estimatedKids?: number | null;
       /** Format: date-time */
       createdAt: string;
       /** Format: date-time */

--- a/src/core/schemas/plan.ts
+++ b/src/core/schemas/plan.ts
@@ -45,6 +45,8 @@ export const planSchema = z.object({
   tags: z.array(z.string()).nullish(),
   defaultLang: z.string().nullish(),
   currency: z.string().nullish(),
+  estimatedAdults: z.number().int().nullish(),
+  estimatedKids: z.number().int().nullish(),
   participantIds: z.array(z.string()).nullish(),
   participants: z.array(participantSummarySchema).nullish(),
   createdAt: z.string(),
@@ -80,6 +82,8 @@ export const planCreateWithOwnerSchema = z.object({
   tags: z.array(z.string()).nullish(),
   defaultLang: z.string().max(10).optional(),
   currency: z.string().max(10).optional(),
+  estimatedAdults: z.number().int().min(0).optional(),
+  estimatedKids: z.number().int().min(0).optional(),
   owner: ownerBodySchema,
   participants: z.array(participantCreateSchema).optional(),
 });
@@ -95,6 +99,8 @@ export const planPatchSchema = z.object({
   tags: z.array(z.string()).nullish(),
   defaultLang: z.string().max(10).nullish(),
   currency: z.string().max(10).nullish(),
+  estimatedAdults: z.number().int().min(0).nullish(),
+  estimatedKids: z.number().int().min(0).nullish(),
 });
 
 export const planPreviewSchema = z.object({

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -118,7 +118,15 @@
     "deleteCancel": "Cancel",
     "deleted": "Plan deleted",
     "deleting": "Deleting…",
-    "planDetails": "Plan Details"
+    "planDetails": "Plan Details",
+    "headcount": "Headcount",
+    "reportedAdults": "Reported Adults",
+    "reportedKids": "Reported Kids",
+    "estimatedAdults": "Estimated Adults",
+    "estimatedKids": "Estimated Kids",
+    "reported": "Reported",
+    "estimated": "Estimated",
+    "notSet": "Not set"
   },
   "addParticipant": {
     "firstName": "First Name *",
@@ -443,7 +451,15 @@
     "submit": "Save Preferences",
     "skip": "Skip for now",
     "updated": "Preferences saved",
-    "rsvpLabel": "Are you coming?"
+    "rsvpLabel": "Are you coming?",
+    "ownerSectionTitle": "Your Group",
+    "ownerSectionSubtitle": "How many people are coming with you?",
+    "estimationSectionTitle": "Other Participants",
+    "estimationSectionSubtitle": "Estimate how many others will join — helps plan the right amounts.",
+    "estimatedAdults": "Estimated adults",
+    "estimatedAdultsPlaceholder": "0",
+    "estimatedKids": "Estimated kids",
+    "estimatedKidsPlaceholder": "0"
   },
   "manageParticipants": {
     "title": "Manage Participants",
@@ -582,6 +598,16 @@
     "expenseListTitle": "All Expenses",
     "amountCopied": "Amount copied!",
     "copyTransfer": "\u200E\u2068{{from}}\u2069 pays \u2068{{to}}\u2069: \u2068{{amount}} {{currency}}\u2069"
+  },
+  "wizard": {
+    "step1Title": "Plan Details",
+    "step2Title": "Preferences",
+    "step3Title": "Add Items",
+    "next": "Next",
+    "back": "Back",
+    "creating": "Creating plan…",
+    "skipItems": "Skip — go to plan",
+    "locationPlaceholder": "Search for a place…"
   },
   "admin": {
     "plansTitle": "Admin — All Plans",

--- a/src/i18n/locales/he.json
+++ b/src/i18n/locales/he.json
@@ -118,7 +118,15 @@
     "deleteCancel": "ביטול",
     "deleted": "התוכנית נמחקה",
     "deleting": "מוחק…",
-    "planDetails": "פרטי תוכנית"
+    "planDetails": "פרטי תוכנית",
+    "headcount": "ספירת משתתפים",
+    "reportedAdults": "מבוגרים מדווחים",
+    "reportedKids": "ילדים מדווחים",
+    "estimatedAdults": "מבוגרים משוערים",
+    "estimatedKids": "ילדים משוערים",
+    "reported": "מדווח",
+    "estimated": "משוער",
+    "notSet": "לא הוגדר"
   },
   "addParticipant": {
     "firstName": "שם פרטי *",
@@ -443,7 +451,15 @@
     "submit": "שמירת העדפות",
     "skip": "דלג לעת עתה",
     "updated": "ההעדפות נשמרו",
-    "rsvpLabel": "מגיעים?"
+    "rsvpLabel": "מגיעים?",
+    "ownerSectionTitle": "הקבוצה שלך",
+    "ownerSectionSubtitle": "כמה אנשים מגיעים איתך?",
+    "estimationSectionTitle": "משתתפים נוספים",
+    "estimationSectionSubtitle": "הערכה של כמה אנשים נוספים יצטרפו — עוזר לתכנן כמויות.",
+    "estimatedAdults": "מבוגרים משוערים",
+    "estimatedAdultsPlaceholder": "0",
+    "estimatedKids": "ילדים משוערים",
+    "estimatedKidsPlaceholder": "0"
   },
   "manageParticipants": {
     "title": "ניהול משתתפים",
@@ -582,6 +598,16 @@
     "expenseListTitle": "כל ההוצאות",
     "amountCopied": "הסכום הועתק!",
     "copyTransfer": "\u200F\u2068{{from}}\u2069 משלם ל\u2068{{to}}\u2069: \u2068{{amount}} {{currency}}\u2069"
+  },
+  "wizard": {
+    "step1Title": "פרטי תוכנית",
+    "step2Title": "העדפות",
+    "step3Title": "הוספת פריטים",
+    "next": "הבא",
+    "back": "חזרה",
+    "creating": "יוצר תוכנית…",
+    "skipItems": "דלג — עבור לתוכנית",
+    "locationPlaceholder": "חפש מקום…"
   },
   "admin": {
     "plansTitle": "מנהל — כל התוכניות",

--- a/src/routes/create-plan.tsx
+++ b/src/routes/create-plan.tsx
@@ -1,20 +1,7 @@
-import { useMemo, useState } from 'react';
-import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
-import { useTranslation } from 'react-i18next';
-import toast from 'react-hot-toast';
-import PlanForm from '../components/PlanForm';
-import PreferencesForm, {
-  type PreferencesFormValues,
-} from '../components/PreferencesForm';
-import Modal from '../components/shared/Modal';
-import { useCreatePlan } from '../hooks/useCreatePlan';
-import { useUpdateParticipant } from '../hooks/useUpdateParticipant';
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import CreatePlanWizard from '../components/CreatePlanWizard';
 import { useAuth } from '../contexts/useAuth';
-import { getApiErrorMessage } from '../core/error-utils';
-import { splitFullName } from '../core/profile-utils';
 import { supabase } from '../lib/supabase';
-import type { PlanFormPayload, DefaultOwner } from '../components/PlanForm';
-import type { PlanWithDetails } from '../core/schemas/plan';
 
 export const Route = createFileRoute('/create-plan')({
   component: CreatePlan,
@@ -29,72 +16,7 @@ export const Route = createFileRoute('/create-plan')({
 });
 
 export function CreatePlan() {
-  const { t } = useTranslation();
-  const navigate = useNavigate();
-  const createPlan = useCreatePlan();
   const { user, loading } = useAuth();
-  const [createdPlan, setCreatedPlan] = useState<PlanWithDetails | null>(null);
-
-  const ownerParticipantId = createdPlan?.participants.find(
-    (p) => p.role === 'owner'
-  )?.participantId;
-
-  const updateParticipant = useUpdateParticipant(createdPlan?.planId ?? '');
-
-  const defaultOwner = useMemo((): DefaultOwner | undefined => {
-    if (!user) return undefined;
-    const meta = user.user_metadata ?? {};
-    const { first, last } = splitFullName(meta.full_name as string);
-    return {
-      ownerName: (meta.first_name as string) || first,
-      ownerLastName: (meta.last_name as string) || last,
-      ownerPhone: (meta.phone as string) || '',
-      ownerEmail: user.email ?? '',
-    };
-  }, [user]);
-
-  function navigateToPlan() {
-    if (createdPlan?.planId) {
-      navigate({ to: '/plan/$planId', params: { planId: createdPlan.planId } });
-    } else {
-      navigate({ to: '/plans' });
-    }
-  }
-
-  async function handleSubmit(payload: PlanFormPayload) {
-    const created = await createPlan.mutateAsync(payload);
-    if (created?.planId) {
-      setCreatedPlan(created);
-    } else {
-      navigate({ to: '/plans' });
-    }
-  }
-
-  async function handlePreferencesSubmit(values: PreferencesFormValues) {
-    if (!ownerParticipantId) {
-      navigateToPlan();
-      return;
-    }
-    try {
-      await updateParticipant.mutateAsync({
-        participantId: ownerParticipantId,
-        updates: {
-          adultsCount: values.adultsCount ?? null,
-          kidsCount: values.kidsCount ?? null,
-          foodPreferences: values.foodPreferences || null,
-          allergies: values.allergies || null,
-          notes: values.notes || null,
-        },
-      });
-      toast.success(t('preferences.updated'));
-    } catch (err) {
-      const { title, message } = getApiErrorMessage(
-        err instanceof Error ? err : new Error(String(err))
-      );
-      toast.error(`${title}: ${message}`);
-    }
-    navigateToPlan();
-  }
 
   if (loading) {
     return (
@@ -104,26 +26,5 @@ export function CreatePlan() {
     );
   }
 
-  return (
-    <>
-      <PlanForm
-        onSubmit={handleSubmit}
-        isSubmitting={createPlan.isPending}
-        defaultOwner={defaultOwner}
-      />
-
-      <Modal
-        open={!!createdPlan}
-        onClose={navigateToPlan}
-        title={t('preferences.title')}
-      >
-        <PreferencesForm
-          onSubmit={handlePreferencesSubmit}
-          onSkip={navigateToPlan}
-          isSubmitting={updateParticipant.isPending}
-          inModal
-        />
-      </Modal>
-    </>
-  );
+  return <CreatePlanWizard user={user} />;
 }

--- a/src/routes/plan.$planId.lazy.tsx
+++ b/src/routes/plan.$planId.lazy.tsx
@@ -202,10 +202,30 @@ function PlanPage() {
   }
 
   async function handleEditPlan(
-    updates: import('../core/schemas/plan').PlanPatch
+    payload: import('../components/EditPlanForm').EditPlanSubmitPayload
   ) {
-    const success = await actions.updatePlanDetails(updates);
-    if (success) setShowEditPlanModal(false);
+    const success = await actions.updatePlanDetails(payload.planPatch);
+    if (!success) return;
+
+    if (!plan || isNotParticipantResponse(plan)) {
+      setShowEditPlanModal(false);
+      return;
+    }
+
+    const ownerId = plan.participants.find(
+      (p: { role: string }) => p.role === 'owner'
+    )?.participantId;
+    if (ownerId) {
+      await actions.updateParticipantPreferences(ownerId, {
+        adultsCount: payload.ownerPreferences.adultsCount ?? undefined,
+        kidsCount: payload.ownerPreferences.kidsCount ?? undefined,
+        foodPreferences: payload.ownerPreferences.foodPreferences ?? undefined,
+        allergies: payload.ownerPreferences.allergies ?? undefined,
+        notes: payload.ownerPreferences.notes ?? undefined,
+      });
+    }
+
+    setShowEditPlanModal(false);
   }
 
   async function handleTransferOwnership() {
@@ -327,6 +347,69 @@ function PlanPage() {
               isDeleting={actions.isDeletingPlan}
             />
           </CollapsibleSection>
+
+          <div
+            data-testid="headcount-section"
+            className="mt-4 sm:mt-6 bg-white rounded-xl shadow-sm p-4 sm:p-6"
+          >
+            <h2 className="text-base font-semibold text-gray-800 mb-3">
+              {t('plan.headcount')}
+            </h2>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div className="rounded-lg border border-blue-200 bg-blue-50/50 p-3">
+                <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+                  {t('plan.reported')}
+                </p>
+                <div className="flex gap-4">
+                  <div>
+                    <p className="text-2xl font-bold text-gray-900">
+                      {totalAdults}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {t('plan.reportedAdults')}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-2xl font-bold text-gray-900">
+                      {totalKids}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {t('plan.reportedKids')}
+                    </p>
+                  </div>
+                </div>
+              </div>
+
+              <div className="rounded-lg border border-gray-200 bg-gray-50/50 p-3">
+                <p className="text-xs font-medium text-gray-500 uppercase tracking-wider mb-2">
+                  {t('plan.estimated')}
+                </p>
+                <div className="flex gap-4">
+                  <div>
+                    <p className="text-2xl font-bold text-gray-900">
+                      {plan.estimatedAdults ?? (
+                        <span className="text-gray-400">—</span>
+                      )}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {t('plan.estimatedAdults')}
+                    </p>
+                  </div>
+                  <div>
+                    <p className="text-2xl font-bold text-gray-900">
+                      {plan.estimatedKids ?? (
+                        <span className="text-gray-400">—</span>
+                      )}
+                    </p>
+                    <p className="text-xs text-gray-500">
+                      {t('plan.estimatedKids')}
+                    </p>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
 
           <div className="mt-4 sm:mt-6">
             <Forecast
@@ -580,6 +663,9 @@ function PlanPage() {
             <EditPlanForm
               key={showEditPlanModal ? 'open' : 'closed'}
               plan={plan}
+              ownerParticipant={
+                plan.participants.find((p) => p.role === 'owner') ?? null
+              }
               onSubmit={handleEditPlan}
               onCancel={() => setShowEditPlanModal(false)}
               isSubmitting={actions.isUpdatingPlan}

--- a/tests/e2e/main-flow.spec.ts
+++ b/tests/e2e/main-flow.spec.ts
@@ -114,16 +114,17 @@ test.describe('Plan creation via UI', () => {
       .getByPlaceholder('Add details about your plan')
       .fill('Automated test plan');
 
-    await page.getByPlaceholder('First name').first().fill('Alex');
-    await page.getByPlaceholder('Last name').first().fill('Test');
-    await page.getByPlaceholder('Phone number').first().fill('555-0100');
-
     await page.getByLabel('One-day plan').check();
     await page.locator('input[type="date"]').fill('2026-07-15');
 
-    await page.getByRole('button', { name: /create plan/i }).click();
+    await page.getByRole('button', { name: /^next$/i }).click();
 
-    const skipBtn = page.getByRole('button', { name: /skip for now/i });
+    await expect(page.getByTestId('wizard-step2')).toBeVisible({
+      timeout: 10000,
+    });
+    await page.getByRole('button', { name: /^next$/i }).click();
+
+    const skipBtn = page.getByTestId('wizard-skip-items');
     await expect(skipBtn).toBeVisible({ timeout: 15000 });
     await skipBtn.scrollIntoViewIfNeeded();
     await skipBtn.click({ force: isMobile });
@@ -135,7 +136,7 @@ test.describe('Plan creation via UI', () => {
         timeout: 10000,
       }
     );
-    await expect(page.getByText('Alex Test').first()).toBeVisible();
+    await expect(page.getByText('Regular User').first()).toBeVisible();
   });
 });
 
@@ -307,21 +308,26 @@ test.describe('Edit Plan', () => {
     await expect(editBtn).toBeVisible();
     await editBtn.click();
 
-    const editForm = page.locator('form').last();
-    await expect(editForm).toBeVisible();
+    const step1Form = page.getByTestId('edit-wizard-step1');
+    await expect(step1Form).toBeVisible();
 
-    const titleInput = editForm.getByPlaceholder('Enter plan title');
+    const titleInput = step1Form.getByPlaceholder('Enter plan title');
     await expect(titleInput).toHaveValue('Original Trip Name');
     await titleInput.clear();
     await titleInput.fill('Updated Trip Name');
 
-    const submitBtn = editForm.getByRole('button', { name: /update plan/i });
+    await step1Form.getByRole('button', { name: /^next$/i }).click();
+
+    const step2Form = page.getByTestId('edit-wizard-step2');
+    await expect(step2Form).toBeVisible({ timeout: 5000 });
+
+    const submitBtn = step2Form.getByRole('button', { name: /update plan/i });
     await expect(submitBtn).toBeVisible();
     await Promise.all([
       page.waitForResponse((r) => r.request().method() === 'PATCH'),
       submitBtn.click(),
     ]);
-    await expect(editForm).toBeHidden({ timeout: 10000 });
+    await expect(step2Form).toBeHidden({ timeout: 10000 });
 
     await expect(page.getByTestId('plan-title')).toHaveText(
       'Updated Trip Name',

--- a/tests/unit/components/EditPlanForm.test.tsx
+++ b/tests/unit/components/EditPlanForm.test.tsx
@@ -2,13 +2,38 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import EditPlanForm from '../../../src/components/EditPlanForm';
+import type { EditPlanSubmitPayload } from '../../../src/components/EditPlanForm';
 import type { PlanWithDetails } from '../../../src/core/schemas/plan';
+import type { Participant } from '../../../src/core/schemas/participant';
 
 vi.mock('uuid', () => ({
   v5: vi.fn(
     (name: string) => `uuid-${name.toLowerCase().replace(/\s+/g, '-')}`
   ),
 }));
+
+const ownerParticipant: Participant = {
+  participantId: 'p-1',
+  planId: 'plan-1',
+  userId: 'user-1',
+  name: 'Alice',
+  lastName: 'Owner',
+  contactPhone: '555-0001',
+  displayName: null,
+  role: 'owner',
+  avatarUrl: null,
+  contactEmail: null,
+  inviteToken: null,
+  rsvpStatus: 'confirmed',
+  lastActivityAt: null,
+  adultsCount: 2,
+  kidsCount: 1,
+  foodPreferences: 'vegetarian',
+  allergies: 'nuts',
+  notes: 'no spicy food',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
 
 function buildTestPlan(overrides?: Partial<PlanWithDetails>): PlanWithDetails {
   return {
@@ -33,30 +58,7 @@ function buildTestPlan(overrides?: Partial<PlanWithDetails>): PlanWithDetails {
       longitude: 151.27,
     },
     items: [],
-    participants: [
-      {
-        participantId: 'p-1',
-        planId: 'plan-1',
-        userId: 'user-1',
-        name: 'Alice',
-        lastName: 'Owner',
-        contactPhone: '555-0001',
-        displayName: null,
-        role: 'owner',
-        avatarUrl: null,
-        contactEmail: null,
-        inviteToken: null,
-        rsvpStatus: 'confirmed',
-        lastActivityAt: null,
-        adultsCount: null,
-        kidsCount: null,
-        foodPreferences: null,
-        allergies: null,
-        notes: null,
-        createdAt: '2026-01-01T00:00:00Z',
-        updatedAt: '2026-01-01T00:00:00Z',
-      },
-    ],
+    participants: [ownerParticipant],
     ...overrides,
   };
 }
@@ -72,9 +74,13 @@ describe('EditPlanForm', () => {
   });
 
   function renderForm(plan?: PlanWithDetails, isSubmitting = false) {
+    const p = plan ?? buildTestPlan();
     return render(
       <EditPlanForm
-        plan={plan ?? buildTestPlan()}
+        plan={p}
+        ownerParticipant={
+          p.participants.find((pt) => pt.role === 'owner') ?? null
+        }
         onSubmit={handleSubmit}
         onCancel={handleCancel}
         isSubmitting={isSubmitting}
@@ -82,133 +88,200 @@ describe('EditPlanForm', () => {
     );
   }
 
-  it('pre-fills form fields from the plan', () => {
-    renderForm();
+  describe('Step 1 — Plan Details', () => {
+    it('pre-fills form fields from the plan', () => {
+      renderForm();
 
-    const titleInput = screen.getByPlaceholderText(/enter plan title/i);
-    expect(titleInput).toHaveValue('Beach Trip');
-
-    const descriptionInput = screen.getByPlaceholderText(
-      /add details about your plan/i
-    );
-    expect(descriptionInput).toHaveValue('A fun day at the beach');
-
-    const tagsInput = screen.getByPlaceholderText(/e\.g\. picnic/i);
-    expect(tagsInput).toHaveValue('beach, summer');
-  });
-
-  it('pre-fills location fields from the plan', () => {
-    renderForm();
-
-    const locationName = screen.getByPlaceholderText(/location name/i);
-    expect(locationName).toHaveValue('Bondi Beach');
-
-    const cityInput = screen.getByPlaceholderText('City');
-    expect(cityInput).toHaveValue('Sydney');
-
-    const countryInput = screen.getByPlaceholderText('Country');
-    expect(countryInput).toHaveValue('Australia');
-  });
-
-  it('shows multi-day date fields when start and end dates differ', () => {
-    renderForm();
-
-    expect(screen.getByText(/start date/i)).toBeInTheDocument();
-    expect(screen.getByText(/end date/i)).toBeInTheDocument();
-  });
-
-  it('shows one-day date fields when start and end dates are the same', () => {
-    const plan = buildTestPlan({
-      startDate: '2026-07-10T09:00:00Z',
-      endDate: '2026-07-10T18:00:00Z',
-    });
-    renderForm(plan);
-
-    expect(screen.getByRole('checkbox', { name: /one-day/i })).toBeChecked();
-  });
-
-  it('shows validation error when title is cleared', async () => {
-    const user = userEvent.setup();
-    renderForm();
-
-    const titleInput = screen.getByPlaceholderText(/enter plan title/i);
-    await user.clear(titleInput);
-
-    const submitButton = screen.getByRole('button', {
-      name: /update plan/i,
-    });
-    await user.click(submitButton);
-
-    await waitFor(() => {
-      expect(screen.getByText(/title is required/i)).toBeInTheDocument();
-    });
-    expect(handleSubmit).not.toHaveBeenCalled();
-  });
-
-  it('calls onSubmit with PlanPatch payload on valid submission', async () => {
-    const user = userEvent.setup();
-    renderForm();
-
-    const titleInput = screen.getByPlaceholderText(/enter plan title/i);
-    await user.clear(titleInput);
-    await user.type(titleInput, 'Updated Beach Trip');
-
-    const submitButton = screen.getByRole('button', {
-      name: /update plan/i,
-    });
-    await user.click(submitButton);
-
-    await waitFor(() => {
-      expect(handleSubmit).toHaveBeenCalledTimes(1);
+      expect(screen.getByTestId('edit-wizard-step1')).toBeInTheDocument();
+      expect(screen.getByPlaceholderText(/enter plan title/i)).toHaveValue(
+        'Beach Trip'
+      );
+      expect(
+        screen.getByPlaceholderText(/add details about your plan/i)
+      ).toHaveValue('A fun day at the beach');
+      expect(screen.getByPlaceholderText(/e\.g\. picnic/i)).toHaveValue(
+        'beach, summer'
+      );
     });
 
-    const payload = handleSubmit.mock.calls[0][0];
-    expect(payload.title).toBe('Updated Beach Trip');
-    expect(payload.description).toBe('A fun day at the beach');
-    expect(payload.status).toBe('active');
-    expect(payload.tags).toEqual(['beach', 'summer']);
+    it('pre-fills location name from the plan', () => {
+      renderForm();
+
+      const locationInput = screen.getByPlaceholderText(/search for a place/i);
+      expect(locationInput).toHaveValue('Bondi Beach');
+    });
+
+    it('shows multi-day date fields when start and end dates differ', () => {
+      renderForm();
+
+      expect(screen.getByText(/start date/i)).toBeInTheDocument();
+      expect(screen.getByText(/end date/i)).toBeInTheDocument();
+    });
+
+    it('shows one-day date fields when start and end dates are the same', () => {
+      const plan = buildTestPlan({
+        startDate: '2026-07-10T09:00:00Z',
+        endDate: '2026-07-10T18:00:00Z',
+      });
+      renderForm(plan);
+
+      expect(screen.getByRole('checkbox', { name: /one-day/i })).toBeChecked();
+    });
+
+    it('shows validation error when title is cleared', async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      const titleInput = screen.getByPlaceholderText(/enter plan title/i);
+      await user.clear(titleInput);
+
+      await user.click(screen.getByRole('button', { name: /next/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/title is required/i)).toBeInTheDocument();
+      });
+    });
+
+    it('handles plan with no location', () => {
+      const plan = buildTestPlan({ location: null });
+      renderForm(plan);
+
+      const locationInput = screen.getByPlaceholderText(/search for a place/i);
+      expect(locationInput).toHaveValue('');
+    });
+
+    it('handles plan with no tags', () => {
+      const plan = buildTestPlan({ tags: null });
+      renderForm(plan);
+
+      expect(screen.getByPlaceholderText(/e\.g\. picnic/i)).toHaveValue('');
+    });
+
+    it('handles plan with no dates', () => {
+      const plan = buildTestPlan({ startDate: null, endDate: null });
+      renderForm(plan);
+
+      expect(screen.getByText(/start date/i)).toBeInTheDocument();
+    });
+
+    it('calls onCancel when cancel button is clicked', async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.click(screen.getByRole('button', { name: /cancel/i }));
+      expect(handleCancel).toHaveBeenCalledTimes(1);
+    });
   });
 
-  it('shows updating state on submit button', () => {
-    renderForm(undefined, true);
+  describe('Step navigation', () => {
+    it('navigates to step 2 when Next is clicked with valid data', async () => {
+      const user = userEvent.setup();
+      renderForm();
 
-    expect(screen.getByRole('button', { name: /updating/i })).toBeDisabled();
+      await user.click(screen.getByRole('button', { name: /next/i }));
+
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-wizard-step2')).toBeInTheDocument();
+      });
+    });
+
+    it('navigates back to step 1 when Back is clicked on step 2', async () => {
+      const user = userEvent.setup();
+      renderForm();
+
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-wizard-step2')).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole('button', { name: /back/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-wizard-step1')).toBeInTheDocument();
+      });
+    });
   });
 
-  it('shows Update Plan on submit button when not submitting', () => {
-    renderForm();
+  describe('Step 2 — Owner Preferences', () => {
+    async function goToStep2() {
+      const user = userEvent.setup();
+      renderForm();
+      await user.click(screen.getByRole('button', { name: /next/i }));
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-wizard-step2')).toBeInTheDocument();
+      });
+      return user;
+    }
 
-    expect(screen.getByRole('button', { name: /update plan/i })).toBeEnabled();
+    it('pre-fills owner preferences from the owner participant', async () => {
+      await goToStep2();
+
+      expect(screen.getByText(/your group/i)).toBeInTheDocument();
+      expect(screen.getByText(/other participants/i)).toBeInTheDocument();
+    });
+
+    it('shows both owner preferences and estimation sections', async () => {
+      await goToStep2();
+
+      expect(screen.getByText(/your group/i)).toBeInTheDocument();
+      expect(screen.getByText(/other participants/i)).toBeInTheDocument();
+      expect(screen.getByText(/estimated adults/i)).toBeInTheDocument();
+      expect(screen.getByText(/estimated kids/i)).toBeInTheDocument();
+    });
   });
 
-  it('calls onCancel when cancel button is clicked', async () => {
-    const user = userEvent.setup();
-    renderForm();
+  describe('Full submission flow', () => {
+    it('calls onSubmit with plan patch and owner preferences', async () => {
+      const user = userEvent.setup();
+      renderForm();
 
-    await user.click(screen.getByRole('button', { name: /cancel/i }));
-    expect(handleCancel).toHaveBeenCalledTimes(1);
-  });
+      const titleInput = screen.getByPlaceholderText(/enter plan title/i);
+      await user.clear(titleInput);
+      await user.type(titleInput, 'Updated Beach Trip');
 
-  it('handles plan with no location', () => {
-    const plan = buildTestPlan({ location: null });
-    renderForm(plan);
+      await user.click(screen.getByRole('button', { name: /next/i }));
 
-    const locationName = screen.getByPlaceholderText(/location name/i);
-    expect(locationName).toHaveValue('');
-  });
+      await waitFor(() => {
+        expect(screen.getByTestId('edit-wizard-step2')).toBeInTheDocument();
+      });
 
-  it('handles plan with no tags', () => {
-    const plan = buildTestPlan({ tags: null });
-    renderForm(plan);
+      await user.click(screen.getByRole('button', { name: /update plan/i }));
 
-    const tagsInput = screen.getByPlaceholderText(/e\.g\. picnic/i);
-    expect(tagsInput).toHaveValue('');
-  });
+      await waitFor(() => {
+        expect(handleSubmit).toHaveBeenCalledTimes(1);
+      });
 
-  it('handles plan with no dates', () => {
-    const plan = buildTestPlan({ startDate: null, endDate: null });
-    renderForm(plan);
+      const payload: EditPlanSubmitPayload = handleSubmit.mock.calls[0][0];
+      expect(payload.planPatch.title).toBe('Updated Beach Trip');
+      expect(payload.planPatch.description).toBe('A fun day at the beach');
+      expect(payload.planPatch.status).toBe('active');
+      expect(payload.planPatch.tags).toEqual(['beach', 'summer']);
+      expect(payload.ownerPreferences.adultsCount).toBe(2);
+      expect(payload.ownerPreferences.kidsCount).toBe(1);
+      expect(payload.ownerPreferences.foodPreferences).toBe('vegetarian');
+      expect(payload.ownerPreferences.allergies).toBe('nuts');
+      expect(payload.ownerPreferences.notes).toBe('no spicy food');
+    });
 
-    expect(screen.getByText(/start date/i)).toBeInTheDocument();
+    it('shows updating state on submit button', async () => {
+      const user = userEvent.setup();
+      const plan = buildTestPlan();
+      render(
+        <EditPlanForm
+          plan={plan}
+          ownerParticipant={ownerParticipant}
+          onSubmit={handleSubmit}
+          onCancel={handleCancel}
+          isSubmitting
+        />
+      );
+
+      await user.click(screen.getByRole('button', { name: /next/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByRole('button', { name: /updating/i })
+        ).toBeDisabled();
+      });
+    });
   });
 });

--- a/tests/unit/routes/CreatePlanNavigation.test.tsx
+++ b/tests/unit/routes/CreatePlanNavigation.test.tsx
@@ -54,14 +54,12 @@ describe('CreatePlan - Navigation', () => {
   it('should navigate from plans list to create-plan page when user clicks Create New Plan', async () => {
     const user = userEvent.setup();
 
-    // Create router with real components
     const rootRoute = createRootRoute();
 
     const plansRoute = createRoute({
       getParentRoute: () => rootRoute,
       path: '/plans',
       component: () => {
-        // Use real PlansList component
         const plans = [
           {
             planId: 'plan-1',
@@ -106,20 +104,16 @@ describe('CreatePlan - Navigation', () => {
       expect(screen.getByText('Summer Picnic')).toBeInTheDocument();
     });
 
-    // Click the "Create New Plan" link
     const createLink = screen.getByText(/create new plan/i);
     await user.click(createLink);
 
-    // Verify navigation to create-plan page
     await waitFor(() => {
-      expect(screen.getByText(/first name/i)).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: /create plan/i })
-      ).toBeInTheDocument();
+      expect(screen.getByTestId('wizard-step1')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
     });
   });
 
-  it('should display create plan form when navigating directly to /create-plan', async () => {
+  it('should display create plan wizard when navigating directly to /create-plan', async () => {
     const rootRoute = createRootRoute();
 
     const createPlanRoute = createRoute({
@@ -146,10 +140,8 @@ describe('CreatePlan - Navigation', () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText(/first name/i)).toBeInTheDocument();
-      expect(
-        screen.getByRole('button', { name: /create plan/i })
-      ).toBeInTheDocument();
+      expect(screen.getByTestId('wizard-step1')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /next/i })).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## Summary
- Refactor plan creation from a single form into a **3-step wizard**: Step 1 (plan details with place-only location), Step 2 (owner preferences + participant estimation), Step 3 (inline bulk item add)
- Refactor edit plan modal from a single form into a **2-step wizard**: Step 1 (plan details), Step 2 (owner preferences + estimation) — matching the create flow
- Add **estimatedAdults/estimatedKids** fields to FE schemas (`planSchema`, `planCreateWithOwnerSchema`, `planPatchSchema`) aligned with BE OpenAPI from `feature/plan-estimation-fields`
- Add **headcount section** on plan detail page showing reported totals from participants and estimated totals from plan data
- Owner details auto-filled from user profile (no longer shown in wizard)
- Location simplified to place-only Google Maps autocomplete in both create and edit
- i18n keys added for EN and HE

## Test plan
- [x] TypeScript typecheck passes
- [x] ESLint passes
- [x] 768 unit tests pass
- [x] E2E tests updated for new wizard flows
- [ ] Manual test: create plan wizard 3 steps, verify estimation sent to BE
- [ ] Manual test: edit plan wizard 2 steps, verify estimation prefilled and patched
- [ ] Manual test: headcount section shows reported + estimated values
- [ ] Verify BE branch `feature/plan-estimation-fields` accepts estimation fields


Made with [Cursor](https://cursor.com)